### PR TITLE
feat: 前台競品分析改良 (#16)

### DIFF
--- a/src/__tests__/lib/boxscore.test.ts
+++ b/src/__tests__/lib/boxscore.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the ESPN client
+vi.mock("@/lib/espn/client", () => ({
+  espnFetch: vi.fn(),
+  CACHE_TTL: { LIVE: 10_000, PBP_FINAL: 3_600_000 },
+  getSportPath: (league: string) => `basketball/${league}`,
+}));
+
+// Mock translate-pbp
+vi.mock("@/lib/espn/translate-pbp", () => ({
+  translatePbpText: (text: string) => text,
+}));
+
+import { fetchBoxScore } from "@/lib/espn/play-by-play";
+import { espnFetch } from "@/lib/espn/client";
+
+const mockEspnFetch = vi.mocked(espnFetch);
+
+beforeEach(() => {
+  mockEspnFetch.mockReset();
+});
+
+const MOCK_SUMMARY_WITH_BOXSCORE = {
+  header: {
+    competitions: [
+      {
+        competitors: [
+          { homeAway: "home", team: { id: "1", displayName: "Boston Celtics" } },
+          { homeAway: "away", team: { id: "2", displayName: "Brooklyn Nets" } },
+        ],
+      },
+    ],
+  },
+  boxscore: {
+    teams: [
+      {
+        team: { displayName: "Boston Celtics", logo: "https://bos.png" },
+        statistics: [
+          { name: "fieldGoalPct", displayValue: ".485" },
+          { name: "rebounds", displayValue: "45" },
+        ],
+      },
+      {
+        team: { displayName: "Brooklyn Nets", logo: "https://bkn.png" },
+        statistics: [
+          { name: "fieldGoalPct", displayValue: ".442" },
+          { name: "rebounds", displayValue: "38" },
+        ],
+      },
+    ],
+    players: [
+      {
+        team: { displayName: "Boston Celtics" },
+        statistics: [
+          {
+            labels: ["MIN", "PTS", "REB", "AST"],
+            athletes: [
+              {
+                athlete: { displayName: "Jayson Tatum", position: { abbreviation: "SF" } },
+                stats: ["36", "28", "8", "5"],
+                starter: true,
+              },
+              {
+                athlete: { displayName: "Bench Player", position: { abbreviation: "PG" } },
+                stats: ["12", "6", "2", "3"],
+                starter: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe("fetchBoxScore", () => {
+  it("parses boxscore data correctly", async () => {
+    mockEspnFetch.mockResolvedValueOnce(MOCK_SUMMARY_WITH_BOXSCORE);
+
+    const boxscore = await fetchBoxScore("nba", "12345");
+    expect(boxscore).not.toBeNull();
+    expect(boxscore!.teams).toHaveLength(2);
+    expect(boxscore!.teams[0].teamName).toBe("波士頓塞爾提克");
+    expect(boxscore!.teams[0].stats[0]).toEqual({ label: "fieldGoalPct", value: ".485" });
+    expect(boxscore!.teams[1].teamName).toBe("布魯克林籃網");
+
+    expect(boxscore!.players).toHaveLength(1);
+    expect(boxscore!.players[0].teamName).toBe("波士頓塞爾提克");
+    expect(boxscore!.players[0].labels).toEqual(["MIN", "PTS", "REB", "AST"]);
+    expect(boxscore!.players[0].athletes).toHaveLength(2);
+
+    const starter = boxscore!.players[0].athletes[0];
+    expect(starter.name).toBe("Jayson Tatum");
+    expect(starter.position).toBe("SF");
+    expect(starter.starter).toBe(true);
+    expect(starter.stats).toEqual(["36", "28", "8", "5"]);
+
+    const bench = boxscore!.players[0].athletes[1];
+    expect(bench.starter).toBe(false);
+  });
+
+  it("returns null when no boxscore data", async () => {
+    mockEspnFetch.mockResolvedValueOnce({
+      header: { competitions: [{ competitors: [] }] },
+    });
+
+    const boxscore = await fetchBoxScore("nba", "12345");
+    expect(boxscore).toBeNull();
+  });
+});

--- a/src/__tests__/lib/leaders.test.ts
+++ b/src/__tests__/lib/leaders.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the ESPN client
+vi.mock("@/lib/espn/client", () => ({
+  espnFetch: vi.fn(),
+  CACHE_TTL: { LIVE: 10_000, PBP_FINAL: 3_600_000 },
+  getSportPath: (league: string) => `basketball/${league}`,
+}));
+
+// Mock translate-pbp
+vi.mock("@/lib/espn/translate-pbp", () => ({
+  translatePbpText: (text: string) => text,
+}));
+
+import { fetchLeaders } from "@/lib/espn/play-by-play";
+import { espnFetch } from "@/lib/espn/client";
+
+const mockEspnFetch = vi.mocked(espnFetch);
+
+beforeEach(() => {
+  mockEspnFetch.mockReset();
+});
+
+const MOCK_SUMMARY_WITH_LEADERS = {
+  header: {
+    competitions: [
+      {
+        competitors: [
+          {
+            homeAway: "home",
+            team: { id: "1", displayName: "Boston Celtics", logo: "https://bos.png" },
+            leaders: [
+              {
+                name: "points",
+                displayName: "Points",
+                leaders: [
+                  { displayValue: "32 PTS", athlete: { displayName: "Jayson Tatum" } },
+                ],
+              },
+              {
+                name: "rebounds",
+                displayName: "Rebounds",
+                leaders: [
+                  { displayValue: "10 REB", athlete: { displayName: "Al Horford" } },
+                ],
+              },
+              {
+                name: "assists",
+                displayName: "Assists",
+                leaders: [
+                  { displayValue: "8 AST", athlete: { displayName: "Derrick White" } },
+                ],
+              },
+            ],
+          },
+          {
+            homeAway: "away",
+            team: { id: "2", displayName: "Brooklyn Nets", logo: "https://bkn.png" },
+            leaders: [
+              {
+                name: "points",
+                displayName: "Points",
+                leaders: [
+                  { displayValue: "24 PTS", athlete: { displayName: "Cam Thomas" } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe("fetchLeaders", () => {
+  it("parses leaders data correctly", async () => {
+    mockEspnFetch.mockResolvedValueOnce(MOCK_SUMMARY_WITH_LEADERS);
+
+    const leaders = await fetchLeaders("nba", "12345");
+    expect(leaders).toHaveLength(2);
+
+    const home = leaders[0];
+    expect(home.teamName).toBe("波士頓塞爾提克");
+    expect(home.logo).toBe("https://bos.png");
+    expect(home.leaders).toHaveLength(3);
+    expect(home.leaders[0]).toEqual({
+      category: "points",
+      displayName: "Jayson Tatum",
+      displayValue: "32 PTS",
+    });
+
+    const away = leaders[1];
+    expect(away.teamName).toBe("布魯克林籃網");
+    expect(away.leaders).toHaveLength(1);
+    expect(away.leaders[0].displayName).toBe("Cam Thomas");
+  });
+
+  it("handles missing leaders gracefully", async () => {
+    mockEspnFetch.mockResolvedValueOnce({
+      header: {
+        competitions: [
+          {
+            competitors: [
+              { homeAway: "home", team: { id: "1", displayName: "Team A" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    const leaders = await fetchLeaders("nba", "12345");
+    expect(leaders).toHaveLength(1);
+    expect(leaders[0].leaders).toEqual([]);
+  });
+});

--- a/src/__tests__/lib/relative-time.test.ts
+++ b/src/__tests__/lib/relative-time.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { formatRelativeTime } from "@/lib/constants";
+
+describe("formatRelativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty string for null input", () => {
+    expect(formatRelativeTime(null)).toBe("");
+  });
+
+  it("returns empty string for empty string input", () => {
+    expect(formatRelativeTime("")).toBe("");
+  });
+
+  it("returns empty string for invalid date", () => {
+    expect(formatRelativeTime("not-a-date")).toBe("");
+  });
+
+  it('returns "剛剛" for less than 1 minute ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:30Z"));
+    expect(formatRelativeTime("2026-03-17T12:00:00Z")).toBe("剛剛");
+  });
+
+  it('returns "N 分鐘前" for less than 60 minutes ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:15:00Z"));
+    expect(formatRelativeTime("2026-03-17T12:00:00Z")).toBe("15 分鐘前");
+  });
+
+  it('returns "N 小時前" for less than 24 hours ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T18:00:00Z"));
+    expect(formatRelativeTime("2026-03-17T12:00:00Z")).toBe("6 小時前");
+  });
+
+  it('returns "N 天前" for less than 7 days ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-20T12:00:00Z"));
+    expect(formatRelativeTime("2026-03-17T12:00:00Z")).toBe("3 天前");
+  });
+
+  it("returns formatted date for 7+ days ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-25T12:00:00Z"));
+    const result = formatRelativeTime("2026-03-17T12:00:00Z");
+    // Should fall through to formatDateShort, which returns zh-TW date
+    expect(result).not.toBe("");
+    expect(result).not.toContain("天前");
+  });
+
+  it("returns formatted date for future dates", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-17T12:00:00Z"));
+    const result = formatRelativeTime("2026-03-20T12:00:00Z");
+    expect(result).not.toBe("");
+    expect(result).not.toContain("前");
+  });
+});

--- a/src/__tests__/lib/scoreboard-linescores.test.ts
+++ b/src/__tests__/lib/scoreboard-linescores.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let fetchScoreboard: typeof import("@/lib/scoreboard").fetchScoreboard;
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockFetch.mockReset();
+  const mod = await import("@/lib/scoreboard");
+  fetchScoreboard = mod.fetchScoreboard;
+});
+
+const MOCK_RESPONSE_WITH_LINESCORES = {
+  events: [
+    {
+      id: "401633205",
+      date: "2026-03-14T17:00Z",
+      status: {
+        type: {
+          name: "STATUS_FINAL",
+          shortDetail: "Final",
+        },
+      },
+      competitions: [
+        {
+          competitors: [
+            {
+              homeAway: "home",
+              score: "110",
+              records: [{ summary: "35-40" }],
+              linescores: [
+                { value: 28 },
+                { value: 25 },
+                { value: 30 },
+                { value: 27 },
+              ],
+              team: {
+                displayName: "Boston Celtics",
+                abbreviation: "BOS",
+                logo: "https://a.espncdn.com/bos.png",
+              },
+            },
+            {
+              homeAway: "away",
+              score: "105",
+              records: [{ summary: "30-45" }],
+              linescores: [
+                { value: 22 },
+                { value: 30 },
+                { value: 28 },
+                { value: 25 },
+              ],
+              team: {
+                displayName: "Brooklyn Nets",
+                abbreviation: "BKN",
+                logo: "https://a.espncdn.com/bkn.png",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("fetchScoreboard with linescores", () => {
+  it("parses linescores correctly", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => MOCK_RESPONSE_WITH_LINESCORES,
+    });
+
+    const games = await fetchScoreboard("basketball/nba");
+    expect(games).toHaveLength(1);
+
+    const game = games[0];
+    expect(game.homeTeam.linescores).toBeDefined();
+    expect(game.homeTeam.linescores).toHaveLength(4);
+    expect(game.homeTeam.linescores![0]).toEqual({ period: 1, value: "28" });
+    expect(game.homeTeam.linescores![3]).toEqual({ period: 4, value: "27" });
+
+    expect(game.awayTeam.linescores).toBeDefined();
+    expect(game.awayTeam.linescores).toHaveLength(4);
+    expect(game.awayTeam.linescores![0]).toEqual({ period: 1, value: "22" });
+  });
+
+  it("handles missing linescores gracefully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: [
+          {
+            id: "123",
+            date: "2026-03-14T17:00Z",
+            status: { type: { name: "STATUS_SCHEDULED", shortDetail: "7 PM" } },
+            competitions: [
+              {
+                competitors: [
+                  { homeAway: "home", score: "0", team: { displayName: "Team A" } },
+                  { homeAway: "away", score: "0", team: { displayName: "Team B" } },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const games = await fetchScoreboard("basketball/nba");
+    expect(games[0].homeTeam.linescores).toBeUndefined();
+    expect(games[0].awayTeam.linescores).toBeUndefined();
+  });
+});

--- a/src/app/(public)/category/[slug]/page.tsx
+++ b/src/app/(public)/category/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createServiceClient } from "@/lib/supabase";
-import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_LABELS, formatDateShort } from "@/lib/constants";
+import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_LABELS, formatRelativeTime } from "@/lib/constants";
 
 export const revalidate = 60;
 
@@ -204,7 +204,7 @@ export default async function CategoryPage({
                     <div className="flex items-center gap-2 text-xs text-slate-400">
                       {writerName && <span>{writerName}</span>}
                       {writerName && <span>&middot;</span>}
-                      <span>{formatDateShort(article.published_at)}</span>
+                      <span>{formatRelativeTime(article.published_at)}</span>
                       <span>&middot;</span>
                       <span>{article.view_count ?? 0} views</span>
                     </div>

--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createServiceClient } from "@/lib/supabase";
-import { CATEGORY_COLORS, formatDateFull, getCategorySlug, SITE_URL } from "@/lib/constants";
+import { CATEGORY_COLORS, formatDateFull, formatRelativeTime, getCategorySlug, SITE_URL } from "@/lib/constants";
 import ViewTracker from "./ViewTracker";
 
 import LikeButton from "./LikeButton";
@@ -201,6 +201,9 @@ export default async function ArticlePage({
           <time dateTime={article.published_at ?? ""}>
             {formatDateFull(article.published_at)}
           </time>
+          {article.published_at && (
+            <span className="text-slate-400">({formatRelativeTime(article.published_at)})</span>
+          )}
           <span>&middot;</span>
           <span className="flex items-center gap-1">
             <svg

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 import { createServiceClient } from "@/lib/supabase";
 import { TelegramBanner } from "@/components/TelegramCTA";
-import { CATEGORY_COLORS, formatDateShort } from "@/lib/constants";
+import { formatRelativeTime } from "@/lib/constants";
+import { PersonalizedArticleGrid } from "@/components/public/PersonalizedArticleGrid";
 
 // 每 60 秒重新驗證頁面資料
 export const revalidate = 60;
@@ -68,7 +69,7 @@ export default async function HomePage() {
                     <span>{hero.writer_personas.name}</span>
                   )}
                   <span>&middot;</span>
-                  <span>{formatDateShort(hero.published_at)}</span>
+                  <span>{formatRelativeTime(hero.published_at)}</span>
                   <span>&middot;</span>
                   <span>{hero.view_count ?? 0} views</span>
                 </div>
@@ -89,93 +90,19 @@ export default async function HomePage() {
         {gridArticles.length === 0 ? (
           <p className="text-slate-500">目前沒有已發布的文章。</p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-            {gridArticles.map((article) => {
-              const writerName = article.writer_personas?.name;
-              const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
-              const thumbnail = article.images?.[0]?.url;
-
-              return (
-                <Link
-                  key={article.id}
-                  href={getArticleHref(article)}
-                  className="group block"
-                >
-                  {/* Desktop: vertical card */}
-                  <article className="hidden sm:block h-full rounded-xl border border-slate-200 bg-white overflow-hidden hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
-                    {thumbnail && (
-                      <div className="aspect-video bg-slate-100">
-                        <img
-                          src={thumbnail}
-                          alt=""
-                          className="w-full h-full object-cover"
-                        />
-                      </div>
-                    )}
-                    <div className="p-5">
-                      <div className="flex items-center gap-2 mb-3">
-                        {article.category && (
-                          <span
-                            className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}
-                          >
-                            {article.category}
-                          </span>
-                        )}
-                        <span className="text-xs text-slate-400">
-                          {formatDateShort(article.published_at)}
-                        </span>
-                      </div>
-                      <h3 className="text-base font-semibold text-slate-900 leading-snug mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors">
-                        {article.title}
-                      </h3>
-                      <p className="text-sm text-slate-500 line-clamp-2 mb-3">
-                        {article.content?.replace(/[#*_>\-\n]/g, " ").slice(0, 120)}
-                      </p>
-                      <div className="flex items-center justify-between text-xs text-slate-400">
-                        {writerName && <span>{writerName}</span>}
-                        <span>{article.view_count ?? 0} views</span>
-                      </div>
-                    </div>
-                  </article>
-
-                  {/* Mobile: horizontal card with small thumbnail */}
-                  <article className="sm:hidden rounded-xl border border-slate-200 bg-white p-4 hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
-                    <div className="flex items-start gap-3">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1.5">
-                          {article.category && (
-                            <span
-                              className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}
-                            >
-                              {article.category}
-                            </span>
-                          )}
-                          <span className="text-xs text-slate-400">
-                            {formatDateShort(article.published_at)}
-                          </span>
-                        </div>
-                        <h3 className="text-sm font-semibold text-slate-900 leading-snug mb-1 line-clamp-2 group-hover:text-blue-600 transition-colors">
-                          {article.title}
-                        </h3>
-                        <div className="flex items-center gap-2 text-xs text-slate-400">
-                          {writerName && <span>{writerName}</span>}
-                          {writerName && <span>&middot;</span>}
-                          <span>{article.view_count ?? 0} views</span>
-                        </div>
-                      </div>
-                      {thumbnail && (
-                        <img
-                          src={thumbnail}
-                          alt=""
-                          className="w-24 h-16 object-cover rounded-lg flex-shrink-0"
-                        />
-                      )}
-                    </div>
-                  </article>
-                </Link>
-              );
-            })}
-          </div>
+          <PersonalizedArticleGrid
+            articles={gridArticles.map((article) => ({
+              id: article.id,
+              title: article.title,
+              content: article.content,
+              category: article.category,
+              published_at: article.published_at,
+              view_count: article.view_count,
+              slug: article.slug,
+              images: article.images,
+              writerName: article.writer_personas?.name ?? null,
+            }))}
+          />
         )}
       </section>
     </div>

--- a/src/app/api/member/game/route.ts
+++ b/src/app/api/member/game/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { fetchPlayByPlay } from "@/lib/espn/play-by-play";
+import { fetchPlayByPlay, fetchBoxScore, fetchLeaders } from "@/lib/espn/play-by-play";
 import { fetchOdds } from "@/lib/espn/odds";
 
 /**
  * 會員專屬比賽資料 API
  * - plays → 完整 PBP
  * - odds → 完整賠率（3 線）
+ * - boxscore → Box Score 資料
+ * - leaders → 本場最佳球員
  */
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -17,7 +19,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const eventId = searchParams.get("eventId");
   const league = searchParams.get("league") || "nba";
-  const type = searchParams.get("type"); // "plays" | "odds"
+  const type = searchParams.get("type"); // "plays" | "odds" | "boxscore" | "leaders"
 
   if (!eventId) {
     return NextResponse.json({ error: "eventId required" }, { status: 400 });
@@ -32,6 +34,16 @@ export async function GET(request: NextRequest) {
     if (type === "odds") {
       const odds = await fetchOdds(league, eventId);
       return NextResponse.json({ odds });
+    }
+
+    if (type === "boxscore") {
+      const boxscore = await fetchBoxScore(league, eventId);
+      return NextResponse.json({ boxscore });
+    }
+
+    if (type === "leaders") {
+      const leaders = await fetchLeaders(league, eventId);
+      return NextResponse.json({ leaders });
     }
 
     return NextResponse.json({ error: "Invalid type" }, { status: 400 });

--- a/src/app/api/public/game/route.ts
+++ b/src/app/api/public/game/route.ts
@@ -1,17 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchPlayByPlayPreview } from "@/lib/espn/play-by-play";
+import { fetchPlayByPlayPreview, fetchBoxScore, fetchLeaders } from "@/lib/espn/play-by-play";
 import { fetchOddsPreview } from "@/lib/espn/odds";
 
 /**
  * 公開版比賽資料 API
- * - plays?preview=true → 前 5 筆 PBP
- * - odds?preview=true → 僅 Spread
+ * - plays → 前 5 筆 PBP
+ * - odds → 僅 Spread
+ * - boxscore → Box Score 資料
+ * - leaders → 本場最佳球員
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const eventId = searchParams.get("eventId");
   const league = searchParams.get("league") || "nba";
-  const type = searchParams.get("type"); // "plays" | "odds"
+  const type = searchParams.get("type"); // "plays" | "odds" | "boxscore" | "leaders"
 
   if (!eventId) {
     return NextResponse.json({ error: "eventId required" }, { status: 400 });
@@ -26,6 +28,16 @@ export async function GET(request: NextRequest) {
     if (type === "odds") {
       const odds = await fetchOddsPreview(league, eventId);
       return NextResponse.json({ odds });
+    }
+
+    if (type === "boxscore") {
+      const boxscore = await fetchBoxScore(league, eventId);
+      return NextResponse.json({ boxscore });
+    }
+
+    if (type === "leaders") {
+      const leaders = await fetchLeaders(league, eventId);
+      return NextResponse.json({ leaders });
     }
 
     return NextResponse.json({ error: "Invalid type" }, { status: 400 });

--- a/src/components/game/GameDetailClient.tsx
+++ b/src/components/game/GameDetailClient.tsx
@@ -49,6 +49,36 @@ interface GameInfo {
   odds?: GameOdds;
 }
 
+interface BoxScoreTeam {
+  teamName: string;
+  logo: string;
+  stats: { label: string; value: string }[];
+}
+
+interface BoxScorePlayer {
+  name: string;
+  position: string;
+  stats: string[];
+  starter: boolean;
+}
+
+interface BoxScoreData {
+  teams: BoxScoreTeam[];
+  players: { teamName: string; labels: string[]; athletes: BoxScorePlayer[] }[];
+}
+
+interface GameLeader {
+  category: string;
+  displayName: string;
+  displayValue: string;
+}
+
+interface TeamLeadersData {
+  teamName: string;
+  logo: string;
+  leaders: GameLeader[];
+}
+
 export function GameDetailClient({
   sport,
   eventId,
@@ -60,6 +90,8 @@ export function GameDetailClient({
   const [game, setGame] = useState<GameInfo | null>(null);
   const [plays, setPlays] = useState<Play[]>([]);
   const [totalPlays, setTotalPlays] = useState(0);
+  const [boxscore, setBoxscore] = useState<BoxScoreData | null>(null);
+  const [leaders, setLeaders] = useState<TeamLeadersData[]>([]);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState("summary");
 
@@ -77,6 +109,18 @@ export function GameDetailClient({
       .finally(() => setLoading(false));
   }, [sport, eventId]);
 
+  // Fetch leaders on mount
+  useEffect(() => {
+    const endpoint = isMember
+      ? `/api/member/game?eventId=${eventId}&league=${sport}&type=leaders`
+      : `/api/public/game?eventId=${eventId}&league=${sport}&type=leaders`;
+
+    fetch(endpoint)
+      .then((r) => r.json())
+      .then((d) => setLeaders(d.leaders ?? []))
+      .catch(() => {});
+  }, [eventId, sport, isMember]);
+
   // Fetch PBP when tab switches
   useEffect(() => {
     if (tab !== "pbp") return;
@@ -91,6 +135,20 @@ export function GameDetailClient({
         setPlays(d.plays ?? []);
         setTotalPlays(d.totalCount ?? 0);
       })
+      .catch(() => {});
+  }, [tab, eventId, sport, isMember]);
+
+  // Fetch boxscore when tab switches
+  useEffect(() => {
+    if (tab !== "boxscore") return;
+
+    const endpoint = isMember
+      ? `/api/member/game?eventId=${eventId}&league=${sport}&type=boxscore`
+      : `/api/public/game?eventId=${eventId}&league=${sport}&type=boxscore`;
+
+    fetch(endpoint)
+      .then((r) => r.json())
+      .then((d) => setBoxscore(d.boxscore ?? null))
       .catch(() => {});
   }, [tab, eventId, sport, isMember]);
 
@@ -174,6 +232,9 @@ export function GameDetailClient({
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
           <TabsTrigger value="summary">摘要</TabsTrigger>
+          {game.status !== "scheduled" && (
+            <TabsTrigger value="boxscore">數據</TabsTrigger>
+          )}
           <TabsTrigger value="pbp">逐球紀錄</TabsTrigger>
           <TabsTrigger value="odds">賠率</TabsTrigger>
         </TabsList>
@@ -201,6 +262,37 @@ export function GameDetailClient({
                 </div>
               </CardContent>
             </Card>
+
+            {/* Leaders */}
+            {leaders.length > 0 && game.status !== "scheduled" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">本場最佳</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 gap-4">
+                    {leaders.map((team) => (
+                      <div key={team.teamName}>
+                        <div className="flex items-center gap-2 mb-2">
+                          {team.logo && (
+                            <img src={team.logo} alt="" className="w-5 h-5" />
+                          )}
+                          <span className="text-sm font-medium text-slate-700">{team.teamName}</span>
+                        </div>
+                        <div className="space-y-1">
+                          {team.leaders.slice(0, 3).map((l) => (
+                            <p key={l.category} className="text-xs text-slate-600">
+                              <span className="font-medium">{l.displayName}</span>
+                              <span className="text-slate-400 ml-1">{l.displayValue}</span>
+                            </p>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
 
             {/* Quick Odds */}
             {game.odds && (
@@ -234,6 +326,125 @@ export function GameDetailClient({
               </Card>
             )}
           </div>
+        </TabsContent>
+
+        {/* Box Score */}
+        <TabsContent value="boxscore">
+          {!boxscore ? (
+            <Card>
+              <CardContent className="p-6 text-center text-slate-500">
+                暫無數據
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {/* Team Stats Comparison */}
+              {boxscore.teams.length >= 2 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">球隊數據對比</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b bg-slate-50">
+                          <th className="text-center py-2 px-2 font-medium text-slate-600 w-1/4">
+                            {boxscore.teams[0].teamName}
+                          </th>
+                          <th className="text-center py-2 px-2 font-medium text-slate-600">項目</th>
+                          <th className="text-center py-2 px-2 font-medium text-slate-600 w-1/4">
+                            {boxscore.teams[1].teamName}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {boxscore.teams[0].stats.map((stat, idx) => (
+                          <tr key={stat.label} className={idx % 2 === 0 ? "bg-white" : "bg-slate-50/50"}>
+                            <td className="text-center py-1.5 px-2 tabular-nums">{stat.value}</td>
+                            <td className="text-center py-1.5 px-2 text-slate-500 text-xs">{stat.label}</td>
+                            <td className="text-center py-1.5 px-2 tabular-nums">
+                              {boxscore.teams[1].stats[idx]?.value ?? "-"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Player Stats */}
+              {boxscore.players.map((group) => (
+                <Card key={group.teamName}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">{group.teamName}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="p-0">
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-xs">
+                        <thead>
+                          <tr className="border-b bg-slate-50">
+                            <th className="text-left py-2 px-2 font-medium text-slate-600 sticky left-0 bg-slate-50 min-w-[100px]">
+                              球員
+                            </th>
+                            {group.labels.map((label) => (
+                              <th key={label} className="text-center py-2 px-1.5 font-medium text-slate-600 min-w-[36px]">
+                                {label}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {/* Starters */}
+                          {group.athletes.filter((a) => a.starter).length > 0 && (
+                            <tr>
+                              <td colSpan={group.labels.length + 1} className="text-xs text-slate-400 font-medium px-2 py-1 bg-slate-100">
+                                先發
+                              </td>
+                            </tr>
+                          )}
+                          {group.athletes
+                            .filter((a) => a.starter)
+                            .map((athlete) => (
+                              <tr key={athlete.name} className="border-b border-slate-100">
+                                <td className="py-1.5 px-2 sticky left-0 bg-white">
+                                  <span className="font-medium">{athlete.name}</span>
+                                  <span className="text-slate-400 ml-1">{athlete.position}</span>
+                                </td>
+                                {athlete.stats.map((s, i) => (
+                                  <td key={i} className="text-center py-1.5 px-1.5 tabular-nums">{s}</td>
+                                ))}
+                              </tr>
+                            ))}
+                          {/* Bench */}
+                          {group.athletes.filter((a) => !a.starter).length > 0 && (
+                            <tr>
+                              <td colSpan={group.labels.length + 1} className="text-xs text-slate-400 font-medium px-2 py-1 bg-slate-100">
+                                替補
+                              </td>
+                            </tr>
+                          )}
+                          {group.athletes
+                            .filter((a) => !a.starter)
+                            .map((athlete) => (
+                              <tr key={athlete.name} className="border-b border-slate-100">
+                                <td className="py-1.5 px-2 sticky left-0 bg-white">
+                                  <span className="font-medium">{athlete.name}</span>
+                                  <span className="text-slate-400 ml-1">{athlete.position}</span>
+                                </td>
+                                {athlete.stats.map((s, i) => (
+                                  <td key={i} className="text-center py-1.5 px-1.5 tabular-nums">{s}</td>
+                                ))}
+                              </tr>
+                            ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
         </TabsContent>
 
         {/* PBP */}

--- a/src/components/public/PersonalizedArticleGrid.tsx
+++ b/src/components/public/PersonalizedArticleGrid.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { CATEGORY_COLORS, formatRelativeTime } from "@/lib/constants";
+import { Star } from "lucide-react";
+
+interface FavoriteTeam {
+  sport: string;
+  teamId: string;
+  name: string;
+}
+
+interface ArticleItem {
+  id: string;
+  title: string;
+  content: string | null;
+  category: string | null;
+  published_at: string | null;
+  view_count: number | null;
+  slug: string | null;
+  images: { url: string }[] | null;
+  writerName: string | null;
+}
+
+export function PersonalizedArticleGrid({
+  articles,
+}: {
+  articles: ArticleItem[];
+}) {
+  const { data: session } = useSession();
+  const [favorites, setFavorites] = useState<FavoriteTeam[]>([]);
+
+  useEffect(() => {
+    if (!session?.user) return;
+    fetch("/api/member/favorites")
+      .then((r) => r.json())
+      .then((d) => setFavorites(d.favorites ?? []))
+      .catch(() => {});
+  }, [session]);
+
+  const sortedArticles = useMemo(() => {
+    if (favorites.length === 0) return articles;
+    const favoriteNames = favorites.map((f) => f.name);
+    // Stable sort: favorites first
+    return [...articles].sort((a, b) => {
+      const aMatch = favoriteNames.some((name) => a.title.includes(name)) ? 1 : 0;
+      const bMatch = favoriteNames.some((name) => b.title.includes(name)) ? 1 : 0;
+      return bMatch - aMatch;
+    });
+  }, [favorites, articles]);
+
+  const favoriteNames = useMemo(
+    () => favorites.map((f) => f.name),
+    [favorites]
+  );
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+      {sortedArticles.map((article) => {
+        const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
+        const thumbnail = article.images?.[0]?.url;
+        const isFavorite = favoriteNames.some((name) => article.title.includes(name));
+
+        return (
+          <Link
+            key={article.id}
+            href={`/news/${article.slug || article.id}`}
+            className="group block"
+          >
+            {/* Desktop: vertical card */}
+            <article className="hidden sm:block h-full rounded-xl border border-slate-200 bg-white overflow-hidden hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
+              {thumbnail && (
+                <div className="aspect-video bg-slate-100 relative">
+                  <img
+                    src={thumbnail}
+                    alt=""
+                    className="w-full h-full object-cover"
+                  />
+                  {isFavorite && (
+                    <span className="absolute top-2 right-2 bg-yellow-400 text-yellow-900 rounded-full p-1">
+                      <Star className="w-3 h-3 fill-current" />
+                    </span>
+                  )}
+                </div>
+              )}
+              <div className="p-5">
+                <div className="flex items-center gap-2 mb-3">
+                  {article.category && (
+                    <span className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+                      {article.category}
+                    </span>
+                  )}
+                  <span className="text-xs text-slate-400">
+                    {formatRelativeTime(article.published_at)}
+                  </span>
+                </div>
+                <h3 className="text-base font-semibold text-slate-900 leading-snug mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors">
+                  {article.title}
+                </h3>
+                <p className="text-sm text-slate-500 line-clamp-2 mb-3">
+                  {article.content?.replace(/[#*_>\-\n]/g, " ").slice(0, 120)}
+                </p>
+                <div className="flex items-center justify-between text-xs text-slate-400">
+                  {article.writerName && <span>{article.writerName}</span>}
+                  <span>{article.view_count ?? 0} views</span>
+                </div>
+              </div>
+            </article>
+
+            {/* Mobile: horizontal card */}
+            <article className="sm:hidden rounded-xl border border-slate-200 bg-white p-4 hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
+              <div className="flex items-start gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    {isFavorite && (
+                      <Star className="w-3 h-3 text-yellow-500 fill-yellow-400 flex-shrink-0" />
+                    )}
+                    {article.category && (
+                      <span className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+                        {article.category}
+                      </span>
+                    )}
+                    <span className="text-xs text-slate-400">
+                      {formatRelativeTime(article.published_at)}
+                    </span>
+                  </div>
+                  <h3 className="text-sm font-semibold text-slate-900 leading-snug mb-1 line-clamp-2 group-hover:text-blue-600 transition-colors">
+                    {article.title}
+                  </h3>
+                  <div className="flex items-center gap-2 text-xs text-slate-400">
+                    {article.writerName && <span>{article.writerName}</span>}
+                    {article.writerName && <span>&middot;</span>}
+                    <span>{article.view_count ?? 0} views</span>
+                  </div>
+                </div>
+                {thumbnail && (
+                  <img
+                    src={thumbnail}
+                    alt=""
+                    className="w-24 h-16 object-cover rounded-lg flex-shrink-0"
+                  />
+                )}
+              </div>
+            </article>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/scoreboard/ScoreCard.tsx
+++ b/src/components/scoreboard/ScoreCard.tsx
@@ -88,6 +88,48 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
         <TeamRow team={game.homeTeam} isWinner={homeWins} />
       </div>
 
+      {/* Linescores */}
+      {isFinishedOrLive && game.homeTeam.linescores && game.awayTeam.linescores && (
+        <div className="px-4 pb-2">
+          <table className="w-full text-xs tabular-nums">
+            <thead>
+              <tr className="text-slate-400">
+                <th className="text-left font-normal py-0.5 w-10"></th>
+                {game.homeTeam.linescores.map((ls) => (
+                  <th key={ls.period} className="text-center font-normal py-0.5 w-7">
+                    {ls.period}
+                  </th>
+                ))}
+                <th className="text-center font-medium py-0.5 w-7 text-slate-600">T</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="text-slate-600">
+                <td className="text-left font-medium py-0.5">{game.awayTeam.abbreviation}</td>
+                {game.awayTeam.linescores.map((ls) => (
+                  <td key={ls.period} className="text-center py-0.5">{ls.value}</td>
+                ))}
+                <td className={`text-center py-0.5 font-medium ${awayWins ? "text-slate-900" : ""}`}>{game.awayTeam.score}</td>
+              </tr>
+              <tr className="text-slate-600">
+                <td className="text-left font-medium py-0.5">{game.homeTeam.abbreviation}</td>
+                {game.homeTeam.linescores.map((ls) => (
+                  <td key={ls.period} className="text-center py-0.5">{ls.value}</td>
+                ))}
+                <td className={`text-center py-0.5 font-medium ${homeWins ? "text-slate-900" : ""}`}>{game.homeTeam.score}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Odds Summary */}
+      {game.odds && game.status !== "final" && (
+        <div className="px-4 pb-2 text-xs text-slate-400 text-center border-t border-slate-100 pt-2">
+          Spread: {game.odds.details || "-"} | O/U: {game.odds.overUnder || "-"}
+        </div>
+      )}
+
       {/* Records */}
       {(game.homeTeam.record || game.awayTeam.record) && (
         <div className="px-4 pb-3 text-xs text-slate-400 text-center">

--- a/src/components/standings/StandingsClient.tsx
+++ b/src/components/standings/StandingsClient.tsx
@@ -45,9 +45,9 @@ export function StandingsClient({
   // NBA/MLB 常見 stat keys
   const statKeys =
     league === "nba"
-      ? ["wins", "losses", "winPercent", "gamesBehind", "streak"]
+      ? ["wins", "losses", "winPercent", "gamesBehind", "Home", "Away", "L10", "streak"]
       : league === "mlb"
-        ? ["wins", "losses", "winPercent", "gamesBehind"]
+        ? ["wins", "losses", "winPercent", "gamesBehind", "Home", "Away", "L10"]
         : ["wins", "losses", "ties", "pointsFor", "pointsAgainst"];
 
   const statLabels: Record<string, string> = {
@@ -59,6 +59,10 @@ export function StandingsClient({
     streak: "連續",
     pointsFor: "得分",
     pointsAgainst: "失分",
+    Home: "主場",
+    Away: "客場",
+    L10: "近10場",
+    OTL: "加時負",
   };
 
   return (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -213,6 +213,35 @@ export function isValidImageUrl(url: string): boolean {
 }
 
 /**
+ * 格式化相對時間，用於文章列表
+ * < 1分鐘 → "剛剛"
+ * < 60分鐘 → "N 分鐘前"
+ * < 24小時 → "N 小時前"
+ * < 7天 → "N 天前"
+ * >= 7天 → 原有 formatDateShort 格式
+ */
+export function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return "";
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  if (isNaN(then)) return "";
+  const diffMs = now - then;
+  if (diffMs < 0) return formatDateShort(dateStr);
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "剛剛";
+  if (minutes < 60) return `${minutes} 分鐘前`;
+
+  const hours = Math.floor(diffMs / 3_600_000);
+  if (hours < 24) return `${hours} 小時前`;
+
+  const days = Math.floor(diffMs / 86_400_000);
+  if (days < 7) return `${days} 天前`;
+
+  return formatDateShort(dateStr);
+}
+
+/**
  * 格式化日期 - 完整版（含時間），用於文章詳情頁
  */
 export function formatDateFull(dateStr: string | null) {

--- a/src/lib/espn/play-by-play.ts
+++ b/src/lib/espn/play-by-play.ts
@@ -3,6 +3,7 @@
 import { espnFetch, CACHE_TTL, getSportPath } from "./client";
 import { getTeamNameZh } from "@/lib/constants";
 import { translatePbpText } from "./translate-pbp";
+import type { BoxScore, BoxScorePlayerGroup, BoxScoreTeam, TeamLeaders, GameLeader } from "./types";
 
 export interface Play {
   id: string;
@@ -32,9 +33,18 @@ interface SummaryPlay {
 
 interface SummaryCompetitor {
   homeAway: "home" | "away";
-  team: { id: string; displayName: string };
+  team: { id: string; displayName: string; logo?: string; logos?: Array<{ href: string }> };
+  leaders?: Array<{
+    name: string;
+    displayName: string;
+    leaders: Array<{
+      displayValue: string;
+      athlete: { displayName: string };
+    }>;
+  }>;
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 interface SummaryResponse {
   plays?: SummaryPlay[];
   header?: {
@@ -42,7 +52,28 @@ interface SummaryResponse {
       competitors?: SummaryCompetitor[];
     }>;
   };
+  boxscore?: {
+    teams?: Array<{
+      team: { displayName: string; logo?: string; logos?: Array<{ href: string }> };
+      statistics: Array<{
+        name: string;
+        displayValue: string;
+      }>;
+    }>;
+    players?: Array<{
+      team: { displayName: string };
+      statistics: Array<{
+        labels: string[];
+        athletes: Array<{
+          athlete: { displayName: string; position?: { abbreviation: string } };
+          stats: string[];
+          starter: boolean;
+        }>;
+      }>;
+    }>;
+  };
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 function buildTeamMap(data: SummaryResponse): Record<string, string> {
   const map: Record<string, string> = {};
@@ -108,4 +139,94 @@ export async function fetchPlayByPlayPreview(
     plays: allPlays.slice(0, 5),
     totalCount: allPlays.length,
   };
+}
+
+// ---------- Box Score ----------
+
+function parseBoxScore(data: SummaryResponse): BoxScore | null {
+  if (!data.boxscore) return null;
+
+  const teams: BoxScoreTeam[] = (data.boxscore.teams ?? []).map((t) => ({
+    teamName: getTeamNameZh(t.team.displayName),
+    logo: t.team.logo ?? t.team.logos?.[0]?.href ?? "",
+    stats: t.statistics.map((s) => ({
+      label: s.name,
+      value: s.displayValue,
+    })),
+  }));
+
+  const players: BoxScorePlayerGroup[] = (data.boxscore.players ?? []).map((p) => {
+    const firstStatGroup = p.statistics?.[0];
+    return {
+      teamName: getTeamNameZh(p.team.displayName),
+      labels: firstStatGroup?.labels ?? [],
+      athletes: (firstStatGroup?.athletes ?? []).map((a) => ({
+        name: a.athlete.displayName,
+        position: a.athlete.position?.abbreviation ?? "",
+        stats: a.stats ?? [],
+        starter: a.starter ?? false,
+      })),
+    };
+  });
+
+  return { teams, players };
+}
+
+/**
+ * 取得 Box Score
+ */
+export async function fetchBoxScore(
+  league: string,
+  eventId: string,
+  isCompleted = false
+): Promise<BoxScore | null> {
+  const sportPath = getSportPath(league);
+  const ttl = isCompleted ? CACHE_TTL.PBP_FINAL : CACHE_TTL.LIVE;
+
+  const data = await espnFetch<SummaryResponse>(
+    `${sportPath}/summary`,
+    { ttl, params: { event: eventId } }
+  );
+
+  return parseBoxScore(data);
+}
+
+// ---------- Leaders ----------
+
+function parseLeaders(data: SummaryResponse): TeamLeaders[] {
+  const competitors = data.header?.competitions?.[0]?.competitors ?? [];
+
+  return competitors.map((c) => {
+    const logo = c.team.logo ?? c.team.logos?.[0]?.href ?? "";
+    const leaders: GameLeader[] = (c.leaders ?? []).map((l) => ({
+      category: l.name,
+      displayName: l.leaders?.[0]?.athlete?.displayName ?? "",
+      displayValue: l.leaders?.[0]?.displayValue ?? "",
+    }));
+
+    return {
+      teamName: getTeamNameZh(c.team.displayName),
+      logo,
+      leaders,
+    };
+  });
+}
+
+/**
+ * 取得本場最佳球員
+ */
+export async function fetchLeaders(
+  league: string,
+  eventId: string,
+  isCompleted = false
+): Promise<TeamLeaders[]> {
+  const sportPath = getSportPath(league);
+  const ttl = isCompleted ? CACHE_TTL.PBP_FINAL : CACHE_TTL.LIVE;
+
+  const data = await espnFetch<SummaryResponse>(
+    `${sportPath}/summary`,
+    { ttl, params: { event: eventId } }
+  );
+
+  return parseLeaders(data);
 }

--- a/src/lib/espn/scoreboard.ts
+++ b/src/lib/espn/scoreboard.ts
@@ -12,6 +12,7 @@ export interface TeamInfo {
   logo: string;
   score: string;
   record: string;
+  linescores?: { period: number; value: string }[];
 }
 
 export interface GameOdds {
@@ -88,6 +89,10 @@ function parseGames(data: ESPNScoreboardResponse): Game[] {
         logo: home?.team?.logo ?? "",
         score: home?.score ?? "0",
         record: home?.records?.[0]?.summary ?? "",
+        linescores: home?.linescores?.map((ls, idx) => ({
+          period: idx + 1,
+          value: String(ls.value ?? 0),
+        })),
       },
       awayTeam: {
         name: getTeamNameZh(away?.team?.displayName ?? ""),
@@ -95,6 +100,10 @@ function parseGames(data: ESPNScoreboardResponse): Game[] {
         logo: away?.team?.logo ?? "",
         score: away?.score ?? "0",
         record: away?.records?.[0]?.summary ?? "",
+        linescores: away?.linescores?.map((ls, idx) => ({
+          period: idx + 1,
+          value: String(ls.value ?? 0),
+        })),
       },
       odds,
     };

--- a/src/lib/espn/types.ts
+++ b/src/lib/espn/types.ts
@@ -40,6 +40,7 @@ export interface ESPNCompetitor {
     color?: string;
   };
   records?: Array<{ summary: string }>;
+  linescores?: Array<{ value: number }>;
 }
 
 export interface ESPNLeague {
@@ -195,6 +196,46 @@ export interface ESPNPlayerResponse {
       }>;
     }>;
   };
+}
+
+// ---------- Box Score ----------
+
+export interface BoxScoreTeam {
+  teamName: string;
+  logo: string;
+  stats: { label: string; value: string }[];
+}
+
+export interface BoxScorePlayer {
+  name: string;
+  position: string;
+  stats: string[];
+  starter: boolean;
+}
+
+export interface BoxScorePlayerGroup {
+  teamName: string;
+  labels: string[];
+  athletes: BoxScorePlayer[];
+}
+
+export interface BoxScore {
+  teams: BoxScoreTeam[];
+  players: BoxScorePlayerGroup[];
+}
+
+// ---------- Leaders ----------
+
+export interface GameLeader {
+  category: string;
+  displayName: string;
+  displayValue: string;
+}
+
+export interface TeamLeaders {
+  teamName: string;
+  logo: string;
+  leaders: GameLeader[];
 }
 
 // ---------- Futures ----------

--- a/src/lib/scoreboard.ts
+++ b/src/lib/scoreboard.ts
@@ -12,6 +12,7 @@ export interface TeamInfo {
   logo: string;
   score: string;
   record: string;
+  linescores?: { period: number; value: string }[];
 }
 
 export interface GameOdds {
@@ -81,6 +82,7 @@ function parseTeam(competitor: Record<string, unknown>): TeamInfo {
   const team = (competitor.team ?? {}) as Record<string, unknown>;
   const records = Array.isArray(competitor.records) ? competitor.records : [];
   const firstRecord = (records[0] ?? {}) as Record<string, unknown>;
+  const rawLinescores = Array.isArray(competitor.linescores) ? competitor.linescores : undefined;
 
   return {
     name: getTeamNameZh(String(team.displayName ?? team.name ?? "")),
@@ -88,6 +90,10 @@ function parseTeam(competitor: Record<string, unknown>): TeamInfo {
     logo: String(team.logo ?? ""),
     score: String(competitor.score ?? "0"),
     record: String(firstRecord.summary ?? ""),
+    linescores: rawLinescores?.map((ls: Record<string, unknown>, idx: number) => ({
+      period: idx + 1,
+      value: String((ls as Record<string, unknown>).value ?? 0),
+    })),
   };
 }
 


### PR DESCRIPTION
## Summary

根據 ESPN/Yahoo Sports 競品分析，利用 ESPN API 已回傳但未使用的欄位改善前台體驗：

- **文章相對時間**：首頁、分類頁改用相對時間（剛剛/N分鐘前/N小時前/N天前），文章詳情頁保留完整時間 + 相對時間輔助
- **逐節分數**：比分卡顯示逐節分數表格（已結束/進行中比賽）
- **戰績表擴充**：NBA/MLB 新增 Home、Away、L10 欄位
- **Box Score**：比賽詳情頁新增「數據」tab（球隊對比 + 球員數據表，先發/替補分組）
- **本場最佳**：Summary tab 比分下方顯示兩隊最佳球員
- **個人化首頁**：登入後追蹤球隊文章優先排序 + 星號標記
- **賠率摘要**：比分卡底部新增 Spread/O-U 摘要行（僅 scheduled/in_progress）

## Test plan

- [x] `npx vitest run` — 245 tests passed（含 4 個新測試檔）
- [x] `npx tsc --noEmit` — 零 TypeScript 錯誤
- [ ] 瀏覽器驗證：首頁文章時間顯示「N小時前」
- [ ] 瀏覽器驗證：比分卡顯示逐節分數
- [ ] 瀏覽器驗證：戰績表可水平滾動，顯示 Home/Away/L10
- [ ] 瀏覽器驗證：比賽詳情頁 Box Score tab 有資料
- [ ] 瀏覽器驗證：比賽詳情頁 Summary 顯示最佳球員
- [ ] 瀏覽器驗證：比分卡底部顯示賠率摘要

🤖 Generated with [Claude Code](https://claude.com/claude-code)