### PR TITLE
feat: 前台畫面優化 — Header 動態隱藏 + 手機版橫式卡片 + TG 精簡

### DIFF
--- a/src/__tests__/components/TelegramCTA.test.tsx
+++ b/src/__tests__/components/TelegramCTA.test.tsx
@@ -10,21 +10,21 @@ describe("TelegramBanner", () => {
 
   it("renders the CTA button with correct text", () => {
     render(<TelegramBanner />);
-    expect(screen.getByText("立即加入頻道")).toBeInTheDocument();
+    expect(screen.getByText("加入頻道")).toBeInTheDocument();
   });
 
   it("links to the correct Telegram channel URL", () => {
     render(<TelegramBanner />);
-    const link = screen.getByText("立即加入頻道").closest("a");
+    const link = screen.getByText("加入頻道").closest("a");
     expect(link).toHaveAttribute("href", "https://t.me/howger_sport_news");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("contains channel description mentioning NBA", () => {
+  it("contains channel description mentioning Telegram", () => {
     render(<TelegramBanner />);
     expect(
-      screen.getByText(/加入我們的 Telegram 頻道/)
+      screen.getByText(/加入 Telegram 頻道/)
     ).toBeInTheDocument();
   });
 });

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,9 +1,7 @@
-import Image from "next/image";
 import Link from "next/link";
-import { UserMenu } from "@/components/auth/UserMenu";
+import { PublicHeader } from "@/components/public/PublicHeader";
 
-const navLinks = [
-  { href: "/", label: "首頁" },
+const footerLinks = [
   { href: "/scores", label: "即時比分" },
   { href: "/category/nba", label: "NBA" },
   { href: "/category/mlb", label: "MLB" },
@@ -20,57 +18,10 @@ export default function PublicLayout({
 }) {
   return (
     <div className="h-[100dvh] flex flex-col bg-white overflow-hidden">
-      {/* Header */}
-      <header className="flex-shrink-0 bg-white/90 backdrop-blur-sm border-b border-slate-200 pt-[env(safe-area-inset-top)]">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6">
-          <div className="flex items-center justify-between h-16">
-            <Link href="/" className="flex items-center flex-shrink-0">
-              <Image
-                src="/logo.png"
-                alt="小豪哥體育資訊網"
-                width={280}
-                height={50}
-                className="h-8 sm:h-10 w-auto"
-                priority
-              />
-            </Link>
-            <div className="hidden sm:flex items-center gap-1">
-              <nav className="flex items-center gap-1">
-                {navLinks.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className="px-3 py-2 text-sm font-medium text-slate-600 rounded-md hover:text-blue-600 hover:bg-blue-50 transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-              </nav>
-              <div className="ml-2 pl-2 border-l border-slate-200">
-                <UserMenu />
-              </div>
-            </div>
-            {/* Mobile nav */}
-            <div className="flex sm:hidden items-center gap-2 min-w-0">
-              <nav className="flex items-center gap-0.5 overflow-x-auto scrollbar-hide pb-1 min-w-0 flex-1">
-                {navLinks.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className="px-2 py-1 text-xs font-medium text-slate-600 rounded hover:text-blue-600 hover:bg-blue-50 transition-colors whitespace-nowrap"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-              </nav>
-              <UserMenu />
-            </div>
-          </div>
-        </div>
-      </header>
+      <PublicHeader />
 
       {/* Scrollable content area */}
-      <div className="flex-1 overflow-y-auto overscroll-contain">
+      <div id="scroll-container" className="flex-1 overflow-y-auto overscroll-contain">
         {/* Main Content */}
         <main className="max-w-6xl mx-auto w-full px-4 sm:px-6 py-8">
           {children}
@@ -78,46 +29,44 @@ export default function PublicLayout({
 
         {/* Footer */}
         <footer className="bg-slate-100 border-t border-slate-200">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
-          <div className="grid sm:grid-cols-2 gap-6 mb-6">
-            <div>
-              <h3 className="font-semibold text-slate-900 mb-2">加入 Telegram 頻道</h3>
-              <p className="text-sm text-slate-500 mb-3">
-                即時體育新聞直送手機，不錯過任何精彩賽事
-              </p>
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 py-4">
+            {/* Telegram CTA - compact */}
+            <div className="flex items-center justify-between gap-4 mb-4">
+              <div className="flex items-center gap-3">
+                <svg className="w-5 h-5 text-blue-600 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm5.53 8.24l-1.82 8.58c-.13.59-.48.73-.98.45l-2.7-1.99-1.3 1.25c-.14.14-.27.27-.54.27l.19-2.73 4.99-4.51c.22-.19-.05-.3-.34-.11l-6.17 3.89-2.66-.83c-.58-.18-.59-.58.12-.86l10.39-4.01c.48-.18.91.12.75.8z" />
+                </svg>
+                <span className="text-sm text-slate-600">即時體育新聞直送手機</span>
+              </div>
               <Link
                 href="https://t.me/howger_sport_news"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors flex-shrink-0"
               >
-                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm5.53 8.24l-1.82 8.58c-.13.59-.48.73-.98.45l-2.7-1.99-1.3 1.25c-.14.14-.27.27-.54.27l.19-2.73 4.99-4.51c.22-.19-.05-.3-.34-.11l-6.17 3.89-2.66-.83c-.58-.18-.59-.58.12-.86l10.39-4.01c.48-.18.91.12.75.8z" />
-                </svg>
-                立即加入
+                加入頻道
               </Link>
             </div>
-            <div className="flex flex-col sm:items-end gap-2">
-              <div className="flex items-center gap-4">
-                {navLinks.slice(1).map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className="text-sm text-slate-500 hover:text-blue-600 transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
+
+            {/* Footer links */}
+            <div className="flex items-center justify-center gap-4 mb-3">
+              {footerLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="text-sm text-slate-500 hover:text-blue-600 transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+            <div className="border-t border-slate-200 pt-3">
+              <div className="text-sm text-slate-400 text-center">
+                &copy; 2019 小豪哥體育資訊網. All rights reserved.
               </div>
             </div>
           </div>
-          <div className="border-t border-slate-200 pt-4">
-            <div className="text-sm text-slate-400 text-center">
-              &copy; 2019 小豪哥體育資訊網. All rights reserved.
-            </div>
-          </div>
-        </div>
-      </footer>
+        </footer>
       </div>
     </div>
   );

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -79,7 +79,7 @@ export default async function HomePage() {
       })()}
 
       {/* Telegram CTA Banner */}
-      <div className="mb-10">
+      <div className="mb-8">
         <TelegramBanner />
       </div>
 
@@ -89,7 +89,7 @@ export default async function HomePage() {
         {gridArticles.length === 0 ? (
           <p className="text-slate-500">目前沒有已發布的文章。</p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
             {gridArticles.map((article) => {
               const writerName = article.writer_personas?.name;
               const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
@@ -101,7 +101,8 @@ export default async function HomePage() {
                   href={getArticleHref(article)}
                   className="group block"
                 >
-                  <article className="h-full rounded-xl border border-slate-200 bg-white overflow-hidden hover:shadow-md hover:border-blue-300 transition-all duration-200">
+                  {/* Desktop: vertical card */}
+                  <article className="hidden sm:block h-full rounded-xl border border-slate-200 bg-white overflow-hidden hover:shadow-md hover:border-blue-300 transition-all duration-200">
                     {thumbnail && (
                       <div className="aspect-video bg-slate-100">
                         <img
@@ -134,6 +135,41 @@ export default async function HomePage() {
                         {writerName && <span>{writerName}</span>}
                         <span>{article.view_count ?? 0} views</span>
                       </div>
+                    </div>
+                  </article>
+
+                  {/* Mobile: horizontal card with small thumbnail */}
+                  <article className="sm:hidden rounded-xl border border-slate-200 bg-white p-4 hover:shadow-md hover:border-blue-300 transition-all duration-200">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1.5">
+                          {article.category && (
+                            <span
+                              className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}
+                            >
+                              {article.category}
+                            </span>
+                          )}
+                          <span className="text-xs text-slate-400">
+                            {formatDateShort(article.published_at)}
+                          </span>
+                        </div>
+                        <h3 className="text-sm font-semibold text-slate-900 leading-snug mb-1 line-clamp-2 group-hover:text-blue-600 transition-colors">
+                          {article.title}
+                        </h3>
+                        <div className="flex items-center gap-2 text-xs text-slate-400">
+                          {writerName && <span>{writerName}</span>}
+                          {writerName && <span>&middot;</span>}
+                          <span>{article.view_count ?? 0} views</span>
+                        </div>
+                      </div>
+                      {thumbnail && (
+                        <img
+                          src={thumbnail}
+                          alt=""
+                          className="w-24 h-16 object-cover rounded-lg flex-shrink-0"
+                        />
+                      )}
                     </div>
                   </article>
                 </Link>

--- a/src/components/TelegramCTA.tsx
+++ b/src/components/TelegramCTA.tsx
@@ -6,33 +6,33 @@ import { TELEGRAM_CHANNEL_URL } from "@/lib/constants";
  */
 export function TelegramBanner() {
   return (
-    <section className="relative overflow-hidden rounded-2xl min-h-[200px] flex items-center">
+    <section className="relative overflow-hidden rounded-xl flex items-center">
       <img
         src="/images/cta-stadium.jpg"
         alt=""
         className="absolute inset-0 w-full h-full object-cover"
       />
-      <div className="absolute inset-0 bg-black/50" />
-      <div className="relative z-10 w-full p-8 sm:p-10">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
-          <div className="flex-1">
-            <h2 className="text-xl sm:text-2xl font-bold text-white mb-2">
+      <div className="absolute inset-0 bg-black/55" />
+      <div className="relative z-10 w-full px-5 py-4 sm:px-8 sm:py-5">
+        <div className="flex items-center gap-4 sm:gap-6">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-base sm:text-lg font-bold text-white mb-0.5">
               即時體育新聞直送手機
             </h2>
-            <p className="text-white/80 text-sm sm:text-base">
-              加入我們的 Telegram 頻道「跟著小豪哥一起看球」，第一時間收到最新 NBA 賽事分析與報導
+            <p className="text-white/75 text-xs sm:text-sm truncate">
+              加入 Telegram 頻道「跟著小豪哥一起看球」
             </p>
           </div>
           <Link
             href={TELEGRAM_CHANNEL_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 transition-colors shrink-0"
+            className="inline-flex items-center gap-1.5 px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition-colors shrink-0"
           >
-            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm5.53 8.24l-1.82 8.58c-.13.59-.48.73-.98.45l-2.7-1.99-1.3 1.25c-.14.14-.27.27-.54.27l.19-2.73 4.99-4.51c.22-.19-.05-.3-.34-.11l-6.17 3.89-2.66-.83c-.58-.18-.59-.58.12-.86l10.39-4.01c.48-.18.91.12.75.8z" />
             </svg>
-            立即加入頻道
+            加入頻道
           </Link>
         </div>
       </div>

--- a/src/components/public/PublicHeader.tsx
+++ b/src/components/public/PublicHeader.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { UserMenu } from "@/components/auth/UserMenu";
+
+const navLinks = [
+  { href: "/", label: "首頁" },
+  { href: "/scores", label: "即時比分" },
+  { href: "/category/nba", label: "NBA" },
+  { href: "/category/mlb", label: "MLB" },
+  { href: "/category/soccer", label: "足球" },
+  { href: "/category/general", label: "綜合" },
+  { href: "/standings/nba", label: "排名" },
+  { href: "/odds", label: "賠率" },
+];
+
+export function PublicHeader() {
+  const [logoHidden, setLogoHidden] = useState(false);
+  const lastScrollY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    const container = document.getElementById("scroll-container");
+    if (!container) return;
+
+    const onScroll = () => {
+      if (ticking.current) return;
+      ticking.current = true;
+
+      requestAnimationFrame(() => {
+        const currentY = container.scrollTop;
+        const delta = currentY - lastScrollY.current;
+
+        // 向下滾超過 10px → 隱藏 logo
+        if (delta > 10 && currentY > 60) {
+          setLogoHidden(true);
+        }
+        // 向上滾超過 10px → 顯示 logo
+        else if (delta < -10) {
+          setLogoHidden(false);
+        }
+
+        lastScrollY.current = currentY;
+        ticking.current = false;
+      });
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => container.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <header className="flex-shrink-0 bg-white/90 backdrop-blur-sm border-b border-slate-200 pt-[env(safe-area-inset-top)]">
+      {/* Row 1: Logo + UserMenu */}
+      <div
+        className={`overflow-hidden transition-all duration-200 ease-in-out ${
+          logoHidden ? "max-h-0 opacity-0" : "max-h-16 opacity-100"
+        }`}
+      >
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+          <div className="flex items-center justify-between h-12 sm:h-14">
+            <Link href="/" className="flex items-center flex-shrink-0">
+              <Image
+                src="/logo.png"
+                alt="小豪哥體育資訊網"
+                width={280}
+                height={50}
+                className="h-7 sm:h-9 w-auto"
+                priority
+              />
+            </Link>
+            <UserMenu />
+          </div>
+        </div>
+      </div>
+
+      {/* Row 2: Nav tabs */}
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <nav className="flex items-center gap-1 overflow-x-auto scrollbar-hide pb-0.5">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="px-3 py-2 text-sm font-medium text-slate-600 rounded-md hover:text-blue-600 hover:bg-blue-50 transition-colors whitespace-nowrap"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- Header 拆為 Logo 行 + 頁籤行，向下滾動時 Logo 隱藏、頁籤置頂，向上滾回時恢復
- 首頁手機版文章卡片改為橫式佈局（左文字 + 右小圖），桌面版維持不變
- TelegramBanner 高度縮小約一半，Footer TG CTA 改為一行式精簡佈局

## Test plan
- [x] vitest 199 tests passed
- [x] next build 成功
- [x] PC (1440×900) 截圖驗證：Logo 行 + 頁籤行分開，滾動隱藏正常
- [x] 手機 (430×932) 截圖驗證：同上，文章卡片橫式佈局
- [ ] iOS in-app browser（Telegram/LINE）無滾動穿透問題

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)