### PR TITLE
fix: LINE 登入移除 openid scope 修復 JWT alg 錯誤

### DIFF
--- a/e2e/scenarios/article-workflow.spec.ts
+++ b/e2e/scenarios/article-workflow.spec.ts
@@ -112,7 +112,7 @@ test.describe("規劃 → 產出文章流程", () => {
     await expect(planButton).toBeVisible();
 
     // 如果有規劃列表，檢查 PlansTable 結構
-    const plansTable = page.locator("table").filter({ hasText: /預測標題|規劃/ });
+    const plansTable = page.locator("table").filter({ hasText: /預計標題|預測標題|規劃/ });
     if (await plansTable.isVisible({ timeout: 3000 }).catch(() => false)) {
       // 規劃表格有 checkbox
       const planCheckbox = plansTable.locator("tbody input[type='checkbox']").first();
@@ -236,7 +236,7 @@ test.describe("規劃 → 產出文章流程", () => {
         timeout: 15_000,
       });
 
-      const plansTable = page.locator("table").filter({ hasText: /預測標題|規劃/ });
+      const plansTable = page.locator("table").filter({ hasText: /預計標題|預測標題|規劃/ });
       await expect(plansTable).toBeVisible({ timeout: 10_000 });
     }
   });
@@ -248,7 +248,7 @@ test.describe("規劃 → 產出文章流程", () => {
     });
 
     // 找到規劃表格
