### PR TITLE
docs: 整理 ESPN API 欄位文件

### DIFF
--- a/docs/espn-api/README.md
+++ b/docs/espn-api/README.md
@@ -1,0 +1,56 @@
+# ESPN API 文件索引
+
+本專案所有運動數據來自 ESPN 公開 API。此文件記錄各端點的完整欄位結構，避免頻繁實測。
+
+> 最後更新：2026-03-17
+
+## Base URLs
+
+| 用途 | Base URL |
+|------|---------|
+| 主要 API | `https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}` |
+| Standings | `https://site.api.espn.com/apis/v2/sports/{sport}/{league}/standings` |
+
+## League 路徑對照表
+
+| Key | ESPN 路徑 | 運動 |
+|-----|---------|------|
+| `nba` | `basketball/nba` | 籃球 |
+| `mlb` | `baseball/mlb` | 棒球 |
+| `nfl` | `football/nfl` | 美式足球 |
+| `nhl` | `hockey/nhl` | 冰球 |
+| `epl` | `soccer/eng.1` | 英超 |
+| `laliga` | `soccer/esp.1` | 西甲 |
+| `ucl` | `soccer/uefa.champions` | 歐冠 |
+| `mls` | `soccer/usa.1` | 美國大聯盟足球 |
+
+## API 端點清單
+
+| 端點 | URL | 文件 | 快取 TTL |
+|------|-----|------|---------|
+| Scoreboard | `{base}/scoreboard?dates=YYYYMMDD` | [scoreboard.md](./scoreboard.md) | 10s（當天）/ 24h（歷史）|
+| Standings | `{standings-base}` | [standings.md](./standings.md) | 5 分鐘 |
+| Summary | `{base}/summary?event={eventId}` | [summary.md](./summary.md) | 10s（進行中）/ 1h（已結束）|
+| Team | `{base}/teams/{id}` | [team.md](./team.md) | 10 分鐘 |
+| Team Roster | `{base}/teams/{id}/roster` | [team.md](./team.md#roster) | 10 分鐘 |
+| Player | `{base}/athletes/{id}` | [player.md](./player.md) | 10 分鐘 |
+
+## 快取 TTL 設定
+
+定義在 `src/lib/espn/client.ts`：
+
+| 常數 | TTL | 適用對象 |
+|------|-----|---------|
+| `LIVE` | 10 秒 | 即時比分、進行中 PBP |
+| `ODDS` | 60 秒 | 賠率 |
+| `STANDINGS` | 5 分鐘 | 排名 |
+| `TEAM` | 10 分鐘 | 球隊、球員資料 |
+| `PBP_FINAL` | 1 小時 | 已結束比賽 PBP |
+| `HISTORICAL` | 24 小時 | 歷史比分 |
+
+## 圖示說明
+
+文件中使用以下標記：
+- ✅ **已使用** — 程式碼已解析並顯示在前端
+- ⚠️ **未使用** — API 有回傳但程式碼未解析，可用於未來功能
+- 📁 **解析檔案** — 標註在哪個原始碼檔案中解析

--- a/docs/espn-api/player.md
+++ b/docs/espn-api/player.md
@@ -1,0 +1,159 @@
+# Player API
+
+球員基本資訊與數據。
+
+## 端點
+
+### 基本資訊 + 統計
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/athletes/{id}
+```
+
+### Overview（含 Game Log、Rankings）
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/athletes/{id}/overview
+```
+
+> ⚠️ 目前程式碼中 `src/lib/espn/player.ts` 呼叫的是 `/overview` 端點，但 API route `src/app/api/public/player/route.ts` 呼叫的是基本端點（無 `/overview`）。兩者回傳結構不同。
+
+## 📁 解析檔案
+
+- `src/lib/espn/player.ts`
+
+---
+
+## 基本端點回傳結構
+
+```
+GET .../athletes/{id}
+```
+
+### Athlete 欄位
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ✅ | 球員 ID |
+| `displayName` | string | ✅ | 全名 |
+| `firstName` | string | ⚠️ | 名 |
+| `lastName` | string | ⚠️ | 姓 |
+| `shortName` | string | ⚠️ | 短名（如 "N. Alexander-Walker"）|
+| `jersey` | string | ✅ | 背號 |
+| `position` | Position | ✅ | 位置 |
+| `position.displayName` | string | ✅ | 位置全名（如 "Guard"）|
+| `position.abbreviation` | string | ⚠️ | 位置縮寫（如 "G"）|
+| `age` | number | ⚠️ | 年齡 |
+| `displayHeight` | string | ⚠️ | 身高 |
+| `displayWeight` | string | ⚠️ | 體重 |
+| `dateOfBirth` | string | ⚠️ | 生日 |
+| `debutYear` | number | ⚠️ | 出道年份 |
+| `birthPlace` | object | ⚠️ | 出生地 |
+| `college` | object | ⚠️ | 大學 |
+| `draft` | Draft | ⚠️ | 選秀資訊 |
+| `experience` | object | ⚠️ | 年資 |
+| `headshot.href` | string | ✅ | 頭像 URL |
+| `team` | Team | ✅ | 所屬球隊 |
+| `team.id` | string | ✅ | 球隊 ID |
+| `team.displayName` | string | ✅ | 球隊全名 |
+| `team.abbreviation` | string | ✅ | 球隊縮寫 |
+| `team.logos[0].href` | string | ✅ | 球隊 Logo |
+| `statistics` | Statistics[] | ✅ | 球員數據 |
+| `status` | object | ⚠️ | 球員狀態 |
+| `injuries` | object[] | ⚠️ | 傷勢 |
+
+### Statistics 結構
+
+```json
+{
+  "statistics": [{
+    "name": "2025-26",
+    "type": "stats",
+    "categories": [{
+      "name": "general",
+      "displayName": "General",
+      "stats": [
+        { "name": "GP", "displayName": "Games Played", "value": 68, "displayValue": "68" },
+        { "name": "GS", "displayName": "Games Started", "value": 68, "displayValue": "68" },
+        { "name": "MIN", "displayName": "Minutes Per Game", "value": 35.2, "displayValue": "35.2" }
+      ]
+    }, {
+      "name": "offensive",
+      "displayName": "Offensive",
+      "stats": [
+        { "name": "PTS", "displayName": "Points Per Game", "value": 24.5, "displayValue": "24.5" },
+        { "name": "FGM", "displayName": "Field Goals Made Per Game", ... },
+        { "name": "FGA", "displayName": "Field Goals Attempted Per Game", ... },
+        { "name": "FG%", "displayName": "Field Goal Percentage", ... },
+        { "name": "3PM", "displayName": "Three Point Field Goals Made Per Game", ... }
+      ]
+    }]
+  }]
+}
+```
+
+程式碼使用 `flatMap` 攤平所有 categories 的 stats，取前 15 筆回傳。
+
+---
+
+## Overview 端點回傳結構
+
+```
+GET .../athletes/{id}/overview
+```
+
+> ⚠️ 此端點可能對某些球員回傳錯誤（如已觀察到回傳 `{"code": ...}`）
+
+### 額外欄位（基本端點沒有的）
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `rankings` | Rankings | ⚠️ **可用** | 聯盟排名 |
+| `gameLog` | GameLog | ⚠️ **可用** | 近期比賽紀錄 |
+| `statistics` | Statistics[] | ⚠️ | 更詳細的統計分類 |
+
+### Rankings 結構（⚠️ 未使用）
+
+```json
+{
+  "rankings": [{
+    "name": "points",
+    "displayName": "Points Per Game",
+    "rank": 1,
+    "value": 32.8
+  }, {
+    "name": "assists",
+    "displayName": "Assists Per Game",
+    "rank": 3,
+    "value": 8.2
+  }]
+}
+```
+
+### GameLog 結構（⚠️ 未使用）
+
+```json
+{
+  "gameLog": {
+    "categories": [{
+      "name": "general",
+      "labels": ["DATE", "OPP", "SCORE", "MIN", "PTS", "FGM", "FGA", "FG%"],
+      "events": [{
+        "gameId": "401810838",
+        "gameDate": "2026-03-16",
+        "opponent": { "id": "1", "abbreviation": "ATL" },
+        "result": "W",
+        "stats": ["03/16", "vs ATL", "W 124-112", "33", "18", "3", "13", ".231"]
+      }]
+    }]
+  }
+}
+```
+
+---
+
+## 注意事項
+
+1. **基本端點 vs Overview 端點**：Overview 多了 rankings 和 gameLog，但可能對部分球員不穩定
+2. **Statistics 結構差異**：基本端點的 statistics 在 `athlete.statistics`，Overview 的在頂層 `statistics`
+3. **前 15 筆限制**：目前程式碼只取前 15 筆 stats 回傳前端

--- a/docs/espn-api/scoreboard.md
+++ b/docs/espn-api/scoreboard.md
@@ -1,0 +1,195 @@
+# Scoreboard API
+
+即時比分資料。
+
+## 端點
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/scoreboard?dates=YYYYMMDD
+```
+
+## 📁 解析檔案
+
+- `src/lib/espn/scoreboard.ts`（新版，使用統一 client）
+- `src/lib/scoreboard.ts`（舊版，仍被 API route 使用）
+
+## 回傳結構
+
+```
+{
+  leagues: [{ id, name, abbreviation, season, ... }],
+  events: Event[]
+}
+```
+
+### Event
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ✅ | 比賽 ID（用於 summary API） |
+| `uid` | string | ⚠️ | ESPN UID |
+| `date` | string | ✅ | ISO 日期 |
+| `name` | string | ⚠️ | 完整比賽名稱（如 "Atlanta Hawks at Orlando Magic"）|
+| `shortName` | string | ⚠️ | 簡短名稱（如 "ATL @ ORL"）|
+| `season` | object | ⚠️ | 賽季資訊 |
+| `status` | Status | ✅ | 比賽狀態 |
+| `competitions` | Competition[] | ✅ | 比賽詳情（通常只有 1 個）|
+| `links` | Link[] | ⚠️ | ESPN 網頁連結 |
+
+### Status
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `clock` | number | ⚠️ | 比賽時鐘秒數 |
+| `displayClock` | string | ⚠️ | 顯示用時鐘 |
+| `period` | number | ⚠️ | 目前節數 |
+| `type.id` | string | ⚠️ | 狀態 ID |
+| `type.name` | string | ✅ | 狀態名稱：`STATUS_IN_PROGRESS` / `STATUS_FINAL` / `STATUS_SCHEDULED` |
+| `type.state` | string | ⚠️ | `in` / `post` / `pre` |
+| `type.completed` | boolean | ⚠️ | 是否已結束 |
+| `type.shortDetail` | string | ✅ | 簡短狀態描述（如 "Final", "Q3 5:22"）|
+
+### Competition
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ⚠️ | 比賽 ID |
+| `date` | string | ⚠️ | 日期 |
+| `attendance` | number | ⚠️ | 入場人數 |
+| `venue` | object | ⚠️ | 場館資訊 |
+| `competitors` | Competitor[] | ✅ | 參賽隊伍（2 隊）|
+| `odds` | Odds[] | ✅ | 賠率（只取第一個 provider）|
+| `broadcasts` | Broadcast[] | ⚠️ | 轉播資訊 |
+| `headlines` | object[] | ⚠️ | 頭條 |
+| `highlights` | object[] | ⚠️ | 精華影片 |
+| `notes` | object[] | ⚠️ | 備註 |
+| `status` | Status | ⚠️ | 比賽狀態（同上層） |
+
+### Competitor
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ⚠️ | 隊伍 ID |
+| `homeAway` | string | ✅ | `"home"` 或 `"away"` |
+| `winner` | boolean | ⚠️ | 是否獲勝 |
+| `score` | string | ✅ | 總分 |
+| `linescores` | LineScore[] | ⚠️ **可用** | 逐節分數 |
+| `statistics` | Statistic[] | ⚠️ | 球隊整場統計 |
+| `leaders` | Leader[] | ⚠️ **可用** | 該隊本場最佳球員 |
+| `records` | Record[] | ✅ | 戰績記錄（只取 `[0].summary`）|
+| `team.id` | string | ⚠️ | 隊伍 ID |
+| `team.displayName` | string | ✅ | 隊伍全名 |
+| `team.abbreviation` | string | ✅ | 縮寫 |
+| `team.logo` | string | ✅ | Logo URL |
+| `team.color` | string | ⚠️ | 主色 hex |
+| `team.alternateColor` | string | ⚠️ | 副色 hex |
+| `team.location` | string | ⚠️ | 城市名 |
+| `team.name` | string | ⚠️ | 隊名（不含城市）|
+| `team.shortDisplayName` | string | ⚠️ | 短隊名 |
+
+### LineScore（⚠️ 未使用，可用於 #16 逐節分數功能）
+
+```json
+[
+  { "value": 34.0, "displayValue": "34", "period": 1 },
+  { "value": 33.0, "displayValue": "33", "period": 2 },
+  { "value": 37.0, "displayValue": "37", "period": 3 },
+  { "value": 20.0, "displayValue": "20", "period": 4 }
+]
+```
+
+- NBA：通常 4 節，加時會多出 period 5, 6...
+- MLB：通常 9 局，延長局會多出
+
+### Competitor Leaders（⚠️ 未使用，可用於 #16 本場最佳功能）
+
+每隊有 4 類 leaders：Points、Rebounds、Assists、Rating。
+
+```json
+{
+  "name": "points",
+  "displayName": "Points",
+  "leaders": [{
+    "displayValue": "41",
+    "value": 41.0,
+    "athlete": {
+      "id": "4278039",
+      "displayName": "Nickeil Alexander-Walker",
+      "shortName": "N. Alexander-Walker",
+      "headshot": "https://a.espncdn.com/i/headshots/nba/players/full/4278039.png",
+      "jersey": "7",
+      "position": { "abbreviation": "G" },
+      "team": { "id": "1" }
+    }
+  }]
+}
+```
+
+### Competitor Statistics（⚠️ 未使用）
+
+球隊整場統計數據。
+
+NBA 範例：
+```json
+[
+  { "name": "rebounds", "abbreviation": "REB", "displayValue": "54" },
+  { "name": "avgRebounds", "abbreviation": "REB", "displayValue": "54.0" },
+  { "name": "assists", "abbreviation": "AST", "displayValue": "33" },
+  { "name": "fieldGoalsAttempted", "abbreviation": "FGA", "displayValue": "93" },
+  { "name": "fieldGoalsMade", "abbreviation": "FGM", "displayValue": "43" }
+]
+```
+
+### Competition Odds（✅ 部分使用）
+
+```json
+{
+  "provider": { "id": "45", "name": "Caesars Sportsbook" },
+  "details": "LAL -3.5",
+  "overUnder": 228.5,
+  "spread": -3.5,
+  "homeTeamOdds": { "moneyLine": -160, "spreadOdds": -110, "favorite": true },
+  "awayTeamOdds": { "moneyLine": 135, "spreadOdds": -110, "favorite": false },
+  "overOdds": -110,
+  "underOdds": -110
+}
+```
+
+| 欄位 | 狀態 | 說明 |
+|------|------|------|
+| `provider.name` | ✅ | 賠率提供商名稱 |
+| `details` | ✅ | 盤口描述 |
+| `overUnder` | ✅ | 大小分 |
+| `spread` | ✅ | 讓分 |
+| `homeTeamOdds.moneyLine` | ✅ | 主隊美式賠率 |
+| `awayTeamOdds.moneyLine` | ✅ | 客隊美式賠率 |
+| `homeTeamOdds.spreadOdds` | ⚠️ | 主隊讓分賠率 |
+| `awayTeamOdds.spreadOdds` | ⚠️ | 客隊讓分賠率 |
+| `homeTeamOdds.favorite` | ⚠️ | 是否為熱門 |
+| `overOdds` | ⚠️ | 大分賠率 |
+| `underOdds` | ⚠️ | 小分賠率 |
+
+### Broadcasts（⚠️ 未使用）
+
+```json
+[{ "market": "national", "names": ["Peacock", "NBCSN"] }]
+```
+
+## 聯賽差異
+
+### MLB Scoreboard
+
+- `linescores`：9 局（可能延長），結構相同
+- `statistics`：MLB 專有欄位
+
+```json
+[
+  { "name": "hits", "abbreviation": "H", "displayValue": "3" },
+  { "name": "runs", "abbreviation": "R", "displayValue": "2" },
+  { "name": "avg", "abbreviation": "AVG", "displayValue": ".115" },
+  { "name": "saves", "abbreviation": "SV", "displayValue": "1" },
+  { "name": "ERA", "abbreviation": "ERA", "displayValue": "0.00" }
+]
+```
+
+- `leaders`：MLB 使用 `MLBRating`，格式為 `"5.0 IP, 0 ER, H, 4 K, 2 BB"`

--- a/docs/espn-api/standings.md
+++ b/docs/espn-api/standings.md
@@ -1,0 +1,132 @@
+# Standings API
+
+戰績排名資料。注意 base URL 與其他端點不同。
+
+## 端點
+
+```
+GET https://site.api.espn.com/apis/v2/sports/{sport}/{league}/standings
+```
+
+> ⚠️ 注意：是 `/apis/v2/` 不是 `/apis/site/v2/`
+
+## 📁 解析檔案
+
+- `src/lib/espn/standings.ts`
+
+## 回傳結構
+
+```
+{
+  uid, id, name, abbreviation,
+  children: StandingsGroup[]
+}
+```
+
+### StandingsGroup
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `uid` | string | ⚠️ | ESPN UID |
+| `id` | string | ⚠️ | 分組 ID |
+| `name` | string | ✅ | 分組名稱（如 "Eastern Conference"）|
+| `abbreviation` | string | ⚠️ | 分組縮寫（如 "East"）|
+| `isConference` | boolean | ⚠️ | 是否為 Conference 級別 |
+| `standings.entries` | Entry[] | ✅ | 該分組的隊伍戰績 |
+
+> MLB 結構更深：`children[0].children[]`（League → Division）
+
+### Entry
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `team.id` | string | ✅ | 隊伍 ID |
+| `team.displayName` | string | ✅ | 隊伍全名 |
+| `team.abbreviation` | string | ✅ | 縮寫 |
+| `team.location` | string | ⚠️ | 城市 |
+| `team.name` | string | ⚠️ | 隊名（不含城市）|
+| `team.shortDisplayName` | string | ⚠️ | 短隊名 |
+| `team.logos[0].href` | string | ✅ | Logo URL |
+| `team.isActive` | boolean | ⚠️ | 是否活躍 |
+| `stats` | Stat[] | ✅ | 統計數據（動態 key-value）|
+
+### Stats 欄位
+
+`stats` 是陣列，每個元素結構為：
+
+```json
+{
+  "name": "wins",
+  "displayName": "Wins",
+  "shortDisplayName": "W",
+  "description": "Wins",
+  "abbreviation": "W",
+  "type": "wins",
+  "value": 15.0,
+  "displayValue": "15"
+}
+```
+
+程式碼將 `stats[]` 轉為 `Record<name, displayValue>` map。
+
+## NBA Standings 所有欄位
+
+| stat name | 簡稱 | 狀態 | 說明 | 範例值 |
+|-----------|------|------|------|--------|
+| `wins` | W | ✅ | 勝場 | 43 |
+| `losses` | L | ✅ | 敗場 | 25 |
+| `winPercent` | PCT | ✅ | 勝率 | .632 |
+| `gamesBehind` | GB | ✅ | 勝差 | 5.5 |
+| `streak` | STRK | ✅ | 連勝/連敗 | W3 |
+| `overall` | OVER | ⚠️ | 總戰績 | 43-25 |
+| `Home` | HOME | ⚠️ **可用** | 主場戰績 | 25-10 |
+| `Road` | AWAY | ⚠️ **可用** | 客場戰績 | 18-15 |
+| `Last Ten Games` | L10 | ⚠️ **可用** | 近十場 | 7-3 |
+| `vs. Div.` | DIV | ⚠️ | 分區對戰 | 8-4 |
+| `vs. Conf.` | CONF | ⚠️ | 聯盟對戰 | 30-15 |
+| `avgPointsFor` | PPG | ⚠️ | 場均得分 | 116.3 |
+| `avgPointsAgainst` | OPP PPG | ⚠️ | 場均失分 | 114.9 |
+| `differential` | DIFF | ⚠️ | 場均分差 | +1.3 |
+| `pointDifferential` | DIFF | ⚠️ | 總分差 | +91 |
+| `pointsFor` | PF | ⚠️ | 總得分 | 7905 |
+| `pointsAgainst` | PA | ⚠️ | 總失分 | 7814 |
+| `playoffSeed` | POS | ⚠️ | 季後賽種子 | 3 |
+| `clincher` | CLINCH | ⚠️ | 晉級/淘汰標記 | x / e |
+| `divisionWinPercent` | DPCT | ⚠️ | 分區勝率 | 0.667 |
+| `leagueWinPercent` | LPCT | ⚠️ | 聯盟勝率 | 0.652 |
+| `gamesAhead` | GA | ⚠️ | 領先場次 | - |
+| `points` | PTS | ⚠️ | 積分（用途不明） | -19.0 |
+
+## MLB Standings 所有欄位
+
+| stat name | 簡稱 | 狀態 | 說明 | 範例值 |
+|-----------|------|------|------|--------|
+| `wins` | W | ✅ | 勝場 | 16 |
+| `losses` | L | ✅ | 敗場 | 7 |
+| `winPercent` | PCT | ✅ | 勝率 | .696 |
+| `gamesBehind` | GB | ✅ | 勝差 | - |
+| `streak` | STRK | ⚠️ | 連勝/連敗 | L1 |
+| `ties` | T | ⚠️ | 和局 | 1 |
+| `overall` | OVER | ⚠️ | 總戰績 | 16-7-1 |
+| `Home` | HOME | ⚠️ | 主場戰績 | 8-4-1 |
+| `Road` | AWAY | ⚠️ | 客場戰績 | 8-3 |
+| `Last Ten Games` | L10 | ⚠️ | 近十場 | 4-5-1 |
+| `gamesPlayed` | GP | ⚠️ | 已打場次 | 23 |
+| `avgPointsFor` | ARS | ⚠️ | 場均得分 | 6.1 |
+| `avgPointsAgainst` | ARA | ⚠️ | 場均失分 | 4.2 |
+| `differential` | ADIFF | ⚠️ | 場均分差 | +1.9 |
+| `pointDifferential` | DIFF | ⚠️ | 總分差 | +44 |
+| `pointsFor` | RS | ⚠️ | 總得分 | 141 |
+| `pointsAgainst` | RA | ⚠️ | 總失分 | 97 |
+| `homeLosses` | HL | ⚠️ | 主場敗 | 4 |
+| `homeWins` | HW | ⚠️ | 主場勝 | 8 |
+| `homeTies` | HD | ⚠️ | 主場和 | 1 |
+| `roadLosses` | AL | ⚠️ | 客場敗 | 3 |
+| `roadWins` | AW | ⚠️ | 客場勝 | 8 |
+| `roadTies` | AD | ⚠️ | 客場和 | 0 |
+| `divisionGamesBehind` | DGB | ⚠️ | 分區勝差 | - |
+| `divisionPercent` | DIV | ⚠️ | 分區勝率 | 0.0% |
+| `playoffPercent` | POFF | ⚠️ | 季後賽機率 | <0.1% |
+| `wildCardPercent` | WC | ⚠️ | 外卡機率 | 0.0% |
+| `magicNumberDivision` | MDIV | ⚠️ | 分區魔術數字 | 0 |
+| `magicNumberWildcard` | MWC | ⚠️ | 外卡魔術數字 | 0 |

--- a/docs/espn-api/summary.md
+++ b/docs/espn-api/summary.md
@@ -1,0 +1,219 @@
+# Summary API
+
+比賽摘要，包含 Play-by-Play、Box Score、賠率、Leaders 等所有比賽相關資料。
+
+## 端點
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/summary?event={eventId}
+```
+
+## 📁 解析檔案
+
+- `src/lib/espn/play-by-play.ts` — 解析 plays
+- `src/lib/espn/odds.ts` — 解析 odds
+
+## 回傳頂層欄位
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `boxscore` | Boxscore | ⚠️ **可用** | Box Score 數據 |
+| `plays` | Play[] | ✅ | Play-by-Play 紀錄 |
+| `odds` | Odds[] | ✅ | 賠率資料 |
+| `leaders` | Leader[] | ⚠️ | 比賽 Leaders（結構較空）|
+| `header` | Header | ✅ | 比賽基本資訊（隊伍、狀態）|
+| `winprobability` | WinProb[] | ⚠️ | 勝率變化曲線 |
+| `standings` | object | ⚠️ | 當前排名 |
+| `seasonseries` | object[] | ⚠️ | 本季對戰紀錄 |
+| `againstTheSpread` | ATS[] | ⚠️ | 對盤口紀錄 |
+| `injuries` | object | ⚠️ | 傷兵名單 |
+| `broadcasts` | object[] | ⚠️ | 轉播資訊 |
+| `pickcenter` | object[] | ⚠️ | 專家預測 |
+| `news` | object | ⚠️ | 相關新聞 |
+| `article` | object | ⚠️ | 相關文章 |
+| `videos` | object[] | ⚠️ | 相關影片 |
+| `gameInfo` | object | ⚠️ | 場館、天氣等資訊 |
+| `format` | object | ⚠️ | 比賽格式 |
+| `wallclockAvailable` | boolean | ⚠️ | 是否有即時時鐘 |
+
+---
+
+## Boxscore（⚠️ 未使用，可用於 #16 Box Score 功能）
+
+### 結構
+
+```json
+{
+  "teams": [TeamBoxscore],
+  "players": [PlayerBoxscore]
+}
+```
+
+### TeamBoxscore
+
+球隊整場統計。
+
+```json
+{
+  "team": { "id": "1", "displayName": "Atlanta Hawks", ... },
+  "statistics": [
+    { "name": "fieldGoalsMade-fieldGoalsAttempted", "label": "FG", "displayValue": "40-95" },
+    { "name": "fieldGoalPct", "label": "Field Goal %", "displayValue": "42" },
+    { "name": "threePointFieldGoalsMade-threePointFieldGoalsAttempted", "label": "3PT", "displayValue": "14-43" },
+    { "name": "threePointFieldGoalPct", "label": "Three Point %", "displayValue": "33" },
+    { "name": "freeThrowsMade-freeThrowsAttempted", "label": "FT", "displayValue": "18-23" },
+    { "name": "freeThrowPct", "label": "Free Throw %", "displayValue": "78" },
+    { "name": "totalRebounds", "label": "Rebounds", "displayValue": "40" },
+    { "name": "offensiveRebounds", "label": "Offensive Rebounds", "displayValue": "8" },
+    { "name": "defensiveRebounds", "label": "Defensive Rebounds", "displayValue": "32" },
+    { "name": "assists", "label": "Assists", "displayValue": "20" },
+    { "name": "steals", "label": "Steals", "displayValue": "9" },
+    { "name": "blocks", "label": "Blocks", "displayValue": "3" },
+    { "name": "turnovers", "label": "Turnovers", "displayValue": "11" },
+    { "name": "teamTurnovers", "label": "Team Turnovers", "displayValue": "0" },
+    { "name": "totalTurnovers", "label": "Total Turnovers", "displayValue": "11" }
+  ],
+  "displayOrder": 1,
+  "homeAway": "home"
+}
+```
+
+### PlayerBoxscore
+
+每位球員的個人數據。
+
+```json
+{
+  "team": { "id": "1", ... },
+  "statistics": [{
+    "names": ["MIN","PTS","FG","3PT","FT","REB","AST","TO","STL","BLK","OREB","DREB","PF","+/-"],
+    "keys": ["minutes","points","fieldGoalsMade-fieldGoalsAttempted",...],
+    "labels": ["MIN","PTS","FG","3PT","FT","REB","AST","TO","STL","BLK","OREB","DREB","PF","+/-"],
+    "descriptions": ["Minutes","Points","Field Goals Made-Field Goals Attempted",...],
+    "athletes": [
+      {
+        "active": true,
+        "athlete": {
+          "id": "4433218",
+          "displayName": "Paolo Banchero",
+          "jersey": "5",
+          "position": { "abbreviation": "F" },
+          "headshot": { "href": "https://..." }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["33","18","3-13","1-2","11-16","10","3","2","0","2","0","10","2","-16"]
+      }
+    ],
+    "totals": ["","112","40-95","14-43","18-23","40","20","11","9","3","8","32","19",""]
+  }]
+}
+```
+
+**注意**：`stats` 陣列的順序對應 `labels` 陣列。
+
+---
+
+## Plays（✅ 已使用）
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ✅ | Play ID |
+| `sequenceNumber` | number | ✅ | 序號 |
+| `type.text` | string | ✅ | 類型文字 |
+| `type.id` | string | ⚠️ | 類型 ID |
+| `text` | string | ✅ | 描述文字 |
+| `awayScore` | number | ✅ | 客隊當前得分 |
+| `homeScore` | number | ✅ | 主隊當前得分 |
+| `period.displayValue` | string | ✅ | 節次顯示（如 "1st Quarter"）|
+| `clock.displayValue` | string | ✅ | 時鐘顯示（如 "5:22"）|
+| `scoringPlay` | boolean | ✅ | 是否得分 |
+| `scoreValue` | number | ⚠️ | 得分值 |
+| `team.id` | string | ✅ | 所屬球隊 ID |
+| `participants` | object[] | ⚠️ | 參與球員 |
+| `wallclock` | string | ⚠️ | 實際時間 |
+| `shootingPlay` | boolean | ⚠️ | 是否為投籃 |
+| `coordinate` | object | ⚠️ | 場上座標 |
+| `shortDescription` | string | ⚠️ | 簡短描述 |
+
+---
+
+## Odds（✅ 已使用）
+
+```json
+[{
+  "provider": { "id": "45", "name": "Caesars Sportsbook" },
+  "details": "LAL -3.5",
+  "overUnder": 228.5,
+  "spread": -3.5,
+  "homeTeamOdds": {
+    "moneyLine": -160,
+    "spreadOdds": -110,
+    "favorite": true
+  },
+  "awayTeamOdds": {
+    "moneyLine": 135,
+    "spreadOdds": -110,
+    "favorite": false
+  },
+  "overOdds": -110,
+  "underOdds": -110
+}]
+```
+
+詳細欄位說明見 [scoreboard.md](./scoreboard.md#competition-odds✅-部分使用)。
+
+**訪客 vs 會員差異**（`src/lib/espn/odds.ts`）：
+- 訪客（`fetchOddsPreview`）：只取第一個 provider，moneyLine 清零
+- 會員（`fetchOdds`）：完整多個 provider，含 ML
+
+---
+
+## Header（✅ 部分使用）
+
+主要用於取得比賽雙方隊伍資訊（team ID → team name 映射）。
+
+```json
+{
+  "id": "401810838",
+  "competitions": [{
+    "competitors": [{
+      "team": {
+        "id": "1",
+        "displayName": "Atlanta Hawks",
+        ...
+      }
+    }]
+  }],
+  "season": { ... },
+  "league": { ... }
+}
+```
+
+---
+
+## Win Probability（⚠️ 未使用）
+
+勝率變化資料，可用於繪製勝率曲線圖。
+
+```json
+[
+  { "homeWinPercentage": 0.59, "tiePercentage": 0.0, "playId": "4018108384" },
+  { "homeWinPercentage": 0.61, "tiePercentage": 0.0, "playId": "4018108385" }
+]
+```
+
+共數百筆，對應每個 play。
+
+---
+
+## 程式碼中的廢棄型別
+
+以下型別定義在 `src/lib/espn/types.ts` 但未被任何模組使用：
+
+| 型別 | 說明 |
+|------|------|
+| `ESPNPlayByPlayResponse` | 舊版 PBP 回應（有 `items: ESPNPlay[]`），已改用 summary API |
+| `ESPNProbability` / `ESPNProbabilitiesResponse` | 勝率預測 |
+| `ESPNFuture` / `ESPNFuturesResponse` | 未來賠率（冠軍賠率等）|

--- a/docs/espn-api/team.md
+++ b/docs/espn-api/team.md
@@ -1,0 +1,161 @@
+# Team API
+
+球隊基本資訊、球員名單。
+
+## 端點
+
+### 球隊資訊
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/teams/{id}
+```
+
+### 球員名單
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/teams/{id}/roster
+```
+
+### ATS（Against The Spread）
+
+```
+GET https://site.api.espn.com/apis/site/v2/sports/{sport}/{league}/teams/{id}/ats
+```
+
+## 📁 解析檔案
+
+- `src/lib/espn/team.ts`
+
+---
+
+## Team 回傳結構
+
+```json
+{
+  "team": { ... }
+}
+```
+
+### Team 欄位
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ✅ | 隊伍 ID |
+| `slug` | string | ⚠️ | URL slug |
+| `location` | string | ⚠️ | 城市名 |
+| `name` | string | ⚠️ | 隊名（不含城市）|
+| `displayName` | string | ✅ | 完整隊名（如 "Los Angeles Lakers"）|
+| `shortDisplayName` | string | ⚠️ | 短隊名 |
+| `abbreviation` | string | ✅ | 縮寫（如 "LAL"）|
+| `color` | string | ✅（解析但前端未用）| 主色 hex（如 "552583"）|
+| `alternateColor` | string | ⚠️ | 副色 hex |
+| `isActive` | boolean | ⚠️ | 是否活躍 |
+| `logos` | Logo[] | ✅ | Logo 圖片（取 `[0].href`）|
+| `record` | Record | ✅ | 戰績 |
+| `groups` | object | ⚠️ | 所屬分組 |
+| `links` | Link[] | ⚠️ | ESPN 網頁連結 |
+| `franchise` | Franchise | ⚠️ | 球隊歷史/特許經營權 |
+| `nextEvent` | NextEvent[] | ⚠️ **可用** | 下一場比賽 |
+| `standingSummary` | string | ✅ | 排名摘要（如 "3rd in Pacific"）|
+
+### Record
+
+```json
+{
+  "items": [
+    {
+      "description": "Overall Record",
+      "type": "total",
+      "summary": "43-25",
+      "stats": [
+        { "name": "OTLosses", "value": 0.0 },
+        { "name": "OTWins", "value": 0.0 },
+        { "name": "avgPointsAgainst", "value": 114.91 },
+        { "name": "avgPointsFor", "value": 116.25 },
+        { "name": "differential", "value": 1.33 },
+        { "name": "gamesPlayed", "value": 68.0 },
+        { "name": "losses", "value": 25.0 },
+        { "name": "playoffSeed", "value": 4.0 },
+        { "name": "streak", "value": -1.0 },
+        { "name": "winPercent", "value": 0.632 },
+        { "name": "wins", "value": 43.0 }
+      ]
+    }
+  ]
+}
+```
+
+✅ 已使用：`items[0].summary`（總戰績字串）
+⚠️ 未使用：`items[0].stats` 的詳細數據
+
+### NextEvent（⚠️ 未使用）
+
+```json
+[{
+  "id": "401810844",
+  "date": "2026-03-17T01:30Z",
+  "name": "Los Angeles Lakers at Houston Rockets",
+  "shortName": "LAL @ HOU",
+  "competitions": [{
+    "id": "401810844",
+    "date": "2026-03-17T01:30Z",
+    "competitors": [{ "id": "10", "homeAway": "home" }, { "id": "13", "homeAway": "away" }]
+  }]
+}]
+```
+
+---
+
+## Roster 回傳結構
+
+```json
+{
+  "timestamp": "2026-03-17T...",
+  "status": "success",
+  "season": { ... },
+  "athletes": [Athlete],
+  "coach": [Coach],
+  "team": { ... }
+}
+```
+
+### Athlete 欄位
+
+| 欄位 | 型別 | 狀態 | 說明 |
+|------|------|------|------|
+| `id` | string | ✅ | 球員 ID |
+| `displayName` | string | ✅ | 全名 |
+| `firstName` | string | ⚠️ | 名 |
+| `lastName` | string | ⚠️ | 姓 |
+| `shortName` | string | ⚠️ | 短名 |
+| `jersey` | string | ✅ | 背號 |
+| `position` | Position | ✅ | 位置（含 `name`, `displayName`, `abbreviation`）|
+| `age` | number | ✅ | 年齡 |
+| `displayHeight` | string | ✅ | 身高顯示（如 "6'10"）|
+| `displayWeight` | string | ✅ | 體重顯示（如 "250 lbs"）|
+| `height` | number | ⚠️ | 身高（英吋） |
+| `weight` | number | ⚠️ | 體重（磅） |
+| `dateOfBirth` | string | ⚠️ | 生日 |
+| `debutYear` | number | ⚠️ | 出道年份 |
+| `birthPlace` | object | ⚠️ | 出生地 |
+| `college` | object | ⚠️ | 大學 |
+| `experience` | object | ⚠️ | 年資 |
+| `headshot` | object | ⚠️ | 頭像（含 `href`）|
+| `injuries` | object[] | ⚠️ | 傷勢 |
+| `contracts` | object[] | ⚠️ | 合約 |
+| `status` | object | ⚠️ | 球員狀態（Active/Injured 等）|
+| `slug` | string | ⚠️ | URL slug |
+
+### Coach（⚠️ 未使用）
+
+Roster API 同時回傳教練資訊。
+
+---
+
+## ATS 回傳結構
+
+`fetchTeamATS()` 函式存在於 `src/lib/espn/team.ts` 但**沒有任何 API route 使用它**。
+
+回傳含：
+- `records[]`：各類型 ATS 紀錄
+- `events[]`：歷史比賽與盤口結果


### PR DESCRIPTION
## Summary
- 新增 `docs/espn-api/` 目錄，記錄所有 ESPN API 端點的完整欄位結構
- 涵蓋 Scoreboard、Standings、Summary、Team、Player 五個端點
- 每個欄位標註 ✅ 已使用 / ⚠️ 未使用，並標註解析檔案位置
- 含 NBA/MLB 聯賽差異說明與真實 API 回傳範例
- 未來查文件即可，不需頻繁實測 API

## Test plan
- [x] 純文件新增，不影響程式碼
- [x] vitest 230 測試全部通過

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)