### PR TITLE
fix: 文章快取失效 + Play-by-Play API 修復

### DIFF
--- a/src/app/api/articles/generated/[id]/route.ts
+++ b/src/app/api/articles/generated/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/supabase";
 import { publishArticle } from "@/lib/publish-article";
 
@@ -61,6 +62,12 @@ export async function PATCH(
     if (result.errors.length > 0) {
       console.error(`[Publish] ${id} errors:`, result.errors);
     }
+
+    revalidatePath("/");
+    revalidatePath("/category/[slug]", "page");
+    revalidatePath("/news/[slug]", "page");
+    revalidatePath("/writer/[id]", "page");
+    revalidatePath("/rss.xml");
 
     // 回傳更新後的文章
     const { data } = await supabase

--- a/src/app/api/articles/generated/batch/route.ts
+++ b/src/app/api/articles/generated/batch/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/supabase";
 import { publishArticle } from "@/lib/publish-article";
 
@@ -29,6 +30,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
+    revalidatePath("/");
+    revalidatePath("/category/[slug]", "page");
+    revalidatePath("/news/[slug]", "page");
+    revalidatePath("/writer/[id]", "page");
+    revalidatePath("/rss.xml");
+
     return NextResponse.json({ success: true, deleted: ids.length });
   }
 
@@ -40,5 +47,14 @@ export async function POST(request: NextRequest) {
   }
 
   const published = results.filter((r) => r.success).length;
+
+  if (published > 0) {
+    revalidatePath("/");
+    revalidatePath("/category/[slug]", "page");
+    revalidatePath("/news/[slug]", "page");
+    revalidatePath("/writer/[id]", "page");
+    revalidatePath("/rss.xml");
+  }
+
   return NextResponse.json({ success: true, published, results });
 }

--- a/src/lib/espn/play-by-play.ts
+++ b/src/lib/espn/play-by-play.ts
@@ -1,7 +1,6 @@
-// Play-by-Play 解析
+// Play-by-Play 解析（使用 ESPN summary API）
 
 import { espnFetch, CACHE_TTL, getSportPath } from "./client";
-import type { ESPNPlay } from "./types";
 
 export interface Play {
   id: string;
@@ -16,27 +15,63 @@ export interface Play {
   awayScore: string;
 }
 
-interface PBPApiResponse {
-  items: ESPNPlay[];
+interface SummaryPlay {
+  id: string;
+  sequenceNumber: string;
+  type?: { id: string; text: string };
+  text: string;
+  awayScore: number;
+  homeScore: number;
+  period: { number: number; displayValue: string };
+  clock: { displayValue: string };
+  scoringPlay: boolean;
+  team?: { id: string };
 }
 
-function parsePlays(data: PBPApiResponse): Play[] {
-  return (data.items ?? []).map((p) => ({
+interface SummaryCompetitor {
+  homeAway: "home" | "away";
+  team: { id: string; displayName: string };
+}
+
+interface SummaryResponse {
+  plays?: SummaryPlay[];
+  header?: {
+    competitions?: Array<{
+      competitors?: SummaryCompetitor[];
+    }>;
+  };
+}
+
+function buildTeamMap(data: SummaryResponse): Record<string, string> {
+  const map: Record<string, string> = {};
+  const competitors =
+    data.header?.competitions?.[0]?.competitors ?? [];
+  for (const c of competitors) {
+    map[c.team.id] = c.team.displayName;
+  }
+  return map;
+}
+
+function parsePlays(
+  plays: SummaryPlay[],
+  teamMap: Record<string, string>
+): Play[] {
+  return plays.map((p) => ({
     id: p.id,
     sequence: parseInt(p.sequenceNumber) || 0,
     text: p.text,
     type: p.type?.text ?? "",
     period: p.period?.displayValue ?? "",
     clock: p.clock?.displayValue ?? "",
-    teamName: p.team?.displayName ?? null,
+    teamName: p.team ? (teamMap[p.team.id] ?? null) : null,
     scoringPlay: p.scoringPlay,
-    homeScore: p.homeScore,
-    awayScore: p.awayScore,
+    homeScore: String(p.homeScore),
+    awayScore: String(p.awayScore),
   }));
 }
 
 /**
- * 取得逐球紀錄
+ * 取得逐球紀錄（透過 summary API）
  * @param league - 聯賽 key (nba, mlb, etc.)
  * @param eventId - ESPN event ID
  * @param isCompleted - 是否已結束（影響快取 TTL）
@@ -49,12 +84,13 @@ export async function fetchPlayByPlay(
   const sportPath = getSportPath(league);
   const ttl = isCompleted ? CACHE_TTL.PBP_FINAL : CACHE_TTL.LIVE;
 
-  const data = await espnFetch<PBPApiResponse>(
-    `${sportPath}/events/${eventId}/competitions/${eventId}/plays`,
-    { ttl, params: { limit: "300" } }
+  const data = await espnFetch<SummaryResponse>(
+    `${sportPath}/summary`,
+    { ttl, params: { event: eventId } }
   );
 
-  return parsePlays(data);
+  const teamMap = buildTeamMap(data);
+  return parsePlays(data.plays ?? [], teamMap);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Issue #6**: 後台刪除/發布文章後，加入 `revalidatePath` 清除前台 Next.js 快取（首頁、分類頁、文章頁、作者頁、RSS），確保即時反映變更
- **Issue #7**: `fetchPlayByPlay` 從不存在的 `/competitions/{id}/plays` 端點改為使用 `/summary?event={id}`，解析 `response.plays[]` + 從 header 建立 team ID→displayName 對應

## Changes
- `src/app/api/articles/generated/batch/route.ts` — delete/publish 後 revalidatePath
- `src/app/api/articles/generated/[id]/route.ts` — 單篇發布後 revalidatePath
- `src/lib/espn/play-by-play.ts` — 改用 summary API、修正 team name 解析、score 型別轉換

## Test plan
- [x] `npx vitest run` — 199 tests passed
- [x] `npx tsc --noEmit` — no errors
- [ ] 部署後驗證：後台刪除文章 → 前台立即消失
- [ ] 部署後驗證：比賽詳情頁「逐球紀錄」tab 正常顯示資料

Closes #6, Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)