### PR TITLE
fix: MemberGate 已登入仍顯示擋住內容

### DIFF
--- a/src/__tests__/api/member-favorites.test.ts
+++ b/src/__tests__/api/member-favorites.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock auth
+const mockAuth = vi.fn();
+vi.mock("@/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+// Mock member functions
+const mockGetPrefs = vi.fn();
+const mockUpdatePrefs = vi.fn();
+vi.mock("@/lib/member", () => ({
+  getMemberPreferences: (...args: unknown[]) => mockGetPrefs(...args),
+  updateMemberPreferences: (...args: unknown[]) => mockUpdatePrefs(...args),
+}));
+
+import { GET, POST, DELETE } from "@/app/api/member/favorites/route";
+import { NextRequest } from "next/server";
+
+function makeRequest(method: string, body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/member/favorites", {
+    method,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+describe("/api/member/favorites", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET", () => {
+    it("未登入回傳 401", async () => {
+      mockAuth.mockResolvedValue(null);
+      const res = await GET();
+      expect(res.status).toBe(401);
+    });
+
+    it("無 memberId 回傳 401", async () => {
+      mockAuth.mockResolvedValue({ user: { name: "Test" } });
+      const res = await GET();
+      expect(res.status).toBe(401);
+    });
+
+    it("正常取得 favorites", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockResolvedValue({
+        favorite_teams: [{ sport: "nba", teamId: "13", name: "Lakers" }],
+      });
+
+      const res = await GET();
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.favorites).toHaveLength(1);
+      expect(data.favorites[0].teamId).toBe("13");
+    });
+
+    it("無 preferences 回傳空陣列", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockResolvedValue(null);
+
+      const res = await GET();
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.favorites).toEqual([]);
+    });
+
+    it("DB 錯誤回傳 500", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockRejectedValue(new Error("DB connection failed"));
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("POST", () => {
+    it("缺少欄位回傳 400", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+
+      const req = makeRequest("POST", { sport: "nba" });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("正常新增 favorite", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockResolvedValue({ favorite_teams: [] });
+      mockUpdatePrefs.mockResolvedValue(null);
+
+      const req = makeRequest("POST", {
+        sport: "nba",
+        teamId: "13",
+        name: "Lakers",
+      });
+      const res = await POST(req);
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.favorites).toHaveLength(1);
+      expect(mockUpdatePrefs).toHaveBeenCalledWith("m1", {
+        favorite_teams: [{ sport: "nba", teamId: "13", name: "Lakers" }],
+      });
+    });
+
+    it("重複新增不產生重複項", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockResolvedValue({
+        favorite_teams: [{ sport: "nba", teamId: "13", name: "Lakers" }],
+      });
+
+      const req = makeRequest("POST", {
+        sport: "nba",
+        teamId: "13",
+        name: "Lakers",
+      });
+      const res = await POST(req);
+      const data = await res.json();
+
+      expect(data.favorites).toHaveLength(1);
+      expect(mockUpdatePrefs).not.toHaveBeenCalled();
+    });
+
+    it("DB 錯誤回傳 500", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockRejectedValue(new Error("DB error"));
+
+      const req = makeRequest("POST", {
+        sport: "nba",
+        teamId: "13",
+        name: "Lakers",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("DELETE", () => {
+    it("正常刪除 favorite", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockResolvedValue({
+        favorite_teams: [
+          { sport: "nba", teamId: "13", name: "Lakers" },
+          { sport: "mlb", teamId: "5", name: "Yankees" },
+        ],
+      });
+      mockUpdatePrefs.mockResolvedValue(null);
+
+      const req = makeRequest("DELETE", { sport: "nba", teamId: "13" });
+      const res = await DELETE(req);
+      const data = await res.json();
+
+      expect(data.favorites).toHaveLength(1);
+      expect(data.favorites[0].sport).toBe("mlb");
+    });
+
+    it("DB 錯誤回傳 500", async () => {
+      mockAuth.mockResolvedValue({
+        user: { memberId: "m1", role: "member" },
+      });
+      mockGetPrefs.mockRejectedValue(new Error("DB error"));
+
+      const req = makeRequest("DELETE", { sport: "nba", teamId: "13" });
+      const res = await DELETE(req);
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/__tests__/components/MemberGate.test.tsx
+++ b/src/__tests__/components/MemberGate.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock next-auth/react
+const mockUseSession = vi.fn();
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}));
+
+// Mock LoginModal to avoid rendering complexity
+vi.mock("@/components/auth/LoginModal", () => ({
+  LoginModal: () => null,
+}));
+
+import { MemberGate } from "@/components/auth/MemberGate";
+
+describe("MemberGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("session loading 時不渲染任何內容", () => {
+    mockUseSession.mockReturnValue({ data: null, status: "loading" });
+
+    const { container } = render(
+      <MemberGate fallback={<div>預覽</div>}>
+        <div>完整內容</div>
+      </MemberGate>
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("未登入時顯示登入引導，不顯示完整內容", () => {
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(
+      <MemberGate message="請登入" fallback={<div>預覽</div>}>
+        <div>完整內容</div>
+      </MemberGate>
+    );
+
+    expect(screen.getByText("請登入")).toBeDefined();
+    expect(screen.getByText("預覽")).toBeDefined();
+    expect(screen.queryByText("完整內容")).toBeNull();
+  });
+
+  it("已登入 member 顯示完整內容", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { name: "Test", role: "member", memberId: "123" } },
+      status: "authenticated",
+    });
+
+    render(
+      <MemberGate fallback={<div>預覽</div>}>
+        <div>完整內容</div>
+      </MemberGate>
+    );
+
+    expect(screen.getByText("完整內容")).toBeDefined();
+    expect(screen.queryByText("預覽")).toBeNull();
+  });
+
+  it("已登入 admin 也顯示完整內容", () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { name: "Admin", role: "admin" } },
+      status: "authenticated",
+    });
+
+    render(
+      <MemberGate fallback={<div>預覽</div>}>
+        <div>完整內容</div>
+      </MemberGate>
+    );
+
+    expect(screen.getByText("完整內容")).toBeDefined();
+    expect(screen.queryByText("預覽")).toBeNull();
+  });
+});

