### PR TITLE
fix: UI 全面優化 — CORS、排名、漸層提示、分類底圖、時區轉換 (#33)

### DIFF
--- a/src/app/(public)/category/[slug]/page.tsx
+++ b/src/app/(public)/category/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createServiceClient } from "@/lib/supabase";
-import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_LABELS, formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_FALLBACK_IMAGES, CATEGORY_LABELS, formatRelativeTime } from "@/lib/constants";
 
 export const revalidate = 60;
 
@@ -184,7 +184,7 @@ export default async function CategoryPage({
         <div className="space-y-4 mb-8">
           {(articles as unknown as ArticleWithWriter[]).map((article) => {
             const writerName = article.writer_personas?.name;
-            const thumbnail = article.images?.[0]?.url;
+            const thumbnail = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
             return (
               <Link
                 key={article.id}
@@ -207,13 +207,11 @@ export default async function CategoryPage({
                       <span>{formatRelativeTime(article.published_at)}</span>
                     </div>
                   </div>
-                  {thumbnail && (
-                    <img
-                      src={thumbnail}
-                      alt=""
-                      className="w-28 h-20 object-cover rounded-lg flex-shrink-0"
-                    />
-                  )}
+                  <img
+                    src={thumbnail}
+                    alt=""
+                    className="w-28 h-20 object-cover rounded-lg flex-shrink-0"
+                  />
                 </div>
               </Link>
             );

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -65,7 +65,7 @@ export default function PublicLayout({
             </div>
             <div className="border-t border-slate-200 pt-3">
               <div className="text-sm text-slate-400 text-center">
-                &copy; 2019 小豪哥體育資訊網. All rights reserved.
+                &copy; {new Date().getFullYear()} 小豪哥體育資訊網. All rights reserved.
               </div>
             </div>
           </div>

--- a/src/components/admin/ProductionPanel.tsx
+++ b/src/components/admin/ProductionPanel.tsx
@@ -21,31 +21,25 @@ export function ProductionPanel({
   onTriggerPlan,
 }: ProductionPanelProps) {
   return (
-    <Card>
-      <CardContent className="py-4">
-        <div className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <Button
-              onClick={onTriggerPlan}
-              disabled={planTriggering || !!runningMode}
-            >
-              {runningMode === "plan" ? "規劃中..." : runningMode === "produce" ? "產出中..." : "規劃"}
-            </Button>
-            {runningMode && (
-              <Badge variant="secondary" className="animate-pulse">
-                {runningMode === "plan" ? "規劃產生中" : "文章產出中"}
-              </Badge>
-            )}
-          </div>
-          <div className="text-sm text-gray-500">
-            <span className="text-gray-400">最後執行：</span>
-            {rewriteStatus?.lastCompleted?.completed_at
-              ? new Date(rewriteStatus.lastCompleted.completed_at).toLocaleString("zh-TW")
-              : "尚未執行"}
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <div className="flex items-center gap-3 px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-lg">
+      <Button
+        size="sm"
+        onClick={onTriggerPlan}
+        disabled={planTriggering || !!runningMode}
+      >
+        {runningMode === "plan" ? "規劃中..." : runningMode === "produce" ? "產出中..." : "規劃"}
+      </Button>
+      {runningMode && (
+        <Badge variant="secondary" className="animate-pulse">
+          {runningMode === "plan" ? "規劃產生中" : "文章產出中"}
+        </Badge>
+      )}
+      <span className="text-xs text-gray-400 ml-auto">
+        最後執行：{rewriteStatus?.lastCompleted?.completed_at
+          ? new Date(rewriteStatus.lastCompleted.completed_at).toLocaleString("zh-TW")
+          : "尚未執行"}
+      </span>
+    </div>
   );
 }
 

--- a/src/components/odds/OddsClient.tsx
+++ b/src/components/odds/OddsClient.tsx
@@ -31,6 +31,33 @@ const LEAGUE_OPTIONS = [
   { value: "mlb", label: "MLB" },
 ];
 
+/** 將 ESPN 時間格式（如 "3/17 - 7:00 PM EDT"）轉為台灣時間 */
+function formatStatusDetail(detail: string): string {
+  // 匹配 "M/D - H:MM PM EDT" 格式
+  const match = detail.match(/(\d{1,2})\/(\d{1,2})\s*-\s*(\d{1,2}):(\d{2})\s*(AM|PM)\s*(E[DS]T)/i);
+  if (!match) return detail;
+
+  const [, month, day, hourStr, minute, ampm, tz] = match;
+  let hour = parseInt(hourStr);
+  if (ampm.toUpperCase() === "PM" && hour !== 12) hour += 12;
+  if (ampm.toUpperCase() === "AM" && hour === 12) hour = 0;
+
+  // EDT = UTC-4, EST = UTC-5
+  const utcOffset = tz.toUpperCase() === "EDT" ? -4 : -5;
+  const now = new Date();
+  const year = now.getFullYear();
+  const utcDate = new Date(Date.UTC(year, parseInt(month) - 1, parseInt(day), hour - utcOffset, parseInt(minute)));
+
+  // 轉台灣時間 (UTC+8)
+  const twDate = new Date(utcDate.getTime() + 8 * 60 * 60 * 1000);
+  const twMonth = twDate.getUTCMonth() + 1;
+  const twDay = twDate.getUTCDate();
+  const twHour = twDate.getUTCHours();
+  const twMin = twDate.getUTCMinutes().toString().padStart(2, "0");
+
+  return `${twMonth}/${twDay} ${twHour}:${twMin}`;
+}
+
 export function OddsClient() {
   const { data: session } = useSession();
   const [league, setLeague] = useState("nba");
@@ -67,7 +94,7 @@ export function OddsClient() {
           ) : games.length === 0 ? (
             <p className="text-slate-500 text-center py-8">今日暫無賽事</p>
           ) : (
-            <div className="space-y-4 mt-4">
+            <div className="space-y-3 mt-4">
               {games.map((game) => (
                 <Card key={game.id}>
                   <CardContent className="p-4">
@@ -87,7 +114,7 @@ export function OddsClient() {
                         )}
                         <span className="font-medium">{game.homeTeam.abbreviation}</span>
                       </Link>
-                      <span className="text-xs text-slate-500">{game.statusDetail}</span>
+                      <span className="text-xs text-slate-500">{formatStatusDetail(game.statusDetail)}</span>
                     </div>
 
                     {/* Odds table */}

--- a/src/components/public/HeroSection.tsx
+++ b/src/components/public/HeroSection.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_FALLBACK_IMAGES, formatRelativeTime } from "@/lib/constants";
 
 interface HeroArticle {
   id: string;
@@ -23,7 +23,7 @@ export function HeroSection({
   hero: HeroArticle;
   subHeroes: HeroArticle[];
 }) {
-  const heroImage = hero.images?.[0]?.url;
+  const heroImage = hero.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[hero.category ?? ""] || "/images/hero-sports-bg.jpg";
 
   return (
     <section className="mb-8">
@@ -33,7 +33,7 @@ export function HeroSection({
         <Link href={getHref(hero)} className="col-span-2 block group">
           <article className="relative rounded-2xl bg-gradient-to-br from-slate-800 to-slate-700 text-white overflow-hidden h-full min-h-[320px] flex items-end active:scale-[0.99] transition-transform duration-150">
             <img
-              src={heroImage || "/images/hero-sports-bg.jpg"}
+              src={heroImage}
               alt=""
               className="absolute inset-0 w-full h-full object-cover"
             />
@@ -62,17 +62,15 @@ export function HeroSection({
         {/* Sub heroes - stacked vertically */}
         <div className="flex flex-col gap-4">
           {subHeroes.map((article) => {
-            const thumb = article.images?.[0]?.url;
+            const thumb = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
             return (
               <Link key={article.id} href={getHref(article)} className="block group flex-1">
                 <article className="relative rounded-xl bg-slate-800 text-white overflow-hidden h-full min-h-[150px] flex items-end active:scale-[0.99] transition-transform duration-150">
-                  {thumb && (
-                    <img
-                      src={thumb}
-                      alt=""
-                      className="absolute inset-0 w-full h-full object-cover"
-                    />
-                  )}
+                  <img
+                    src={thumb}
+                    alt=""
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
                   <div className="relative z-10 p-4">
                     {article.category && (
@@ -99,7 +97,7 @@ export function HeroSection({
         <Link href={getHref(hero)} className="block group">
           <article className="relative rounded-2xl bg-slate-800 text-white overflow-hidden min-h-[200px] flex items-end active:scale-[0.99] transition-transform duration-150">
             <img
-              src={heroImage || "/images/hero-sports-bg.jpg"}
+              src={heroImage}
               alt=""
               className="absolute inset-0 w-full h-full object-cover"
             />
@@ -124,17 +122,15 @@ export function HeroSection({
 
         <div className="grid grid-cols-2 gap-3">
           {subHeroes.map((article) => {
-            const thumb = article.images?.[0]?.url;
+            const thumb = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
             return (
               <Link key={article.id} href={getHref(article)} className="block group">
                 <article className="relative rounded-xl bg-slate-800 text-white overflow-hidden min-h-[120px] flex items-end active:scale-[0.99] transition-transform duration-150">
-                  {thumb && (
-                    <img
-                      src={thumb}
-                      alt=""
-                      className="absolute inset-0 w-full h-full object-cover"
-                    />
-                  )}
+                  <img
+                    src={thumb}
+                    alt=""
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
                   <div className="relative z-10 p-3">
                     {article.category && (

--- a/src/components/public/LiveScoreTicker.tsx
+++ b/src/components/public/LiveScoreTicker.tsx
@@ -151,10 +151,14 @@ export function LiveScoreTicker({ leagues }: { leagues: League[] }) {
           ))}
         </div>
       ) : (
-        <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
-          {games.map(({ game, league }) => (
-            <TickerGameCard key={`${league}-${game.id}`} game={game} league={league} />
-          ))}
+        <div className="relative">
+          <div className="flex gap-3 overflow-x-auto pb-1 scrollbar-hide">
+            {games.map(({ game, league }) => (
+              <TickerGameCard key={`${league}-${game.id}`} game={game} league={league} />
+            ))}
+          </div>
+          {/* 右側漸層遮罩提示可滾動 */}
+          <div className="absolute top-0 right-0 bottom-1 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none" />
         </div>
       )}
     </section>

--- a/src/components/public/PersonalizedArticleGrid.tsx
+++ b/src/components/public/PersonalizedArticleGrid.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { CATEGORY_COLORS, formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_COLORS, CATEGORY_FALLBACK_IMAGES, formatRelativeTime } from "@/lib/constants";
 import { Star } from "lucide-react";
 
 interface FavoriteTeam {
@@ -60,7 +60,7 @@ export function PersonalizedArticleGrid({
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
       {sortedArticles.map((article) => {
         const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
-        const thumbnail = article.images?.[0]?.url;
+        const thumbnail = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
         const isFavorite = favoriteNames.some((name) => article.title.includes(name));
 
         return (
@@ -71,20 +71,18 @@ export function PersonalizedArticleGrid({
           >
             {/* Desktop: vertical card */}
             <article className="hidden sm:block h-full rounded-xl border border-slate-200 bg-white overflow-hidden hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
-              {thumbnail && (
-                <div className="aspect-video bg-slate-100 relative">
-                  <img
-                    src={thumbnail}
-                    alt=""
-                    className="w-full h-full object-cover"
-                  />
-                  {isFavorite && (
-                    <span className="absolute top-2 right-2 bg-yellow-400 text-yellow-900 rounded-full p-1">
-                      <Star className="w-3 h-3 fill-current" />
-                    </span>
-                  )}
-                </div>
-              )}
+              <div className="aspect-video bg-slate-100 relative">
+                <img
+                  src={thumbnail}
+                  alt=""
+                  className="w-full h-full object-cover"
+                />
+                {isFavorite && (
+                  <span className="absolute top-2 right-2 bg-yellow-400 text-yellow-900 rounded-full p-1">
+                    <Star className="w-3 h-3 fill-current" />
+                  </span>
+                )}
+              </div>
               <div className="p-5">
                 <div className="flex items-center gap-2 mb-3">
                   {article.category && (
@@ -136,13 +134,11 @@ export function PersonalizedArticleGrid({
                     </div>
                   )}
                 </div>
-                {thumbnail && (
-                  <img
-                    src={thumbnail}
-                    alt=""
-                    className="w-24 h-16 object-cover rounded-lg flex-shrink-0"
-                  />
-                )}
+                <img
+                  src={thumbnail}
+                  alt=""
+                  className="w-24 h-16 object-cover rounded-lg flex-shrink-0"
+                />
               </div>
             </article>
           </Link>

--- a/src/components/public/PublicHeader.tsx
+++ b/src/components/public/PublicHeader.tsx
@@ -78,17 +78,21 @@ export function PublicHeader() {
 
       {/* Row 2: Nav tabs */}
       <div className="max-w-6xl mx-auto px-4 sm:px-6">
-        <nav className="flex items-center gap-1 overflow-x-auto scrollbar-hide pb-0.5">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="px-3 py-2 text-sm font-medium text-slate-600 rounded-md hover:text-blue-600 hover:bg-blue-50 active:scale-[0.97] transition-all duration-150 whitespace-nowrap"
-            >
-              {link.label}
-            </Link>
-          ))}
-        </nav>
+        <div className="relative">
+          <nav className="flex items-center gap-1 overflow-x-auto scrollbar-hide pb-0.5">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="px-3 py-2 text-sm font-medium text-slate-600 rounded-md hover:text-blue-600 hover:bg-blue-50 active:scale-[0.97] transition-all duration-150 whitespace-nowrap"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          {/* Mobile 右側漸層提示可滾動 */}
+          <div className="absolute top-0 right-0 bottom-0 w-6 bg-gradient-to-l from-white to-transparent pointer-events-none sm:hidden" />
+        </div>
       </div>
     </header>
   );

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -132,6 +132,16 @@ export const CATEGORY_COLORS: Record<string, string> = {
   綜合: "bg-purple-50 text-purple-700 border border-purple-300 rounded-lg",
 };
 
+/** 分類名稱 → 分類底圖 fallback（無文章配圖時使用） */
+export const CATEGORY_FALLBACK_IMAGES: Record<string, string> = {
+  NBA: "/images/category-nba.jpg",
+  籃球: "/images/category-nba.jpg",
+  棒球: "/images/category-mlb.jpg",
+  MLB: "/images/category-mlb.jpg",
+  足球: "/images/category-soccer.jpg",
+  綜合: "/images/category-general.jpg",
+};
+
 /** slug → 顯示名稱 */
 export const CATEGORY_LABELS: Record<string, string> = {
   nba: "NBA",

--- a/src/lib/espn/standings.ts
+++ b/src/lib/espn/standings.ts
@@ -22,13 +22,20 @@ export interface StandingsEntry {
   stats: Record<string, string>;
 }
 
+// ESPN stat name → 前端 key 映射
+const STAT_NAME_MAP: Record<string, string> = {
+  "Road": "Away",
+  "Last Ten Games": "L10",
+};
+
 function parseStandings(data: ESPNStandingsResponse): StandingsGroup[] {
   return (data.children ?? []).map((group) => ({
     name: group.name,
     entries: (group.standings?.entries ?? []).map((entry) => {
       const statsMap: Record<string, string> = {};
       (entry.stats ?? []).forEach((s) => {
-        statsMap[s.name] = s.displayValue;
+        const key = STAT_NAME_MAP[s.name] ?? s.name;
+        statsMap[key] = s.displayValue;
       });
       return {
         teamId: entry.team?.id ?? "",
@@ -37,6 +44,12 @@ function parseStandings(data: ESPNStandingsResponse): StandingsGroup[] {
         logo: entry.team?.logos?.[0]?.href ?? "",
         stats: statsMap,
       };
+    })
+    // 按勝率降序排列（ESPN 回傳順序不固定）
+    .sort((a, b) => {
+      const aWp = parseFloat(a.stats.winPercent || "0");
+      const bWp = parseFloat(b.stats.winPercent || "0");
+      return bWp - aWp;
     }),
   }));
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@ const ADMIN_ALLOWED_PREFIXES = [
   "/admin",
   "/login",
   "/api/auth",
+  "/api/admin",
   "/api/dashboard",
   "/api/settings",
   "/api/rewrite",


### PR DESCRIPTION
## Summary
- middleware: 加入 `/api/admin` 到 ADMIN_ALLOWED_PREFIXES 修復成效分析 CORS
- standings: 修正 ESPN stat name 映射 (Road→Away, Last Ten Games→L10) + 按勝率降序排列
- LiveScoreTicker / PublicHeader: 加右側漸層遮罩提示可滾動
- HeroSection / PersonalizedArticleGrid / CategoryPage: 無圖文章顯示分類底圖 fallback
- OddsClient: EDT/EST 時間轉台灣時間 + 卡片間距縮小
- ProductionPanel: 改為 inline bar 減少垂直空間
- Footer: 年份動態化

Closes #33

## Test plan
- [x] vitest 245/245 通過
- [ ] PC 1440×900: 首頁、排名、賠率、後台
- [ ] Mobile 430×932: 首頁、文章
- [ ] 正式環境 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)