### PR TITLE
fix: MemberGate 排除 admin + 補 E2E 測試

### DIFF
--- a/e2e/public.spec.ts
+++ b/e2e/public.spec.ts
@@ -155,6 +155,45 @@ test.describe("即時比分頁", () => {
 });
 
 // ---------------------------------------------------------------------------
+// MemberGate（球隊頁訪客限制）
+// ---------------------------------------------------------------------------
+test.describe("MemberGate 訪客限制", () => {
+  test("未登入訪問球隊頁顯示登入引導與模糊預覽", async ({ page }) => {
+    await page.goto("/team/nba/13");
+
+    // 球隊頁載入成功
+    await expect(page.getByText("球員名單", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+    // 未登入應看到登入引導
+    await expect(page.getByText("登入查看完整球員名單與數據")).toBeVisible();
+    await expect(page.getByRole("button", { name: "免費登入" })).toBeVisible();
+  });
+
+  test("Team API 回傳球隊資料", async ({ request }) => {
+    const resp = await request.get("/api/public/team?sport=nba&id=13");
+    expect(resp.ok()).toBeTruthy();
+    const json = await resp.json();
+    expect(json).toHaveProperty("team");
+    expect(json.team).toHaveProperty("name");
+    expect(json.team).toHaveProperty("abbreviation");
+  });
+
+  test("Team Roster API 回傳球員名單", async ({ request }) => {
+    const resp = await request.get("/api/public/team?sport=nba&id=13&type=roster");
+    expect(resp.ok()).toBeTruthy();
+    const json = await resp.json();
+    expect(json).toHaveProperty("roster");
+    expect(Array.isArray(json.roster)).toBeTruthy();
+  });
+
+  test("Favorites API 未登入回傳 401", async ({ request }) => {
+    const resp = await request.get("/api/member/favorites");
+    // 未登入應回傳 401 或 redirect
+    expect([401, 302].includes(resp.status())).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // SEO / crawler files
 // ---------------------------------------------------------------------------
 test.describe("SEO 檔案", () => {

--- a/src/__tests__/components/MemberGate.test.tsx
+++ b/src/__tests__/components/MemberGate.test.tsx
@@ -61,19 +61,19 @@ describe("MemberGate", () => {
     expect(screen.queryByText("預覽")).toBeNull();
   });
 
-  it("已登入 admin 也顯示完整內容", () => {
+  it("已登入 admin 不顯示會員內容（前後台分離）", () => {
     mockUseSession.mockReturnValue({
       data: { user: { name: "Admin", role: "admin" } },
       status: "authenticated",
     });
 
     render(
-      <MemberGate fallback={<div>預覽</div>}>
+      <MemberGate message="請登入" fallback={<div>預覽</div>}>
         <div>完整內容</div>
       </MemberGate>
     );
 
-    expect(screen.getByText("完整內容")).toBeDefined();
-    expect(screen.queryByText("預覽")).toBeNull();
+    expect(screen.queryByText("完整內容")).toBeNull();
+    expect(screen.getByText("請登入")).toBeDefined();
   });
 });

--- a/src/components/auth/MemberGate.tsx
+++ b/src/components/auth/MemberGate.tsx
@@ -35,8 +35,8 @@ export function MemberGate({
     return null;
   }
 
-  // 已登入用戶 → 顯示完整內容
-  if (session?.user) {
+  // 已登入會員 → 顯示完整內容（admin 是後台帳號，不算前台會員）
+  if (session?.user && session.user.role !== "admin") {
     return <>{children}</>;
   }
 
@@ -100,8 +100,8 @@ export function MemberGateList<T>({
     return null;
   }
 
-  // 已登入用戶 → 顯示全部
-  if (session?.user) {
+  // 已登入會員 → 顯示全部（admin 不算前台會員）
+  if (session?.user && session.user.role !== "admin") {
     return (
       <div className={className}>
         {items.map((item, i) => renderItem(item, i))}


### PR DESCRIPTION
## Summary
- MemberGate 排除 admin 帳號（前後台分離，admin 不算前台會員）
- 新增 4 個 MemberGate E2E 測試（球隊頁訪客限制、Team API、Roster API、Favorites 401）

Follow-up to #19

## Changes
- `MemberGate.tsx`：`session?.user` → `session?.user && role !== "admin"`
- `MemberGate.test.tsx`：更新 admin 測試斷言
- `e2e/public.spec.ts`：新增 MemberGate 訪客限制測試區塊

## Test
- Unit tests 95 passed ✓
- Smoke 28/28 ✓
- E2E public 19 passed ✓