-    const plansTable = page.locator("table").filter({ hasText: /預測標題|規劃/ });
+    const plansTable = page.locator("table").filter({ hasText: /預計標題|預測標題|規劃/ });
     if (!(await plansTable.isVisible({ timeout: 5000 }).catch(() => false))) {
       test.skip(true, "目前沒有規劃項目，跳過產出測試");
       return;

--- a/src/__tests__/integration/articles-page-state.test.ts
+++ b/src/__tests__/integration/articles-page-state.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Integration tests: ArticlesPage state management
+ *
+ * Tests the state management logic from page.tsx — filter resets,
+ * batch operations, and single publish behavior — using the same
+ * hook + fetch patterns as the real page.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useState, useCallback, useEffect } from "react";
+import { useRewritePolling } from "@/hooks/useRewritePolling";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+vi.stubGlobal("confirm", vi.fn(() => true));
+vi.stubGlobal("alert", vi.fn());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface Article {
+  id: string;
+  title: string;
+  status: string;
+  published_at: string | null;
+}
+
+function makeArticle(id: string, status = "draft"): Article {
+  return { id, title: `Article ${id}`, status, published_at: null };
+}
+
+function makeStatusResponse(currentTask: unknown = null) {
+  return { lastCompleted: null, currentTask, newArticleCount: 0 };
+}
+
+/**
+ * Mimics the state management parts of page.tsx for testing.
+ */
+function useArticlesPageState() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [status, setStatus] = useState("all");
+  const [loading, setLoading] = useState(true);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [batchLoading, setBatchLoading] = useState(false);
+  const [publishingIds, setPublishingIds] = useState<Set<string>>(new Set());
+
+  const fetchArticles = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams({
+      page: page.toString(),
+      limit: pageSize.toString(),
+    });
+    if (status !== "all") params.set("status", status);
+
+    try {
+      const res = await fetch(`/api/articles/generated?${params}`);
+      const data = await res.json();
+      setArticles(data.articles || []);
+      setTotal(data.total || 0);
+    } catch {
+      // noop
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, status]);
+
+  const rewritePolling = useRewritePolling({
+    onPollComplete: () => fetchArticles(),
+    onPlanPollComplete: () => fetchArticles(),
+    onProducePollComplete: () => fetchArticles(),
+  });
+
+  useEffect(() => {
+    fetchArticles();
+  }, [fetchArticles]);
+
+  const handleStatusChange = (value: string) => {
+    setStatus(value);
+    setPage(1);
+    setSelectedIds(new Set());
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size);
+    setPage(1);
+  };
+
+  const handleBatchAction = async (action: "publish" | "delete") => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0) return;
+
+    setBatchLoading(true);
+    try {
+      const res = await fetch("/api/articles/generated/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids, action }),
+      });
+      if (res.ok) {
+        setSelectedIds(new Set());
+        await fetchArticles();
+      }
+    } catch {
+      // noop
+    } finally {
+      setBatchLoading(false);
+    }
+  };
+
+  const handlePublishOne = async (articleId: string) => {
+    setPublishingIds((prev) => new Set(prev).add(articleId));
+    try {
+      const res = await fetch("/api/articles/generated/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: [articleId], action: "publish" }),
+      });
+      if (res.ok) {
+        setArticles((prev) =>
+          prev.map((a) =>
+            a.id === articleId
+              ? { ...a, status: "published", published_at: new Date().toISOString() }
+              : a
+          )
+        );
+      }
+    } catch {
+      // noop
+    } finally {
+      setPublishingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(articleId);
+        return next;
+      });
+    }
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return {
+    articles, total, page, pageSize, status, loading,
+    selectedIds, batchLoading, publishingIds,
+    rewritePolling,
+    setPage, handleStatusChange, handlePageSizeChange,
+    handleBatchAction, handlePublishOne, toggleSelect,
+    fetchArticles,
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+function setupDefaultFetch(articleList: Article[] = []) {
+  mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (typeof url === "string" && url === "/api/rewrite" && (!init?.method || init.method === "GET")) {
+      return { ok: true, json: async () => makeStatusResponse() };
+    }
+    if (typeof url === "string" && url.startsWith("/api/articles/generated") && (!init?.method || init.method === "GET")) {
+      return { ok: true, json: async () => ({ articles: articleList, total: articleList.length }) };
+    }
+    if (typeof url === "string" && url === "/api/articles/generated/batch" && init?.method === "POST") {
+      return { ok: true, json: async () => ({ success: true }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Filter change resets page and selectedIds
+// ---------------------------------------------------------------------------
+
+describe("filter change resets state", () => {
+  it("handleStatusChange resets page to 1 and clears selectedIds", async () => {
+    const articles = [makeArticle("a1"), makeArticle("a2"), makeArticle("a3")];
+    setupDefaultFetch(articles);
+
+    const { result } = renderHook(() => useArticlesPageState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Select some articles and change page
+    act(() => {
+      result.current.toggleSelect("a1");
+      result.current.toggleSelect("a2");
+      result.current.setPage(3);
+    });
+
+    expect(result.current.selectedIds.size).toBe(2);
+    expect(result.current.page).toBe(3);
+
+    // Change status filter
+    act(() => {
+      result.current.handleStatusChange("published");
+    });
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.status).toBe("published");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. pageSize change resets page
+// ---------------------------------------------------------------------------
+
+describe("pageSize change resets page", () => {
+  it("handlePageSizeChange resets page to 1", async () => {
+    setupDefaultFetch();
+
+    const { result } = renderHook(() => useArticlesPageState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.setPage(5));
+    expect(result.current.page).toBe(5);
+
+    act(() => result.current.handlePageSizeChange(50));
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.pageSize).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Filter works during plan running mode
+// ---------------------------------------------------------------------------
+
+describe("filter during running mode", () => {
+  it("changing filter while runningMode=plan still triggers fetchArticles", async () => {
+    const callLog: string[] = [];
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (typeof url === "string" && url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (typeof url === "string" && url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      if (typeof url === "string" && url === "/api/rewrite/plan" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      return new Promise(() => {}); // keep polling pending
+    });
+
+    const { result } = renderHook(() => useArticlesPageState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Simulate plan running
+    act(() => {
+      result.current.rewritePolling.setRunningMode("plan");
+    });
+
+    expect(result.current.rewritePolling.runningMode).toBe("plan");
+
+    callLog.length = 0;
+
+    // Change filter — should still trigger fetchArticles
+    act(() => {
+      result.current.handleStatusChange("draft");
+    });
+
+    // fetchArticles is triggered by the useEffect [page, pageSize, status] dependency
+    await waitFor(() => {
+      const articleCalls = callLog.filter((c) => c.startsWith("GET /api/articles/generated"));
+      expect(articleCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Batch publish clears selectedIds and re-fetches
+// ---------------------------------------------------------------------------
+
+describe("batch publish", () => {
+  it("clears selectedIds and re-fetches articles after success", async () => {
+    const articles = [makeArticle("a1"), makeArticle("a2")];
+    setupDefaultFetch(articles);
+
+    const { result } = renderHook(() => useArticlesPageState());
+
+    await waitFor(() => expect(result.current.articles).toHaveLength(2));
+
+    act(() => {
+      result.current.toggleSelect("a1");
+      result.current.toggleSelect("a2");
+    });
+
+    expect(result.current.selectedIds.size).toBe(2);
+
+    await act(async () => {
+      await result.current.handleBatchAction("publish");
+    });
+
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.batchLoading).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Single publish updates only that article, doesn't clear selectedIds
+// ---------------------------------------------------------------------------
+
+describe("single publish", () => {
+  it("updates only the published article status, keeps selectedIds intact", async () => {
+    const articles = [makeArticle("a1"), makeArticle("a2"), makeArticle("a3")];
+    setupDefaultFetch(articles);
+
+    const { result } = renderHook(() => useArticlesPageState());
+
+    await waitFor(() => expect(result.current.articles).toHaveLength(3));
+
+    // Select a1 and a3
+    act(() => {
+      result.current.toggleSelect("a1");
+      result.current.toggleSelect("a3");
+    });
+
+    expect(result.current.selectedIds.size).toBe(2);
+
+    // Publish a2 (not in selection)
+    await act(async () => {
+      await result.current.handlePublishOne("a2");
+    });
+
+    // a2 should now be published
+    const a2 = result.current.articles.find((a) => a.id === "a2");
+    expect(a2?.status).toBe("published");
+    expect(a2?.published_at).not.toBeNull();
+
+    // Other articles unchanged
+    expect(result.current.articles.find((a) => a.id === "a1")?.status).toBe("draft");
+    expect(result.current.articles.find((a) => a.id === "a3")?.status).toBe("draft");
+
+    // selectedIds should NOT be cleared
+    expect(result.current.selectedIds.size).toBe(2);
+    expect(result.current.selectedIds.has("a1")).toBe(true);
+    expect(result.current.selectedIds.has("a3")).toBe(true);
+
+    // publishingIds should be cleared
+    expect(result.current.publishingIds.size).toBe(0);
+  });
+});

--- a/src/__tests__/integration/articles-page-wiring.test.ts
+++ b/src/__tests__/integration/articles-page-wiring.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Integration tests: ArticlesPage callback wiring
+ *
+ * Verifies that useRewritePolling + usePlanManager are wired together
+ * the same way as in page.tsx — specifically the callback chains that
+ * connect polling completion to data refreshes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useRewritePolling } from "@/hooks/useRewritePolling";
+import { usePlanManager } from "@/hooks/usePlanManager";
+import { POLLING_INTERVAL_MS } from "@/lib/constants";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+vi.stubGlobal("confirm", vi.fn(() => true));
+vi.stubGlobal("alert", vi.fn());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatusResponse(currentTask: unknown = null) {
+  return { lastCompleted: null, currentTask, newArticleCount: 0 };
+}
+
+const activeTask = { status: "running", created_at: "2024-01-01T00:00:00Z" };
+
+function makePlansResponse(count = 2) {
+  const plans = Array.from({ length: count }, (_, i) => ({
+    id: `p${i + 1}`,
+    title: `Plan ${i + 1}`,
+    raw_article_ids: [],
+    league: "NBA",
+    plan_type: "analysis",
+    created_at: "2024-01-01T00:00:00Z",
+    writer_personas: null,
+  }));
+  return { plans, rawArticleMap: {}, earliestCrawledAt: null };
+}
+
+/**
+ * Mimics page.tsx wiring: renders both hooks with the same callback pattern.
+ * We track which API endpoints are called to verify wiring correctness.
+ */
+function useArticlesPageWiring() {
+  const planManager = usePlanManager();
+
+  const rewritePolling = useRewritePolling({
+    onPollComplete: () => {
+      // page.tsx: fetchArticles()
+      fetch("/api/articles/generated?page=1&limit=20");
+    },
+    onPlanPollComplete: () => {
+      // page.tsx: planManager.fetchPlans() + fetchArticles()
+      planManager.fetchPlans();
+      fetch("/api/articles/generated?page=1&limit=20");
+    },
+    onProducePollComplete: () => {
+      // page.tsx: planManager.fetchPlans() + fetchArticles()
+      planManager.fetchPlans();
+      fetch("/api/articles/generated?page=1&limit=20");
+    },
+  });
+
+  return { planManager, rewritePolling };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// 1. onPlanPollComplete triggers both fetchPlans and fetchArticles
+// ---------------------------------------------------------------------------
+
+describe("onPlanPollComplete wiring", () => {
+  it("triggers both fetchPlans and fetchArticles when plan polling completes", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    // Track calls by URL
+    const callLog: string[] = [];
+
+    // Mount: no active task
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+
+      if (url === "/api/rewrite" && (!init || !init.method || init.method === "GET")) {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init || !init.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url === "/api/rewrite/plan" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useArticlesPageWiring());
+
+    // Wait for mount fetches
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Clear log to isolate triggerPlan flow
+    callLog.length = 0;
+
+    // triggerPlan → POST /api/rewrite/plan → start polling
+    await act(async () => {
+      await result.current.rewritePolling.triggerPlan(result.current.planManager.clearPlans);
+    });
+
+    expect(callLog).toContain("POST /api/rewrite/plan");
+
+    // Polling: first tick returns active task
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(activeTask) };
+      }
+      if (url === "/api/rewrite/plan") {
+        return { ok: true, json: async () => makePlansResponse(3) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Second tick: task completes → triggers onPlanPollComplete
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(null) };
+      }
+      if (url === "/api/rewrite/plan") {
+        return { ok: true, json: async () => makePlansResponse(3) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    callLog.length = 0; // Clear to isolate completion callbacks
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBeNull();
+    });
+
+    // Verify both fetchPlans (GET /api/rewrite/plan) and fetchArticles were called
+    const planFetches = callLog.filter((c) => c === "GET /api/rewrite/plan");
+    const articleFetches = callLog.filter((c) => c.startsWith("GET /api/articles/generated"));
+
+    expect(planFetches.length).toBeGreaterThanOrEqual(1);
+    expect(articleFetches.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. onProducePollComplete triggers both fetchPlans and fetchArticles
+// ---------------------------------------------------------------------------
+
+describe("onProducePollComplete wiring", () => {
+  it("triggers both fetchPlans and fetchArticles when produce polling completes", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const callLog: string[] = [];
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url === "/api/rewrite/plan/produce" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useArticlesPageWiring());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Select a plan and trigger produce (mimics page.tsx handlePlanProduce)
+    act(() => result.current.planManager.togglePlanSelect("p1"));
+
+    await act(async () => {
+      await result.current.planManager.handlePlanProduce(() => {
+        result.current.rewritePolling.triggerProduce();
+      });
+    });
+
+    // Polling: active task on first tick
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(activeTask) };
+      }
+      if (url === "/api/rewrite/plan") {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Second tick: task done → triggers onProducePollComplete
+    callLog.length = 0;
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(null) };
+      }
+      if (url === "/api/rewrite/plan") {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBeNull();
+    });
+
+    const planFetches = callLog.filter((c) => c === "GET /api/rewrite/plan");
+    const articleFetches = callLog.filter((c) => c.startsWith("GET /api/articles/generated"));
+
+    expect(planFetches.length).toBeGreaterThanOrEqual(1);
+    expect(articleFetches.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. onPollComplete (page-load auto-detect) only triggers fetchArticles
+// ---------------------------------------------------------------------------
+
+describe("onPollComplete wiring (page-load auto-detect)", () => {
+  it("only triggers fetchArticles, not an extra fetchPlans", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const callLog: string[] = [];
+
+    // Mount: active task → auto-detect triggers polling
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(activeTask) };
+      }
+      if (url === "/api/rewrite/plan") {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useArticlesPageWiring());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Should auto-detect the running task
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBe("rewrite");
+    });
+
+    // Now task completes
+    callLog.length = 0;
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(null) };
+      }
+      if (url === "/api/rewrite/plan") {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBeNull();
+    });
+
+    // fetchArticles should be called
+    const articleFetches = callLog.filter((c) => c.startsWith("GET /api/articles/generated"));
+    expect(articleFetches.length).toBeGreaterThanOrEqual(1);
+
+    // fetchPlans should NOT be called extra (only the polling status fetch)
+    // The only /api/rewrite/plan calls should be from the polling tick itself, not from onPollComplete
+    const planFetchesFromCallback = callLog.filter(
+      (c) => c === "GET /api/rewrite/plan"
+    );
+    // onPollComplete does NOT call fetchPlans, so no extra plan fetch calls
+    // (usePlanManager doesn't auto-refetch on poll complete — only onPlanPollComplete does)
+    expect(planFetchesFromCallback.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. triggerPlan full chain: clearPlans → POST → poll → callbacks
+// ---------------------------------------------------------------------------
+
+describe("triggerPlan full chain", () => {
+  it("clearPlans → POST → poll → onPlanPollComplete fires fetchPlans + fetchArticles", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const callLog: string[] = [];
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(2) };
+      }
+      if (url === "/api/rewrite/plan" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useArticlesPageWiring());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Verify plans loaded
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    // triggerPlan with clearPlans (mimics page.tsx handleTriggerPlan)
+    await act(async () => {
+      await result.current.rewritePolling.triggerPlan(result.current.planManager.clearPlans);
+    });
+
+    // clearPlans should have emptied plans
+    expect(result.current.planManager.plans).toEqual([]);
+    expect(result.current.rewritePolling.runningMode).toBe("plan");
+
+    // Complete the polling
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(null) };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(5) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBeNull();
+    });
+
+    // After onPlanPollComplete, plans should be refreshed
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(5);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. handlePlanProduce full chain: POST produce → triggerProduce → poll → callbacks
+// ---------------------------------------------------------------------------
+
+describe("handlePlanProduce full chain", () => {
+  it("POST produce → triggerProduce → poll complete → fetchPlans + fetchArticles", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const callLog: string[] = [];
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(3) };
+      }
+      if (url === "/api/rewrite/plan/produce" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useArticlesPageWiring());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(3);
+    });
+
+    // Select plans and trigger produce (mimics page.tsx handlePlanProduce)
+    act(() => {
+      result.current.planManager.togglePlanSelect("p1");
+      result.current.planManager.togglePlanSelect("p2");
+    });
+
+    await act(async () => {
+      await result.current.planManager.handlePlanProduce(() => {
+        result.current.rewritePolling.triggerProduce();
+      });
+    });
+
+    expect(result.current.rewritePolling.runningMode).toBe("produce");
+    // Produced plans should be removed from local list
+    expect(result.current.planManager.plans.find((p) => p.id === "p1")).toBeUndefined();
+    expect(result.current.planManager.plans.find((p) => p.id === "p2")).toBeUndefined();
+
+    // Complete polling
+    callLog.length = 0;
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(null) };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(1) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBeNull();
+    });
+
+    // Verify onProducePollComplete fired: both fetchPlans and fetchArticles
+    const planFetches = callLog.filter((c) => c === "GET /api/rewrite/plan");
+    const articleFetches = callLog.filter((c) => c.startsWith("GET /api/articles/generated"));
+
+    expect(planFetches.length).toBeGreaterThanOrEqual(1);
+    expect(articleFetches.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/__tests__/integration/rewrite-plan-cross-hook.test.ts
+++ b/src/__tests__/integration/rewrite-plan-cross-hook.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Integration tests: Cross-hook interaction between useRewritePolling and usePlanManager
+ *
+ * Tests the scenarios where actions in one hook affect the other,
+ * mimicking the wiring in ArticlesPage.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useRewritePolling } from "@/hooks/useRewritePolling";
+import { usePlanManager } from "@/hooks/usePlanManager";
+import { POLLING_INTERVAL_MS } from "@/lib/constants";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+vi.stubGlobal("confirm", vi.fn(() => true));
+vi.stubGlobal("alert", vi.fn());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatusResponse(currentTask: unknown = null) {
+  return { lastCompleted: null, currentTask, newArticleCount: 0 };
+}
+
+function makePlansResponse(count = 2) {
+  const plans = Array.from({ length: count }, (_, i) => ({
+    id: `p${i + 1}`,
+    title: `Plan ${i + 1}`,
+    raw_article_ids: [],
+    league: "NBA",
+    plan_type: "analysis",
+    created_at: "2024-01-01T00:00:00Z",
+    writer_personas: null,
+  }));
+  return { plans, rawArticleMap: {}, earliestCrawledAt: null };
+}
+
+/**
+ * Combined hook that mirrors page.tsx wiring.
+ */
+function useCrossHookWiring() {
+  const planManager = usePlanManager();
+
+  const rewritePolling = useRewritePolling({
+    onPollComplete: () => {
+      fetch("/api/articles/generated?page=1&limit=20");
+    },
+    onPlanPollComplete: () => {
+      planManager.fetchPlans();
+      fetch("/api/articles/generated?page=1&limit=20");
+    },
+    onProducePollComplete: () => {
+      planManager.fetchPlans();
+      fetch("/api/articles/generated?page=1&limit=20");
+    },
+  });
+
+  return { planManager, rewritePolling };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// 1. triggerPlan calls clearPlans, which actually empties plans state
+// ---------------------------------------------------------------------------
+
+describe("triggerPlan → clearPlans cross-hook", () => {
+  it("calling triggerPlan with clearPlans clears the planManager plans", async () => {
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(3) };
+      }
+      if (url === "/api/rewrite/plan" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      return new Promise(() => {});
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(3);
+    });
+
+    // triggerPlan with clearPlans (mimics page.tsx)
+    await act(async () => {
+      await result.current.rewritePolling.triggerPlan(result.current.planManager.clearPlans);
+    });
+
+    expect(result.current.planManager.plans).toEqual([]);
+    expect(result.current.planManager.selectedPlanIds.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. handlePlanProduce → triggerProduce, runningMode set to "produce"
+// ---------------------------------------------------------------------------
+
+describe("handlePlanProduce → triggerProduce cross-hook", () => {
+  it("sets runningMode to produce when handlePlanProduce calls triggerProduce", async () => {
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(2) };
+      }
+      if (url === "/api/rewrite/plan/produce" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      return new Promise(() => {});
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    act(() => result.current.planManager.togglePlanSelect("p1"));
+
+    await act(async () => {
+      await result.current.planManager.handlePlanProduce(() => {
+        result.current.rewritePolling.triggerProduce();
+      });
+    });
+
+    expect(result.current.rewritePolling.runningMode).toBe("produce");
+    expect(result.current.planManager.planLoading).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Produce completion triggers both fetchPlans and fetchArticles
+// ---------------------------------------------------------------------------
+
+describe("produce completion → cross-hook refresh", () => {
+  it("onProducePollComplete calls fetchPlans and fetchArticles", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const callLog: string[] = [];
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(2) };
+      }
+      if (url === "/api/rewrite/plan/produce" && init?.method === "POST") {
+        return { ok: true, json: async () => ({ started: true }) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    // Select and produce
+    act(() => result.current.planManager.togglePlanSelect("p1"));
+
+    await act(async () => {
+      await result.current.planManager.handlePlanProduce(() => {
+        result.current.rewritePolling.triggerProduce();
+      });
+    });
+
+    // Polling: task completes on first tick
+    callLog.length = 0;
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      callLog.push(`${init?.method || "GET"} ${url}`);
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse(null) };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(1) };
+      }
+      if (url.startsWith("/api/articles/generated")) {
+        return { ok: true, json: async () => ({ articles: [], total: 0 }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(POLLING_INTERVAL_MS + 100);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.rewritePolling.runningMode).toBeNull();
+    });
+
+    const planFetches = callLog.filter((c) => c === "GET /api/rewrite/plan");
+    const articleFetches = callLog.filter((c) => c.startsWith("GET /api/articles/generated"));
+
+    expect(planFetches.length).toBeGreaterThanOrEqual(1);
+    expect(articleFetches.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Plan API failure (500) → both hooks recover correctly
+// ---------------------------------------------------------------------------
+
+describe("plan API failure recovery", () => {
+  it("500 from plan POST resets runningMode and planTriggering", async () => {
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(2) };
+      }
+      if (url === "/api/rewrite/plan" && init?.method === "POST") {
+        return { ok: false, json: async () => ({ error: "Internal Server Error" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.rewritePolling.triggerPlan(result.current.planManager.clearPlans);
+    });
+
+    // runningMode should be reset to null on failure
+    expect(result.current.rewritePolling.runningMode).toBeNull();
+    expect(result.current.rewritePolling.planTriggering).toBe(false);
+
+    // alert should have been called
+    expect(alert).toHaveBeenCalled();
+  });
+
+  it("network error on plan POST resets runningMode", async () => {
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse() };
+      }
+      if (url === "/api/rewrite/plan" && init?.method === "POST") {
+        throw new Error("Network failure");
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.rewritePolling.triggerPlan();
+    });
+
+    expect(result.current.rewritePolling.runningMode).toBeNull();
+    expect(result.current.rewritePolling.planTriggering).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Produce API failure → planLoading resets to false
+// ---------------------------------------------------------------------------
+
+describe("produce API failure recovery", () => {
+  it("500 from produce POST resets planLoading to false", async () => {
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(2) };
+      }
+      if (url === "/api/rewrite/plan/produce" && init?.method === "POST") {
+        return { ok: false, json: async () => ({ error: "Produce failed" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    act(() => result.current.planManager.togglePlanSelect("p1"));
+
+    await act(async () => {
+      await result.current.planManager.handlePlanProduce(() => {
+        result.current.rewritePolling.triggerProduce();
+      });
+    });
+
+    // planLoading should be false after failure
+    expect(result.current.planManager.planLoading).toBe(false);
+    // alert should be called
+    expect(alert).toHaveBeenCalled();
+  });
+
+  it("network error on produce POST resets planLoading to false", async () => {
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/rewrite") {
+        return { ok: true, json: async () => makeStatusResponse() };
+      }
+      if (url === "/api/rewrite/plan" && (!init?.method || init.method === "GET")) {
+        return { ok: true, json: async () => makePlansResponse(2) };
+      }
+      if (url === "/api/rewrite/plan/produce" && init?.method === "POST") {
+        throw new Error("Network failure");
+      }
+      return { ok: true, json: async () => ({}) };
+    });
+
+    const { result } = renderHook(() => useCrossHookWiring());
+
+    await waitFor(() => {
+      expect(result.current.planManager.plans).toHaveLength(2);
+    });
+
+    act(() => result.current.planManager.togglePlanSelect("p1"));
+
+    await act(async () => {
+      await result.current.planManager.handlePlanProduce(() => {
+        result.current.rewritePolling.triggerProduce();
+      });
+    });
+
+    expect(result.current.planManager.planLoading).toBe(false);
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -45,7 +45,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       checks: ["state"],
       authorization: {
         url: "https://access.line.me/oauth2/v2.1/authorize",
-        params: { scope: "profile openid email", response_type: "code" },
+        params: { scope: "profile email", response_type: "code" },
       },
       token: "https://api.line.me/oauth2/v2.1/token",
       userinfo: "https://api.line.me/v2/profile",


### PR DESCRIPTION
## Summary
- LINE OAuth 回傳的 id_token 使用 NextAuth jose 不支援的簽章演算法（`unexpected JWT "alg" header parameter`），導致透過 LINE app 授權回 callback 時報 `CallbackRouteError`
- 移除 scope 中的 `openid`，不再請求 id_token，改用 userinfo endpoint 取得用戶資料
- 補上 articles page 的整合測試（3 個檔案 17 個測試案例），驗證跨 hook callback 接線正確性
- 修正 E2E 測試 PlansTable selector 匹配「預計標題」

## Test plan
- [ ] Safari LINE 登入正常
- [ ] Chrome LINE 網頁登入正常
- [ ] Chrome → LINE app → 回 Chrome 登入正常（原本 server error）
- [ ] Google 登入不受影響
- [ ] `npx vitest run` 全部通過（199 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)