### PR TITLE
fix: 移除比分卡賠率摘要 + 前台隱藏瀏覽數 (#30, #31)

### DIFF
--- a/src/app/(public)/category/[slug]/page.tsx
+++ b/src/app/(public)/category/[slug]/page.tsx
@@ -205,8 +205,6 @@ export default async function CategoryPage({
                       {writerName && <span>{writerName}</span>}
                       {writerName && <span>&middot;</span>}
                       <span>{formatRelativeTime(article.published_at)}</span>
-                      <span>&middot;</span>
-                      <span>{article.view_count ?? 0} views</span>
                     </div>
                   </div>
                   {thumbnail && (

--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -204,29 +204,6 @@ export default async function ArticlePage({
           {article.published_at && (
             <span className="text-slate-400">({formatRelativeTime(article.published_at)})</span>
           )}
-          <span>&middot;</span>
-          <span className="flex items-center gap-1">
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
-            {article.view_count ?? 0}
-          </span>
         </div>
       </header>
 
@@ -361,8 +338,6 @@ export default async function ArticlePage({
                         )
                       : ""}
                   </time>
-                  <span>&middot;</span>
-                  <span>{related.view_count ?? 0} views</span>
                 </div>
               </Link>
             ))}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -70,8 +70,6 @@ export default async function HomePage() {
                   )}
                   <span>&middot;</span>
                   <span>{formatRelativeTime(hero.published_at)}</span>
-                  <span>&middot;</span>
-                  <span>{hero.view_count ?? 0} views</span>
                 </div>
               </div>
             </article>

--- a/src/app/(public)/writer/[id]/page.tsx
+++ b/src/app/(public)/writer/[id]/page.tsx
@@ -131,7 +131,9 @@ export default async function WriterPage({
                     .slice(0, 160)}
                 </p>
                 <span className="text-xs text-slate-400">
-                  {article.view_count ?? 0} views
+                  {article.published_at
+                    ? new Date(article.published_at).toLocaleDateString("zh-TW")
+                    : ""}
                 </span>
               </Link>
             );

--- a/src/components/public/PersonalizedArticleGrid.tsx
+++ b/src/components/public/PersonalizedArticleGrid.tsx
@@ -102,10 +102,11 @@ export function PersonalizedArticleGrid({
                 <p className="text-sm text-slate-500 line-clamp-2 mb-3">
                   {article.content?.replace(/[#*_>\-\n]/g, " ").slice(0, 120)}
                 </p>
-                <div className="flex items-center justify-between text-xs text-slate-400">
-                  {article.writerName && <span>{article.writerName}</span>}
-                  <span>{article.view_count ?? 0} views</span>
-                </div>
+                {article.writerName && (
+                  <div className="text-xs text-slate-400">
+                    <span>{article.writerName}</span>
+                  </div>
+                )}
               </div>
             </article>
 
@@ -129,11 +130,11 @@ export function PersonalizedArticleGrid({
                   <h3 className="text-sm font-semibold text-slate-900 leading-snug mb-1 line-clamp-2 group-hover:text-blue-600 transition-colors">
                     {article.title}
                   </h3>
-                  <div className="flex items-center gap-2 text-xs text-slate-400">
-                    {article.writerName && <span>{article.writerName}</span>}
-                    {article.writerName && <span>&middot;</span>}
-                    <span>{article.view_count ?? 0} views</span>
-                  </div>
+                  {article.writerName && (
+                    <div className="text-xs text-slate-400">
+                      <span>{article.writerName}</span>
+                    </div>
+                  )}
                 </div>
                 {thumbnail && (
                   <img

--- a/src/components/scoreboard/ScoreCard.tsx
+++ b/src/components/scoreboard/ScoreCard.tsx
@@ -123,13 +123,6 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
         </div>
       )}
 
-      {/* Odds Summary */}
-      {game.odds && game.status !== "final" && (
-        <div className="px-4 pb-2 text-xs text-slate-400 text-center border-t border-slate-100 pt-2">
-          Spread: {game.odds.details || "-"} | O/U: {game.odds.overUnder || "-"}
-        </div>
-      )}
-
       {/* Records */}
       {(game.homeTeam.record || game.awayTeam.record) && (
         <div className="px-4 pb-3 text-xs text-slate-400 text-center">


### PR DESCRIPTION
## Summary

- 移除 ScoreCard 底部無效的賠率摘要行（ESPN scoreboard API 不含 odds 資料，永遠不顯示）
- 前台所有頁面移除 view_count 顯示（首頁、分類頁、文章詳情頁、寫手頁、相關文章）
- view tracking API 持續運作，後台 analytics 頁面仍可查看瀏覽數

Closes #30, Closes #31

## Test plan

- [x] `npx vitest run` — 245 tests passed
- [x] `npx tsc --noEmit` — 零錯誤
- [ ] 瀏覽器確認前台無 views 顯示
- [ ] 後台 analytics 仍顯示瀏覽數

🤖 Generated with [Claude Code](https://claude.com/claude-code)