--- a/src/app/api/member/favorites/route.ts
+++ b/src/app/api/member/favorites/route.ts
@@ -18,10 +18,15 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const prefs = await getMemberPreferences(session.user.memberId);
-  return NextResponse.json({
-    favorites: prefs?.favorite_teams ?? [],
-  });
+  try {
+    const prefs = await getMemberPreferences(session.user.memberId);
+    return NextResponse.json({
+      favorites: prefs?.favorite_teams ?? [],
+    });
+  } catch (err) {
+    console.error("[Favorites] GET error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -30,25 +35,30 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { sport, teamId, name } = await request.json();
-  if (!sport || !teamId || !name) {
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  try {
+    const { sport, teamId, name } = await request.json();
+    if (!sport || !teamId || !name) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    }
+
+    const prefs = await getMemberPreferences(session.user.memberId);
+    const existing = prefs?.favorite_teams ?? [];
+
+    // 避免重複
+    if (existing.some((t) => t.teamId === teamId && t.sport === sport)) {
+      return NextResponse.json({ favorites: existing });
+    }
+
+    const updated = [...existing, { sport, teamId, name }];
+    await updateMemberPreferences(session.user.memberId, {
+      favorite_teams: updated,
+    });
+
+    return NextResponse.json({ favorites: updated });
+  } catch (err) {
+    console.error("[Favorites] POST error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
   }
-
-  const prefs = await getMemberPreferences(session.user.memberId);
-  const existing = prefs?.favorite_teams ?? [];
-
-  // 避免重複
-  if (existing.some((t) => t.teamId === teamId && t.sport === sport)) {
-    return NextResponse.json({ favorites: existing });
-  }
-
-  const updated = [...existing, { sport, teamId, name }];
-  await updateMemberPreferences(session.user.memberId, {
-    favorite_teams: updated,
-  });
-
-  return NextResponse.json({ favorites: updated });
 }
 
 export async function DELETE(request: NextRequest) {
@@ -57,17 +67,22 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { sport, teamId } = await request.json();
+  try {
+    const { sport, teamId } = await request.json();
 
-  const prefs = await getMemberPreferences(session.user.memberId);
-  const existing = prefs?.favorite_teams ?? [];
-  const updated = existing.filter(
-    (t) => !(t.teamId === teamId && t.sport === sport)
-  );
+    const prefs = await getMemberPreferences(session.user.memberId);
+    const existing = prefs?.favorite_teams ?? [];
+    const updated = existing.filter(
+      (t) => !(t.teamId === teamId && t.sport === sport)
+    );
 
-  await updateMemberPreferences(session.user.memberId, {
-    favorite_teams: updated,
-  });
+    await updateMemberPreferences(session.user.memberId, {
+      favorite_teams: updated,
+    });
 
-  return NextResponse.json({ favorites: updated });
+    return NextResponse.json({ favorites: updated });
+  } catch (err) {
+    console.error("[Favorites] DELETE error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
 }

--- a/src/components/auth/MemberGate.tsx
+++ b/src/components/auth/MemberGate.tsx
@@ -27,11 +27,16 @@ export function MemberGate({
   message = "登入查看完整內容",
   className,
 }: MemberGateProps) {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const [loginOpen, setLoginOpen] = useState(false);
 
-  // 已登入會員 → 顯示完整內容（admin 不算會員）
-  if (session?.user?.role === "member") {
+  // Session 載入中 → 不顯示任何內容，避免閃爍
+  if (status === "loading") {
+    return null;
+  }
+
+  // 已登入用戶 → 顯示完整內容
+  if (session?.user) {
     return <>{children}</>;
   }
 
@@ -89,10 +94,14 @@ export function MemberGateList<T>({
   message?: string;
   className?: string;
 }) {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
 
-  // 已登入會員 → 顯示全部（admin 不算會員）
-  if (session?.user?.role === "member") {
+  if (status === "loading") {
+    return null;
+  }
+
+  // 已登入用戶 → 顯示全部
+  if (session?.user) {
     return (
       <div className={className}>
         {items.map((item, i) => renderItem(item, i))}


### PR DESCRIPTION
## Summary
- MemberGate 從 `role === "member"` 改為 `!!session?.user`，任何已登入用戶皆可看到完整內容
- 新增 session loading 狀態處理，避免已登入用戶看到閃爍的登入引導
- favorites API 加入 try-catch 錯誤處理，防止 500 error

Closes #10

## Changes
- `src/components/auth/MemberGate.tsx`：修正登入判斷邏輯 + loading 狀態
- `src/app/api/member/favorites/route.ts`：GET/POST/DELETE 加入 try-catch
- `src/__tests__/components/MemberGate.test.tsx`：新增 4 個測試
- `src/__tests__/api/member-favorites.test.ts`：新增 11 個測試

## Test
- QA 通過 ✓
- Review 通過 ✓
- Unit tests 95 passed ✓