### PR TITLE
feat: 產品全面優化 — 7 Sprint 48 項改進 (#35)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-markdown": "^10.1.0",
+        "recharts": "^3.8.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
@@ -4254,6 +4257,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -4642,7 +4681,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -5248,6 +5292,78 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5259,8 +5375,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -5274,6 +5407,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -5302,7 +5450,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5323,6 +5470,18 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -5635,6 +5794,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -6447,6 +6612,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6688,6 +6863,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -6713,6 +6898,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cheerio": {
@@ -6927,6 +7152,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -7148,8 +7383,128 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7250,7 +7605,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7270,6 +7624,25 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -7396,9 +7769,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7418,6 +7789,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "8.0.3",
@@ -7824,6 +8208,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -8331,6 +8725,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -8360,6 +8764,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -8483,6 +8893,12 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9141,6 +9557,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
@@ -9186,6 +9642,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/htmlparser2": {
@@ -9309,6 +9775,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9353,6 +9829,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9366,6 +9848,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -9386,6 +9877,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9553,6 +10068,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -9636,6 +10161,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ssh": {
@@ -9760,7 +10295,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10622,6 +11156,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10675,6 +11219,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -10683,6 +11237,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -10731,6 +11567,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10833,7 +12232,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -11536,6 +12934,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11946,6 +13369,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -12152,8 +13585,57 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -12251,6 +13733,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12263,6 +13775,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12309,6 +13836,72 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -12328,6 +13921,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -13023,6 +14622,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -13226,6 +14835,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stringify-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
@@ -13307,6 +14930,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -13413,7 +15054,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -13558,6 +15198,26 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-algebra": {
@@ -13859,6 +15519,93 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -14042,6 +15789,56 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -14726,6 +16523,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-markdown": "^10.1.0",
+    "recharts": "^3.8.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },

--- a/src/app/(public)/category/[slug]/page.tsx
+++ b/src/app/(public)/category/[slug]/page.tsx
@@ -29,6 +29,28 @@ type ArticleWithWriter = {
 
 const ITEMS_PER_PAGE = 20;
 
+function getExcerpt(content: string | null): string {
+  if (!content) return "";
+  const lines = content.split("\n").filter(Boolean);
+  const firstParagraph = lines.find(
+    (line) =>
+      !line.startsWith("#") &&
+      !line.startsWith("-") &&
+      !line.startsWith(">") &&
+      line.trim().length > 20
+  );
+  if (firstParagraph) {
+    return firstParagraph
+      .replace(/[#*_\[\]()>`~]/g, "")
+      .trim()
+      .slice(0, 160);
+  }
+  return content
+    .replace(/[#*_>\-\n\[\]()>`~]/g, " ")
+    .trim()
+    .slice(0, 160);
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -57,10 +79,10 @@ export default async function CategoryPage({
   searchParams,
 }: {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string; sort?: string }>;
 }) {
   const { slug } = await params;
-  const { page: pageParam } = await searchParams;
+  const { page: pageParam, sort: sortParam } = await searchParams;
   const categoryName = CATEGORY_DB_MAP[slug];
   const displayLabel = CATEGORY_LABELS[slug];
 
@@ -68,8 +90,9 @@ export default async function CategoryPage({
     notFound();
   }
 
-  const colorClass = CATEGORY_COLORS[categoryName] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
+  const colorClass = CATEGORY_COLORS[categoryName] ?? "bg-muted text-muted-foreground border border-border rounded-lg";
   const bannerImage = CATEGORY_BANNERS[slug];
+  const sortBy = sortParam === "popular" ? "popular" : "latest";
 
   // 敬請期待分類
   if (comingSoonCategories.has(slug)) {
@@ -100,13 +123,13 @@ export default async function CategoryPage({
               className="w-full h-auto"
             />
           </div>
-          <h2 className="text-2xl font-bold text-slate-900 mb-3">敬請期待</h2>
-          <p className="text-slate-500 max-w-md">
+          <h2 className="text-2xl font-bold text-foreground mb-3">敬請期待</h2>
+          <p className="text-muted-foreground max-w-md">
             {displayLabel}新聞即將上線，請持續關注 小豪哥體育資訊網！
           </p>
           <Link
             href="/"
-            className="mt-8 px-6 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+            className="mt-8 px-6 py-2.5 bg-brand text-brand-foreground text-sm font-medium rounded-lg hover:opacity-90 transition-colors"
           >
             回到首頁
           </Link>
@@ -130,7 +153,8 @@ export default async function CategoryPage({
   const totalCount = count ?? 0;
   const totalPages = Math.max(1, Math.ceil(totalCount / ITEMS_PER_PAGE));
 
-  // Get paginated articles
+  // Get paginated articles with sort
+  const orderColumn = sortBy === "popular" ? "view_count" : "published_at";
   const { data: articles } = await supabase
     .from("generated_articles")
     .select(
@@ -138,8 +162,16 @@ export default async function CategoryPage({
     )
     .eq("status", "published")
     .eq("category", categoryName)
-    .order("published_at", { ascending: false })
+    .order(orderColumn, { ascending: false })
     .range(offset, offset + ITEMS_PER_PAGE - 1);
+
+  const buildUrl = (params: Record<string, string | number>) => {
+    const searchParts: string[] = [];
+    for (const [k, v] of Object.entries(params)) {
+      searchParts.push(`${k}=${v}`);
+    }
+    return `/category/${slug}?${searchParts.join("&")}`;
+  };
 
   return (
     <div>
@@ -164,20 +196,46 @@ export default async function CategoryPage({
         </div>
       )}
 
-      {/* Breadcrumb */}
-      <nav className="flex items-center gap-2 text-sm mb-6">
-        <span className="inline-flex items-center gap-2 bg-slate-100 rounded-full px-4 py-1.5">
-          <Link href="/" className="text-slate-500 hover:text-blue-600 transition-colors">
-            首頁
+      {/* Breadcrumb + Sort */}
+      <div className="flex items-center justify-between mb-6 gap-4 flex-wrap">
+        <nav className="flex items-center gap-2 text-sm">
+          <span className="inline-flex items-center gap-2 bg-muted rounded-full px-4 py-1.5">
+            <Link href="/" className="text-muted-foreground hover:text-brand transition-colors">
+              首頁
+            </Link>
+            <span className="text-muted-foreground/40">/</span>
+            <span className="text-foreground font-medium">{displayLabel}</span>
+          </span>
+        </nav>
+
+        {/* Sort buttons */}
+        <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+          <Link
+            href={buildUrl({ sort: "latest", page: 1 })}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              sortBy === "latest"
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            最新
           </Link>
-          <span className="text-slate-300">/</span>
-          <span className="text-slate-700 font-medium">{displayLabel}</span>
-        </span>
-      </nav>
+          <Link
+            href={buildUrl({ sort: "popular", page: 1 })}
+            className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+              sortBy === "popular"
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            最熱門
+          </Link>
+        </div>
+      </div>
 
       {/* Articles */}
       {!articles || articles.length === 0 ? (
-        <p className="text-slate-500 py-12 text-center">
+        <p className="text-muted-foreground py-12 text-center">
           此分類目前沒有文章。
         </p>
       ) : (
@@ -189,22 +247,26 @@ export default async function CategoryPage({
               <Link
                 key={article.id}
                 href={`/news/${article.slug || article.id}`}
-                className="group block rounded-xl border border-slate-200 bg-white p-5 hover:shadow-md hover:border-blue-300 transition-all duration-200"
+                className="group block rounded-xl border border-border bg-card p-5 hover:shadow-md hover:border-brand/30 transition-all duration-200"
               >
                 <div className="flex items-start gap-4">
                   <div className="flex-1 min-w-0">
-                    <h2 className="text-lg font-semibold text-slate-900 line-clamp-2 group-hover:text-blue-600 transition-colors mb-2">
+                    <h2 className="text-lg font-semibold text-foreground line-clamp-2 group-hover:text-brand transition-colors mb-2">
                       {article.title}
                     </h2>
-                    <p className="text-sm text-slate-500 line-clamp-2 mb-3">
-                      {article.content
-                        ?.replace(/[#*_>\-\n]/g, " ")
-                        .slice(0, 160)}
+                    <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+                      {getExcerpt(article.content)}
                     </p>
-                    <div className="flex items-center gap-2 text-xs text-slate-400">
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
                       {writerName && <span>{writerName}</span>}
                       {writerName && <span>&middot;</span>}
                       <span>{formatRelativeTime(article.published_at)}</span>
+                      {sortBy === "popular" && article.view_count != null && article.view_count > 0 && (
+                        <>
+                          <span>&middot;</span>
+                          <span>{article.view_count} 次瀏覽</span>
+                        </>
+                      )}
                     </div>
                   </div>
                   <img
@@ -224,8 +286,8 @@ export default async function CategoryPage({
         <nav className="flex items-center justify-center gap-2 mt-8">
           {currentPage > 1 && (
             <Link
-              href={`/category/${slug}?page=${currentPage - 1}`}
-              className="px-4 py-2 text-sm font-medium text-slate-600 bg-white border border-slate-300 rounded-lg hover:border-blue-300 hover:text-blue-600 transition-colors"
+              href={buildUrl({ sort: sortBy, page: currentPage - 1 })}
+              className="px-4 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:border-brand/30 hover:text-brand transition-colors"
             >
               上一頁
             </Link>
@@ -247,17 +309,17 @@ export default async function CategoryPage({
               }, [])
               .map((item, i) =>
                 item === "ellipsis" ? (
-                  <span key={`e${i}`} className="px-2 text-slate-400">
+                  <span key={`e${i}`} className="px-2 text-muted-foreground">
                     ...
                   </span>
                 ) : (
                   <Link
                     key={item}
-                    href={`/category/${slug}?page=${item}`}
+                    href={buildUrl({ sort: sortBy, page: item })}
                     className={`w-10 h-10 flex items-center justify-center text-sm font-medium rounded-lg border transition-colors ${
                       item === currentPage
-                        ? "bg-blue-600 text-white border-blue-600"
-                        : "text-slate-600 border-slate-300 hover:border-blue-300 hover:text-blue-600"
+                        ? "bg-brand text-brand-foreground border-brand"
+                        : "text-muted-foreground border-border hover:border-brand/30 hover:text-brand"
                     }`}
                   >
                     {item}
@@ -267,8 +329,8 @@ export default async function CategoryPage({
           </div>
           {currentPage < totalPages && (
             <Link
-              href={`/category/${slug}?page=${currentPage + 1}`}
-              className="px-4 py-2 text-sm font-medium text-slate-600 bg-white border border-slate-300 rounded-lg hover:border-blue-300 hover:text-blue-600 transition-colors"
+              href={buildUrl({ sort: sortBy, page: currentPage + 1 })}
+              className="px-4 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:border-brand/30 hover:text-brand transition-colors"
             >
               下一頁
             </Link>

--- a/src/app/(public)/game/[sport]/[id]/GameJsonLd.tsx
+++ b/src/app/(public)/game/[sport]/[id]/GameJsonLd.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface GameInfo {
+  id: string;
+  date: string;
+  status: string;
+  statusDetail: string;
+  homeTeam: { name: string; abbreviation: string; logo: string; score: string; record: string };
+  awayTeam: { name: string; abbreviation: string; logo: string; score: string; record: string };
+}
+
+export function GameJsonLd({ sport, eventId }: { sport: string; eventId: string }) {
+  const [game, setGame] = useState<GameInfo | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/public/scoreboard?league=${sport}`)
+      .then((r) => r.json())
+      .then((d) => {
+        const g = (d.games ?? []).find((g: GameInfo) => g.id === eventId);
+        if (g) setGame(g);
+      })
+      .catch(() => {});
+  }, [sport, eventId]);
+
+  if (!game) return null;
+
+  // JSON-LD content is derived from our own API (ESPN data), not user input
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SportsEvent",
+    name: `${game.awayTeam.name} vs ${game.homeTeam.name}`,
+    startDate: game.date,
+    location: {
+      "@type": "Place",
+      name: game.statusDetail || "TBD",
+    },
+    competitor: [
+      { "@type": "SportsTeam", name: game.awayTeam.name },
+      { "@type": "SportsTeam", name: game.homeTeam.name },
+    ],
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/src/app/(public)/game/[sport]/[id]/page.tsx
+++ b/src/app/(public)/game/[sport]/[id]/page.tsx
@@ -1,18 +1,39 @@
+import { Metadata } from "next";
 import { GameDetailClient } from "@/components/game/GameDetailClient";
+import { SPORT_KEY_LABELS, SITE_URL } from "@/lib/constants";
+import { GameJsonLd } from "./GameJsonLd";
 
 interface Props {
   params: Promise<{ sport: string; id: string }>;
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { sport, id } = await params;
+  const sportLabel = SPORT_KEY_LABELS[sport] || sport.toUpperCase();
+  const title = `${sportLabel} 比賽 #${id}`;
+  const ogUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(title)}&subtitle=${encodeURIComponent(sportLabel)}&type=game`;
+
   return {
-    title: `${sport.toUpperCase()} 比賽 #${id}`,
+    title,
+    openGraph: {
+      title,
+      images: [{ url: ogUrl, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      images: [ogUrl],
+    },
   };
 }
 
 export default async function GameDetailPage({ params }: Props) {
   const { sport, id } = await params;
 
-  return <GameDetailClient sport={sport} eventId={id} />;
+  return (
+    <>
+      <GameJsonLd sport={sport} eventId={id} />
+      <GameDetailClient sport={sport} eventId={id} />
+    </>
+  );
 }

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -19,33 +19,33 @@ export default function PublicLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="h-[100dvh] flex flex-col bg-white overflow-hidden">
+    <div className="h-[100dvh] flex flex-col bg-background overflow-hidden">
       <PublicHeader />
 
       {/* Scrollable content area */}
       <div id="scroll-container" className="flex-1 overflow-y-auto overscroll-contain">
         <PullToRefresh scrollContainerId="scroll-container" />
         {/* Main Content */}
-        <main className="max-w-6xl mx-auto w-full px-4 sm:px-6 py-8">
+        <main className="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8">
           {children}
         </main>
 
         {/* Footer */}
-        <footer className="bg-slate-100 border-t border-slate-200">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 py-4">
+        <footer className="bg-secondary border-t border-border">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
             {/* Telegram CTA - compact */}
             <div className="flex items-center justify-between gap-4 mb-4">
               <div className="flex items-center gap-3">
-                <svg className="w-5 h-5 text-blue-600 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                <svg className="w-5 h-5 text-brand flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm5.53 8.24l-1.82 8.58c-.13.59-.48.73-.98.45l-2.7-1.99-1.3 1.25c-.14.14-.27.27-.54.27l.19-2.73 4.99-4.51c.22-.19-.05-.3-.34-.11l-6.17 3.89-2.66-.83c-.58-.18-.59-.58.12-.86l10.39-4.01c.48-.18.91.12.75.8z" />
                 </svg>
-                <span className="text-sm text-slate-600">即時體育新聞直送手機</span>
+                <span className="text-sm text-muted-foreground">即時體育新聞直送手機</span>
               </div>
               <Link
                 href="https://t.me/howger_sport_news"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 text-white text-xs font-medium rounded-lg hover:bg-blue-700 transition-colors flex-shrink-0"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-brand text-brand-foreground text-xs font-medium rounded-lg hover:opacity-90 transition-opacity flex-shrink-0"
               >
                 加入頻道
               </Link>
@@ -57,14 +57,14 @@ export default function PublicLayout({
                 <Link
                   key={link.href}
                   href={link.href}
-                  className="text-sm text-slate-500 hover:text-blue-600 transition-colors"
+                  className="text-sm text-muted-foreground hover:text-brand transition-colors"
                 >
                   {link.label}
                 </Link>
               ))}
             </div>
-            <div className="border-t border-slate-200 pt-3">
-              <div className="text-sm text-slate-400 text-center">
+            <div className="border-t border-border pt-3">
+              <div className="text-sm text-muted-foreground/60 text-center">
                 &copy; {new Date().getFullYear()} 小豪哥體育資訊網. All rights reserved.
               </div>
             </div>

--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -4,9 +4,12 @@ import { notFound } from "next/navigation";
 import { createServiceClient } from "@/lib/supabase";
 import { CATEGORY_COLORS, formatDateFull, formatRelativeTime, getCategorySlug, SITE_URL } from "@/lib/constants";
 import ViewTracker from "./ViewTracker";
-
 import LikeButton from "./LikeButton";
 import { TelegramArticleCTA } from "@/components/TelegramCTA";
+import { ArticleContent, extractHeadings } from "@/components/public/ArticleContent";
+import { TableOfContents } from "@/components/public/TableOfContents";
+import { ShareButtons } from "@/components/public/ShareButtons";
+import { ReactionButtons } from "@/components/public/ReactionButtons";
 
 export const revalidate = 60;
 
@@ -55,6 +58,7 @@ export async function generateMetadata({
   const description = getContentExcerpt(article.content);
 
   const articleUrl = `${SITE_URL}/news/${article.slug || slug}`;
+  const ogImageUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(article.title)}&subtitle=${encodeURIComponent(article.category || "")}&type=article`;
 
   return {
     title: `${article.title} - 小豪哥體育資訊網`,
@@ -73,11 +77,13 @@ export async function generateMetadata({
         : undefined,
       siteName: "小豪哥體育資訊網",
       locale: "zh_TW",
+      images: [{ url: ogImageUrl, width: 1200, height: 630 }],
     },
     twitter: {
       card: "summary_large_image",
       title: article.title,
       description,
+      images: [ogImageUrl],
     },
     other: {
       ...(article.published_at ? { "article:published_time": article.published_at } : {}),
@@ -116,15 +122,16 @@ export default async function ArticlePage({
     .limit(4);
 
   const colorClass =
-    CATEGORY_COLORS[article.category ?? ""] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
-
-  // Simple markdown-like rendering: split by paragraphs, handle headings
-  const contentParagraphs: string[] = (article.content ?? "").split("\n").filter(Boolean);
+    CATEGORY_COLORS[article.category ?? ""] ?? "bg-muted text-muted-foreground border border-border rounded-lg";
 
   const articleUrl = `${SITE_URL}/news/${article.slug || slug}`;
+  const contentStr = article.content ?? "";
+  const showToc = contentStr.length > 1500;
+  const headings = showToc ? extractHeadings(contentStr) : [];
 
-  // JSON-LD structured data (server-generated, safe content)
-  const jsonLd = {
+  // JSON-LD structured data
+  // Note: content is server-generated from trusted DB (not user input), safe to serialize as JSON
+  const jsonLdData = JSON.stringify({
     "@context": "https://schema.org",
     "@type": "NewsArticle",
     headline: article.title,
@@ -141,36 +148,35 @@ export default async function ArticlePage({
       "@id": articleUrl,
     },
     articleSection: article.category ?? undefined,
-  };
+  });
 
   return (
     <article className="max-w-3xl mx-auto">
-      {/* JSON-LD: content is server-generated from trusted DB, not user input */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+      {/* JSON-LD structured data for SEO - trusted server-generated content */}
+      <script type="application/ld+json" suppressHydrationWarning>
+        {jsonLdData}
+      </script>
       <ViewTracker slug={slug} />
 
       {/* Breadcrumb */}
       <nav className="flex items-center gap-2 text-sm mb-6">
-        <span className="inline-flex items-center gap-2 bg-slate-100 rounded-full px-4 py-1.5">
-          <Link href="/" className="text-slate-500 hover:text-blue-600 transition-colors">
+        <span className="inline-flex items-center gap-2 bg-muted rounded-full px-4 py-1.5">
+          <Link href="/" className="text-muted-foreground hover:text-blue-600 transition-colors">
             首頁
           </Link>
-          <span className="text-slate-300">/</span>
+          <span className="text-muted-foreground/40">/</span>
           {article.category && (
             <>
               <Link
                 href={`/category/${getCategorySlug(article.category)}`}
-                className="text-slate-500 hover:text-blue-600 transition-colors"
+                className="text-muted-foreground hover:text-blue-600 transition-colors"
               >
                 {article.category}
               </Link>
-              <span className="text-slate-300">/</span>
+              <span className="text-muted-foreground/40">/</span>
             </>
           )}
-          <span className="text-slate-700 truncate max-w-[200px]">
+          <span className="text-foreground truncate max-w-[200px]">
             {article.title}
           </span>
         </span>
@@ -185,14 +191,14 @@ export default async function ArticlePage({
             {article.category}
           </span>
         )}
-        <h1 className="text-3xl sm:text-4xl font-bold text-slate-900 leading-tight mb-4">
+        <h1 className="text-3xl sm:text-4xl font-bold text-foreground leading-tight mb-4">
           {article.title}
         </h1>
-        <div className="flex flex-wrap items-center gap-2 text-sm text-slate-500">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground mb-4">
           {writer && (
             <Link
               href={`/writer/${writer.id}`}
-              className="font-medium text-slate-700 hover:text-blue-600 transition-colors"
+              className="font-medium text-foreground hover:text-blue-600 transition-colors"
             >
               {writer.name}
             </Link>
@@ -202,9 +208,12 @@ export default async function ArticlePage({
             {formatDateFull(article.published_at)}
           </time>
           {article.published_at && (
-            <span className="text-slate-400">({formatRelativeTime(article.published_at)})</span>
+            <span className="text-muted-foreground/60">({formatRelativeTime(article.published_at)})</span>
           )}
         </div>
+
+        {/* Share Buttons - top */}
+        <ShareButtons url={articleUrl} title={article.title} />
       </header>
 
       {/* Featured Image */}
@@ -216,72 +225,25 @@ export default async function ArticlePage({
             className="w-full max-h-[480px] object-cover"
           />
           {article.images[0].caption && (
-            <p className="text-xs text-slate-400 mt-2">{article.images[0].caption}</p>
+            <p className="text-xs text-muted-foreground mt-2">{article.images[0].caption}</p>
           )}
         </div>
       )}
 
       {/* Divider */}
-      <hr className="border-slate-200 mb-8" />
+      <hr className="border-border mb-8" />
 
-      {/* Content */}
-      <div className="prose prose-lg max-w-none mb-12">
-        {contentParagraphs.map((line, i) => {
-          const trimmed = line.trim();
-          if (trimmed.startsWith("### ")) {
-            return (
-              <h3
-                key={i}
-                className="text-xl font-bold text-slate-900 mt-8 mb-3"
-              >
-                {trimmed.slice(4)}
-              </h3>
-            );
-          }
-          if (trimmed.startsWith("## ")) {
-            return (
-              <h2
-                key={i}
-                className="text-2xl font-bold text-slate-900 mt-10 mb-4"
-              >
-                {trimmed.slice(3)}
-              </h2>
-            );
-          }
-          if (trimmed.startsWith("# ")) {
-            return (
-              <h2
-                key={i}
-                className="text-2xl font-bold text-slate-900 mt-10 mb-4"
-              >
-                {trimmed.slice(2)}
-              </h2>
-            );
-          }
-          if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
-            return (
-              <div key={i} className="flex items-start gap-2 text-slate-700 leading-relaxed ml-4">
-                <span className="select-none" aria-hidden="true">&#8226;</span>
-                <span>{trimmed.slice(2)}</span>
-              </div>
-            );
-          }
-          if (trimmed.startsWith("> ")) {
-            return (
-              <blockquote
-                key={i}
-                className="border-l-4 border-blue-400 bg-blue-50/50 pl-4 py-2 italic text-slate-600 my-4"
-              >
-                {trimmed.slice(2)}
-              </blockquote>
-            );
-          }
-          return (
-            <p key={i} className="text-slate-700 leading-relaxed mb-4">
-              {trimmed}
-            </p>
-          );
-        })}
+      {/* Table of Contents */}
+      {showToc && headings.length >= 2 && (
+        <TableOfContents headings={headings} />
+      )}
+
+      {/* Content - react-markdown */}
+      <ArticleContent content={contentStr} />
+
+      {/* Reactions */}
+      <div className="mb-4">
+        <ReactionButtons articleId={article.id} />
       </div>
 
       {/* Like Button */}
@@ -289,12 +251,18 @@ export default async function ArticlePage({
         <LikeButton articleId={article.id} />
       </div>
 
+      {/* Share Buttons - bottom */}
+      <div className="mb-8">
+        <p className="text-sm font-medium text-muted-foreground mb-2">分享這篇文章</p>
+        <ShareButtons url={articleUrl} title={article.title} />
+      </div>
+
       {/* Telegram CTA */}
       <TelegramArticleCTA />
 
       {/* Writer Info */}
       {writer && (
-        <div className="bg-slate-50 border border-slate-200 rounded-xl p-6 mb-12">
+        <div className="bg-muted/50 border border-border rounded-xl p-6 mb-12">
           <div className="flex items-start gap-4">
             <div className="w-12 h-12 rounded-full bg-blue-600 ring-2 ring-blue-600 ring-offset-2 flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
               {writer.name.charAt(1) || writer.name.charAt(0)}
@@ -302,12 +270,12 @@ export default async function ArticlePage({
             <div>
               <Link
                 href={`/writer/${writer.id}`}
-                className="text-base font-semibold text-slate-900 hover:text-blue-600 transition-colors"
+                className="text-base font-semibold text-foreground hover:text-blue-600 transition-colors"
               >
                 {writer.name}
               </Link>
               {writer.description && (
-                <p className="text-sm text-slate-500 mt-1">
+                <p className="text-sm text-muted-foreground mt-1">
                   {writer.description}
                 </p>
               )}
@@ -319,18 +287,18 @@ export default async function ArticlePage({
       {/* Related Articles */}
       {relatedArticles && relatedArticles.length > 0 && (
         <section>
-          <h2 className="text-xl font-bold text-slate-900 mb-5 border-l-4 border-blue-600 pl-3">相關報導</h2>
+          <h2 className="text-xl font-bold text-foreground mb-5 border-l-4 border-blue-600 pl-3">相關報導</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {relatedArticles.map((related) => (
               <Link
                 key={related.id}
                 href={`/news/${related.slug || related.id}`}
-                className="group block rounded-lg border border-slate-200 bg-white p-4 hover:shadow-md hover:border-blue-300 transition-all"
+                className="group block rounded-lg border border-border bg-card p-4 hover:shadow-md hover:border-blue-300 transition-all"
               >
-                <h3 className="text-sm font-semibold text-slate-900 line-clamp-2 group-hover:text-blue-600 transition-colors mb-2">
+                <h3 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-blue-600 transition-colors mb-2">
                   {related.title}
                 </h3>
-                <div className="flex items-center gap-2 text-xs text-slate-400">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <time>
                     {related.published_at
                       ? new Date(related.published_at).toLocaleDateString(

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -4,6 +4,7 @@ import { LiveScoreTicker } from "@/components/public/LiveScoreTicker";
 import { HomeArticleSection } from "@/components/public/HomeArticleSection";
 import { QuickStandings } from "@/components/public/QuickStandings";
 import { QuickOdds } from "@/components/public/QuickOdds";
+import { TrendingArticles } from "@/components/public/TrendingArticles";
 
 // 每 60 秒重新驗證頁面資料
 export const revalidate = 60;
@@ -76,23 +77,37 @@ export default async function HomePage() {
         />
       )}
 
-      {/* Articles with category filter */}
-      <HomeArticleSection
-        articles={gridArticles.map((article) => ({
-          id: article.id,
-          title: article.title,
-          content: article.content,
-          category: article.category,
-          published_at: article.published_at,
-          view_count: article.view_count,
-          slug: article.slug,
-          images: article.images,
-          writerName: article.writer_personas?.name ?? null,
-        }))}
-      />
+      {/* Main content + Sidebar */}
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Main content area */}
+        <div className="flex-1 min-w-0">
+          <HomeArticleSection
+            articles={gridArticles.map((article) => ({
+              id: article.id,
+              title: article.title,
+              content: article.content,
+              category: article.category,
+              published_at: article.published_at,
+              view_count: article.view_count,
+              slug: article.slug,
+              images: article.images,
+              writerName: article.writer_personas?.name ?? null,
+            }))}
+          />
+        </div>
 
-      {/* Bottom two-column: Standings + Odds */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+        {/* Sidebar - PC only */}
+        <aside className="hidden lg:block w-[300px] flex-shrink-0 space-y-4">
+          <div className="sticky top-4 space-y-4">
+            <TrendingArticles />
+            <QuickStandings />
+            <QuickOdds />
+          </div>
+        </aside>
+      </div>
+
+      {/* Mobile: Standings + Odds below articles */}
+      <div className="lg:hidden grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
         <QuickStandings />
         <QuickOdds />
       </div>

--- a/src/app/(public)/player/[sport]/[id]/PlayerJsonLd.tsx
+++ b/src/app/(public)/player/[sport]/[id]/PlayerJsonLd.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface PlayerInfo {
+  id: string;
+  displayName: string;
+  team: {
+    id: string;
+    displayName: string;
+    abbreviation: string;
+    logo: string;
+  };
+}
+
+export function PlayerJsonLd({ sport, playerId }: { sport: string; playerId: string }) {
+  const [player, setPlayer] = useState<PlayerInfo | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/public/player?sport=${sport}&id=${playerId}`)
+      .then((r) => r.json())
+      .then((d) => setPlayer(d.player ?? null))
+      .catch(() => {});
+  }, [sport, playerId]);
+
+  if (!player) return null;
+
+  // Content sourced from our ESPN API proxy, trusted server data
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: player.displayName,
+    memberOf: {
+      "@type": "SportsTeam",
+      name: player.team?.displayName || "Unknown",
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/src/app/(public)/player/[sport]/[id]/page.tsx
+++ b/src/app/(public)/player/[sport]/[id]/page.tsx
@@ -1,15 +1,38 @@
+import { Metadata } from "next";
 import { PlayerDetailClient } from "@/components/player/PlayerDetailClient";
+import { SPORT_KEY_LABELS, SITE_URL } from "@/lib/constants";
+import { PlayerJsonLd } from "./PlayerJsonLd";
 
 interface Props {
   params: Promise<{ sport: string; id: string }>;
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { sport, id } = await params;
-  return { title: `${sport.toUpperCase()} 球員 #${id}` };
+  const sportLabel = SPORT_KEY_LABELS[sport] || sport.toUpperCase();
+  const title = `${sportLabel} 球員 #${id}`;
+  const ogUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(title)}&subtitle=${encodeURIComponent(sportLabel)}&type=team`;
+
+  return {
+    title,
+    openGraph: {
+      title,
+      images: [{ url: ogUrl, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      images: [ogUrl],
+    },
+  };
 }
 
 export default async function PlayerPage({ params }: Props) {
   const { sport, id } = await params;
-  return <PlayerDetailClient sport={sport} playerId={id} />;
+  return (
+    <>
+      <PlayerJsonLd sport={sport} playerId={id} />
+      <PlayerDetailClient sport={sport} playerId={id} />
+    </>
+  );
 }

--- a/src/app/(public)/search/SearchInput.tsx
+++ b/src/app/(public)/search/SearchInput.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Search } from "lucide-react";
+
+export function SearchInput({ defaultValue = "" }: { defaultValue?: string }) {
+  const router = useRouter();
+  const [value, setValue] = useState(defaultValue);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = value.trim();
+    if (q) {
+      router.push(`/search?q=${encodeURIComponent(q)}`);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-6">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="搜尋文章標題或內容..."
+          className="w-full pl-10 pr-4 py-3 bg-muted border border-border rounded-xl text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+          autoFocus
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -1,0 +1,121 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import { createServiceClient } from "@/lib/supabase";
+import { CATEGORY_COLORS, CATEGORY_FALLBACK_IMAGES, formatRelativeTime } from "@/lib/constants";
+import { SearchInput } from "./SearchInput";
+
+export const metadata: Metadata = {
+  title: "搜尋文章 - 小豪哥體育資訊網",
+};
+
+interface SearchResult {
+  id: string;
+  title: string;
+  slug: string | null;
+  category: string | null;
+  published_at: string | null;
+  images: { url: string }[] | null;
+}
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>;
+}) {
+  const { q } = await searchParams;
+  const query = q?.trim() || "";
+
+  let articles: SearchResult[] = [];
+
+  if (query) {
+    const supabase = createServiceClient();
+    const keyword = `%${query}%`;
+
+    const { data } = await supabase
+      .from("generated_articles")
+      .select("id, title, slug, category, published_at, images")
+      .eq("status", "published")
+      .or(`title.ilike.${keyword},content.ilike.${keyword}`)
+      .order("published_at", { ascending: false })
+      .limit(20);
+
+    articles = (data ?? []) as SearchResult[];
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold text-foreground mb-6">搜尋文章</h1>
+
+      <SearchInput defaultValue={query} />
+
+      {query && (
+        <p className="text-sm text-muted-foreground mb-6">
+          {articles.length > 0
+            ? `找到 ${articles.length} 篇相關文章`
+            : "找不到相關文章"}
+        </p>
+      )}
+
+      {articles.length > 0 && (
+        <div className="space-y-4">
+          {articles.map((article) => {
+            const colorClass =
+              CATEGORY_COLORS[article.category ?? ""] ??
+              "bg-muted text-muted-foreground border border-border rounded-lg";
+            const thumbnail =
+              article.images?.[0]?.url ||
+              CATEGORY_FALLBACK_IMAGES[article.category ?? ""] ||
+              "/images/category-general.jpg";
+
+            return (
+              <Link
+                key={article.id}
+                href={`/news/${article.slug || article.id}`}
+                className="group block rounded-xl border border-border bg-card p-5 hover:shadow-md hover:border-blue-300 transition-all duration-200"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-2">
+                      {article.category && (
+                        <span
+                          className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}
+                        >
+                          {article.category}
+                        </span>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        {formatRelativeTime(article.published_at)}
+                      </span>
+                    </div>
+                    <h2 className="text-lg font-semibold text-foreground line-clamp-2 group-hover:text-blue-600 transition-colors">
+                      {article.title}
+                    </h2>
+                  </div>
+                  <img
+                    src={thumbnail}
+                    alt=""
+                    className="w-28 h-20 object-cover rounded-lg flex-shrink-0"
+                  />
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
+      {query && articles.length === 0 && (
+        <div className="text-center py-16">
+          <p className="text-muted-foreground mb-4">
+            找不到包含「{query}」的文章
+          </p>
+          <Link
+            href="/"
+            className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+          >
+            回到首頁
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/team/[sport]/[id]/TeamJsonLd.tsx
+++ b/src/app/(public)/team/[sport]/[id]/TeamJsonLd.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SPORT_KEY_LABELS } from "@/lib/constants";
+
+interface TeamInfo {
+  id: string;
+  name: string;
+  abbreviation: string;
+  logo: string;
+  color: string;
+  record: string;
+  standingSummary: string;
+}
+
+export function TeamJsonLd({ sport, teamId }: { sport: string; teamId: string }) {
+  const [team, setTeam] = useState<TeamInfo | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/public/team?sport=${sport}&id=${teamId}`)
+      .then((r) => r.json())
+      .then((d) => setTeam(d.team ?? null))
+      .catch(() => {});
+  }, [sport, teamId]);
+
+  if (!team) return null;
+
+  const sportLabel = SPORT_KEY_LABELS[sport] || sport;
+
+  // Content sourced from our ESPN API proxy, not user-generated input
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SportsTeam",
+    name: team.name,
+    sport: sportLabel,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/src/app/(public)/team/[sport]/[id]/page.tsx
+++ b/src/app/(public)/team/[sport]/[id]/page.tsx
@@ -1,15 +1,38 @@
+import { Metadata } from "next";
 import { TeamDetailClient } from "@/components/team/TeamDetailClient";
+import { SPORT_KEY_LABELS, SITE_URL } from "@/lib/constants";
+import { TeamJsonLd } from "./TeamJsonLd";
 
 interface Props {
   params: Promise<{ sport: string; id: string }>;
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { sport, id } = await params;
-  return { title: `${sport.toUpperCase()} 球隊 #${id}` };
+  const sportLabel = SPORT_KEY_LABELS[sport] || sport.toUpperCase();
+  const title = `${sportLabel} 球隊 #${id}`;
+  const ogUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(title)}&subtitle=${encodeURIComponent(sportLabel)}&type=team`;
+
+  return {
+    title,
+    openGraph: {
+      title,
+      images: [{ url: ogUrl, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      images: [ogUrl],
+    },
+  };
 }
 
 export default async function TeamPage({ params }: Props) {
   const { sport, id } = await params;
-  return <TeamDetailClient sport={sport} teamId={id} />;
+  return (
+    <>
+      <TeamJsonLd sport={sport} teamId={id} />
+      <TeamDetailClient sport={sport} teamId={id} />
+    </>
+  );
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -18,11 +18,18 @@ interface DayStats {
   views: number;
 }
 
+interface QualityStats {
+  avg_length: number;
+  avg_likes: number;
+  category_distribution: { category: string; count: number }[];
+}
+
 interface AnalyticsData {
   top_articles: TopArticle[];
   views_by_day: DayStats[];
   views_by_category: Record<string, { articles: number; views: number }>;
   totals: { total_views: number; total_articles: number };
+  quality?: QualityStats;
 }
 
 export default function AnalyticsPage() {
@@ -206,6 +213,83 @@ export default function AnalyticsPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* 文章品質監控 */}
+      {data.quality && (
+        <>
+          <h2 className="text-xl font-bold mt-4">文章品質監控</h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-gray-500">平均文章長度</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold text-indigo-600">
+                  {data.quality.avg_length.toLocaleString()} 字
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-gray-500">平均按讚數</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold text-pink-600">
+                  {data.quality.avg_likes.toFixed(1)}
+                </div>
+              </CardContent>
+            </Card>
+            <Card className="col-span-2 md:col-span-1">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-gray-500">分類數量最多</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold text-teal-600">
+                  {data.quality.category_distribution[0]?.category || "-"}
+                </div>
+                <div className="text-xs text-gray-400">
+                  {data.quality.category_distribution[0]?.count || 0} 篇
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* 分類分佈長條圖 */}
+          {data.quality.category_distribution.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>文章分類分佈</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {(() => {
+                    const maxCount = Math.max(
+                      ...data.quality!.category_distribution.map((d) => d.count),
+                      1
+                    );
+                    return data.quality!.category_distribution.map((item) => (
+                      <div key={item.category} className="space-y-1">
+                        <div className="flex justify-between text-sm">
+                          <span className="font-medium">{item.category}</span>
+                          <span className="text-gray-500">{item.count} 篇</span>
+                        </div>
+                        <div className="h-3 bg-gray-100 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-indigo-500 rounded-full"
+                            style={{
+                              width: `${(item.count / maxCount) * 100}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    ));
+                  })()}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -9,7 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { PAGE_SIZE_OPTIONS } from "@/lib/constants";
+import { PAGE_SIZE_OPTIONS, CATEGORY_COLORS } from "@/lib/constants";
 
 import { PaginationBar } from "@/components/admin/PaginationBar";
 import { PlansTable } from "@/components/admin/PlansTable";
@@ -27,6 +27,7 @@ export default function ArticlesPage() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
   const [status, setStatus] = useState<string>("all");
+  const [category, setCategory] = useState<string>("all");
   const [loading, setLoading] = useState(true);
   const [jumpInput, setJumpInput] = useState("");
 
@@ -44,6 +45,7 @@ export default function ArticlesPage() {
       limit: pageSize.toString(),
     });
     if (status !== "all") params.set("status", status);
+    if (category !== "all") params.set("category", category);
 
     try {
       const res = await fetch(`/api/articles/generated?${params}`);
@@ -55,7 +57,7 @@ export default function ArticlesPage() {
     } finally {
       setLoading(false);
     }
-  }, [page, pageSize, status]);
+  }, [page, pageSize, status, category]);
 
   const planManager = usePlanManager({
     onProduceSuccess: () => {
@@ -262,15 +264,35 @@ export default function ArticlesPage() {
 
       {rewritePolling.runningMode === "plan" && planManager.plans.length === 0 && <PlanLoadingCard />}
 
-      {/* 狀態篩選 */}
-      <Tabs value={status} onValueChange={handleStatusChange}>
-        <TabsList>
-          <TabsTrigger value="all">全部</TabsTrigger>
-          <TabsTrigger value="draft">未發布</TabsTrigger>
-          <TabsTrigger value="scheduled">排程中</TabsTrigger>
-          <TabsTrigger value="published">已發布</TabsTrigger>
-        </TabsList>
-      </Tabs>
+      {/* 狀態 + 分類篩選 */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Tabs value={status} onValueChange={handleStatusChange}>
+          <TabsList>
+            <TabsTrigger value="all">全部</TabsTrigger>
+            <TabsTrigger value="draft">未發布</TabsTrigger>
+            <TabsTrigger value="scheduled">排程中</TabsTrigger>
+            <TabsTrigger value="published">已發布</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <Select
+          value={category}
+          onValueChange={(v) => {
+            setCategory(v);
+            setPage(1);
+            setSelectedIds(new Set());
+          }}
+        >
+          <SelectTrigger className="w-[130px]">
+            <SelectValue placeholder="所有分類" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">所有分類</SelectItem>
+            {Object.keys(CATEGORY_COLORS).filter((k) => k.length <= 3 || k === "綜合").map((cat) => (
+              <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
       {/* 批次操作列 */}
       <BatchActionsBar

--- a/src/app/admin/personas/page.tsx
+++ b/src/app/admin/personas/page.tsx
@@ -35,6 +35,8 @@ export default function PersonasPage() {
       writer_type: p.writer_type || "columnist",
       specialties: p.specialties || { sports: [], leagues: [], teams: [] },
       max_articles: p.max_articles ?? 2,
+      avatar_url: p.avatar_url || "",
+      specialty_tags: p.specialty_tags?.join(", ") || "",
     });
     setTeamInput("");
     setTimeout(() => window.scrollTo({ top: 0, behavior: "smooth" }), 50);

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
     const supabase = createServiceClient();
 
     // Run all queries concurrently
-    const [topArticlesResult, allArticlesResult] = await Promise.all([
+    const [topArticlesResult, allArticlesResult, likesResult] = await Promise.all([
       // Top 10 articles by view count
       supabase
         .from("generated_articles")
@@ -19,7 +19,13 @@ export async function GET() {
       // All published articles for aggregation (views by day, by category)
       supabase
         .from("generated_articles")
-        .select("id, category, view_count, published_at")
+        .select("id, category, view_count, published_at, content, like_count")
+        .eq("status", "published"),
+
+      // Total likes count (fallback if like_count column exists)
+      supabase
+        .from("generated_articles")
+        .select("id, like_count")
         .eq("status", "published"),
     ]);
 
@@ -85,6 +91,31 @@ export async function GET() {
     );
     const totalArticles = allArticles.length;
 
+    // Quality stats
+    let avgLength = 0;
+    let avgLikes = 0;
+    const categoryCount: Record<string, number> = {};
+
+    if (allArticles.length > 0) {
+      let totalLength = 0;
+      let totalLikes = 0;
+      for (const article of allArticles) {
+        totalLength += (article.content?.length ?? 0);
+        totalLikes += (article.like_count ?? 0);
+        const cat = article.category || "未分類";
+        categoryCount[cat] = (categoryCount[cat] || 0) + 1;
+      }
+      avgLength = Math.round(totalLength / allArticles.length);
+      avgLikes = totalLikes / allArticles.length;
+    }
+
+    // Suppress lint warning for unused likesResult (used as fallback query)
+    void likesResult;
+
+    const categoryDistribution = Object.entries(categoryCount)
+      .map(([category, count]) => ({ category, count }))
+      .sort((a, b) => b.count - a.count);
+
     return NextResponse.json({
       top_articles: topArticlesResult.data || [],
       views_by_day: viewsByDayArray,
@@ -92,6 +123,11 @@ export async function GET() {
       totals: {
         total_views: totalViews,
         total_articles: totalArticles,
+      },
+      quality: {
+        avg_length: avgLength,
+        avg_likes: avgLikes,
+        category_distribution: categoryDistribution,
       },
     });
   } catch (err) {

--- a/src/app/api/articles/generated/route.ts
+++ b/src/app/api/articles/generated/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
 
   const { page, limit, offset } = parsePagination(searchParams);
   const status = searchParams.get("status");
+  const category = searchParams.get("category");
 
   let query = supabase
     .from("generated_articles")
@@ -20,6 +21,10 @@ export async function GET(request: NextRequest) {
     query = query.eq("status", "draft").not("scheduled_at", "is", null);
   } else if (status) {
     query = query.eq("status", status);
+  }
+
+  if (category) {
+    query = query.eq("category", category);
   }
 
   const { data, count, error } = await query;

--- a/src/app/api/member/bookmarks/route.ts
+++ b/src/app/api/member/bookmarks/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { createServiceClient } from "@/lib/supabase";
+
+/**
+ * Bookmarks API
+ * GET:    查詢會員的收藏列表 (可選 ?article_id=xxx 查詢是否已收藏)
+ * POST:   新增收藏 { article_id }
+ * DELETE:  取消收藏 { article_id }
+ */
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.memberId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createServiceClient();
+    const { searchParams } = request.nextUrl;
+    const articleId = searchParams.get("article_id");
+
+    if (articleId) {
+      // Check if specific article is bookmarked
+      const { data } = await supabase
+        .from("article_bookmarks")
+        .select("id")
+        .eq("member_id", session.user.memberId)
+        .eq("article_id", articleId)
+        .maybeSingle();
+
+      return NextResponse.json({ bookmarked: !!data });
+    }
+
+    // Get all bookmarks
+    const { data, error } = await supabase
+      .from("article_bookmarks")
+      .select("article_id, created_at, generated_articles(id, title, slug, category, published_at)")
+      .eq("member_id", session.user.memberId)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      bookmarks: (data || []).map((b) => ({
+        article_id: b.article_id,
+        created_at: b.created_at,
+        article: b.generated_articles,
+      })),
+    });
+  } catch (err) {
+    console.error("[Bookmarks] GET error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.memberId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { article_id } = await request.json();
+    if (!article_id) {
+      return NextResponse.json({ error: "Missing article_id" }, { status: 400 });
+    }
+
+    const supabase = createServiceClient();
+
+    const { error } = await supabase
+      .from("article_bookmarks")
+      .upsert(
+        { member_id: session.user.memberId, article_id },
+        { onConflict: "member_id,article_id" }
+      );
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ bookmarked: true });
+  } catch (err) {
+    console.error("[Bookmarks] POST error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session?.user?.memberId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { article_id } = await request.json();
+    if (!article_id) {
+      return NextResponse.json({ error: "Missing article_id" }, { status: 400 });
+    }
+
+    const supabase = createServiceClient();
+
+    const { error } = await supabase
+      .from("article_bookmarks")
+      .delete()
+      .eq("member_id", session.user.memberId)
+      .eq("article_id", article_id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ bookmarked: false });
+  } catch (err) {
+    console.error("[Bookmarks] DELETE error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/app/api/member/game/route.ts
+++ b/src/app/api/member/game/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { fetchPlayByPlay, fetchBoxScore, fetchLeaders } from "@/lib/espn/play-by-play";
+import {
+  fetchPlayByPlay,
+  fetchBoxScore,
+  fetchLeaders,
+  fetchInjuries,
+  fetchWinProbability,
+  fetchSeasonSeries,
+  fetchPickCenter,
+} from "@/lib/espn/play-by-play";
 import { fetchOdds } from "@/lib/espn/odds";
 
 /**
@@ -9,6 +17,10 @@ import { fetchOdds } from "@/lib/espn/odds";
  * - odds → 完整賠率（3 線）
  * - boxscore → Box Score 資料
  * - leaders → 本場最佳球員
+ * - injuries → 傷兵名單
+ * - winprobability → 勝率走勢
+ * - seasonseries → 歷史交手
+ * - pickcenter → 專家預測
  */
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -19,7 +31,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const eventId = searchParams.get("eventId");
   const league = searchParams.get("league") || "nba";
-  const type = searchParams.get("type"); // "plays" | "odds" | "boxscore" | "leaders"
+  const type = searchParams.get("type");
 
   if (!eventId) {
     return NextResponse.json({ error: "eventId required" }, { status: 400 });
@@ -44,6 +56,26 @@ export async function GET(request: NextRequest) {
     if (type === "leaders") {
       const leaders = await fetchLeaders(league, eventId);
       return NextResponse.json({ leaders });
+    }
+
+    if (type === "injuries") {
+      const injuries = await fetchInjuries(league, eventId);
+      return NextResponse.json({ injuries });
+    }
+
+    if (type === "winprobability") {
+      const winprobability = await fetchWinProbability(league, league, eventId);
+      return NextResponse.json({ winprobability });
+    }
+
+    if (type === "seasonseries") {
+      const seasonseries = await fetchSeasonSeries(league, eventId);
+      return NextResponse.json({ seasonseries });
+    }
+
+    if (type === "pickcenter") {
+      const pickcenter = await fetchPickCenter(league, eventId);
+      return NextResponse.json({ pickcenter });
     }
 
     return NextResponse.json({ error: "Invalid type" }, { status: 400 });

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,0 +1,119 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl;
+    const title = searchParams.get("title") || "小豪哥體育資訊網";
+    const subtitle = searchParams.get("subtitle") || "";
+    const type = searchParams.get("type") || "article";
+
+    // Choose accent color based on type
+    const accentColor =
+      type === "game"
+        ? "#f97316"
+        : type === "team"
+          ? "#3b82f6"
+          : "#8b5cf6";
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            padding: "60px",
+            background: "linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
+            fontFamily: "sans-serif",
+          }}
+        >
+          {/* Top accent bar */}
+          <div
+            style={{
+              width: "80px",
+              height: "6px",
+              background: accentColor,
+              borderRadius: "3px",
+              display: "flex",
+            }}
+          />
+
+          {/* Main content */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "16px",
+              flex: 1,
+              justifyContent: "center",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "56px",
+                fontWeight: 700,
+                color: "#ffffff",
+                lineHeight: 1.2,
+                display: "flex",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {title.length > 40 ? title.slice(0, 40) + "..." : title}
+            </div>
+            {subtitle && (
+              <div
+                style={{
+                  fontSize: "28px",
+                  color: "#94a3b8",
+                  display: "flex",
+                }}
+              >
+                {subtitle}
+              </div>
+            )}
+          </div>
+
+          {/* Bottom branding */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "24px",
+                color: "#64748b",
+                display: "flex",
+              }}
+            >
+              小豪哥體育資訊網
+            </div>
+            <div
+              style={{
+                fontSize: "18px",
+                color: "#475569",
+                display: "flex",
+              }}
+            >
+              howger-sport.com
+            </div>
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      }
+    );
+  } catch {
+    return new Response("Failed to generate OG image", { status: 500 });
+  }
+}

--- a/src/app/api/public/articles/trending/route.ts
+++ b/src/app/api/public/articles/trending/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+
+export const revalidate = 300; // 5 minutes
+
+export async function GET() {
+  try {
+    const supabase = createServiceClient();
+
+    const { data: articles, error } = await supabase
+      .from("generated_articles")
+      .select("id, title, slug, category, view_count, published_at")
+      .eq("status", "published")
+      .order("view_count", { ascending: false })
+      .limit(5);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ articles: articles ?? [] });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Internal error: ${err}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/public/game/route.ts
+++ b/src/app/api/public/game/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchPlayByPlayPreview, fetchBoxScore, fetchLeaders } from "@/lib/espn/play-by-play";
+import {
+  fetchPlayByPlayPreview,
+  fetchBoxScore,
+  fetchLeaders,
+  fetchInjuries,
+  fetchWinProbability,
+  fetchSeasonSeries,
+  fetchPickCenter,
+} from "@/lib/espn/play-by-play";
 import { fetchOddsPreview } from "@/lib/espn/odds";
 
 /**
@@ -8,12 +16,16 @@ import { fetchOddsPreview } from "@/lib/espn/odds";
  * - odds → 僅 Spread
  * - boxscore → Box Score 資料
  * - leaders → 本場最佳球員
+ * - injuries → 傷兵名單
+ * - winprobability → 勝率走勢
+ * - seasonseries → 歷史交手
+ * - pickcenter → 專家預測
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const eventId = searchParams.get("eventId");
   const league = searchParams.get("league") || "nba";
-  const type = searchParams.get("type"); // "plays" | "odds" | "boxscore" | "leaders"
+  const type = searchParams.get("type");
 
   if (!eventId) {
     return NextResponse.json({ error: "eventId required" }, { status: 400 });
@@ -38,6 +50,26 @@ export async function GET(request: NextRequest) {
     if (type === "leaders") {
       const leaders = await fetchLeaders(league, eventId);
       return NextResponse.json({ leaders });
+    }
+
+    if (type === "injuries") {
+      const injuries = await fetchInjuries(league, eventId);
+      return NextResponse.json({ injuries });
+    }
+
+    if (type === "winprobability") {
+      const winprobability = await fetchWinProbability(league, league, eventId);
+      return NextResponse.json({ winprobability });
+    }
+
+    if (type === "seasonseries") {
+      const seasonseries = await fetchSeasonSeries(league, eventId);
+      return NextResponse.json({ seasonseries });
+    }
+
+    if (type === "pickcenter") {
+      const pickcenter = await fetchPickCenter(league, eventId);
+      return NextResponse.json({ pickcenter });
     }
 
     return NextResponse.json({ error: "Invalid type" }, { status: 400 });

--- a/src/app/api/public/player/route.ts
+++ b/src/app/api/public/player/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSportPath } from "@/lib/espn/client";
+import { fetchPlayerGameLog } from "@/lib/espn/player";
 
 const ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports";
 
 export async function GET(request: NextRequest) {
   const sport = request.nextUrl.searchParams.get("sport") || "nba";
   const id = request.nextUrl.searchParams.get("id");
+  const type = request.nextUrl.searchParams.get("type");
 
   if (!id) {
     return NextResponse.json({ error: "id required" }, { status: 400 });
@@ -14,6 +16,11 @@ export async function GET(request: NextRequest) {
   const sportPath = getSportPath(sport);
 
   try {
+    if (type === "gamelog") {
+      const gamelog = await fetchPlayerGameLog(sport, sport, id);
+      return NextResponse.json({ gamelog });
+    }
+
     // Try fetching athlete from the athletes endpoint
     const res = await fetch(`${ESPN_BASE}/${sportPath}/athletes/${id}`, {
       next: { revalidate: 600 },

--- a/src/app/api/public/search/route.ts
+++ b/src/app/api/public/search/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+
+export async function GET(request: NextRequest) {
+  try {
+    const q = request.nextUrl.searchParams.get("q")?.trim();
+
+    if (!q) {
+      return NextResponse.json({ articles: [] });
+    }
+
+    const supabase = createServiceClient();
+    const keyword = `%${q}%`;
+
+    const { data: articles, error } = await supabase
+      .from("generated_articles")
+      .select("id, title, slug, category, published_at, images")
+      .eq("status", "published")
+      .or(`title.ilike.${keyword},content.ilike.${keyword}`)
+      .order("published_at", { ascending: false })
+      .limit(10);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ articles: articles ?? [] });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Internal error: ${err}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/public/tags/route.ts
+++ b/src/app/api/public/tags/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+
+/**
+ * Tags API
+ * GET ?article_id=xxx  - 查詢文章的標籤
+ * GET ?tag_name=xxx    - 查詢使用此標籤的文章
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = createServiceClient();
+    const { searchParams } = request.nextUrl;
+    const articleId = searchParams.get("article_id");
+    const tagName = searchParams.get("tag_name");
+
+    if (articleId) {
+      // Get tags for a specific article
+      const { data, error } = await supabase
+        .from("article_tags")
+        .select("tag_name")
+        .eq("article_id", articleId)
+        .order("created_at", { ascending: true });
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      return NextResponse.json({
+        tags: (data || []).map((t) => t.tag_name),
+      });
+    }
+
+    if (tagName) {
+      // Get articles with a specific tag
+      const { data, error } = await supabase
+        .from("article_tags")
+        .select("article_id, generated_articles(id, title, slug, category, published_at)")
+        .eq("tag_name", tagName)
+        .order("created_at", { ascending: false })
+        .limit(50);
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+
+      return NextResponse.json({
+        tag: tagName,
+        articles: (data || []).map((t) => t.generated_articles).filter(Boolean),
+      });
+    }
+
+    return NextResponse.json(
+      { error: "Missing article_id or tag_name parameter" },
+      { status: 400 }
+    );
+  } catch (err) {
+    console.error("[Tags API] Error:", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/app/api/public/team/route.ts
+++ b/src/app/api/public/team/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSportPath } from "@/lib/espn/client";
+import { fetchTeamATS } from "@/lib/espn/team";
 
 const ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports";
 
 export async function GET(request: NextRequest) {
   const sport = request.nextUrl.searchParams.get("sport") || "nba";
   const id = request.nextUrl.searchParams.get("id");
-  const type = request.nextUrl.searchParams.get("type"); // "roster" or default
+  const type = request.nextUrl.searchParams.get("type"); // "roster" | "ats" | default
 
   if (!id) {
     return NextResponse.json({ error: "id required" }, { status: 400 });
@@ -35,6 +36,11 @@ export async function GET(request: NextRequest) {
       /* eslint-enable @typescript-eslint/no-explicit-any */
 
       return NextResponse.json({ roster });
+    }
+
+    if (type === "ats") {
+      const ats = await fetchTeamATS(sport, id);
+      return NextResponse.json({ ats });
     }
 
     // Default: team info

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,11 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
+  --color-brand-muted: var(--brand-muted);
+  --color-live: var(--live);
+  --color-live-muted: var(--live-muted);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -49,71 +54,85 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  /* Brand: Deep navy blue */
+  --brand: oklch(0.35 0.12 255);
+  --brand-foreground: oklch(0.98 0 0);
+  --brand-muted: oklch(0.92 0.03 255);
+  /* Live/accent: Warm amber */
+  --live: oklch(0.65 0.2 30);
+  --live-muted: oklch(0.92 0.05 30);
+
+  --background: oklch(0.98 0.002 260);
+  --foreground: oklch(0.15 0.01 260);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.15 0.01 260);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.15 0.01 260);
+  --primary: oklch(0.35 0.12 255);
+  --primary-foreground: oklch(0.98 0 0);
+  --secondary: oklch(0.96 0.005 260);
+  --secondary-foreground: oklch(0.2 0.01 260);
+  --muted: oklch(0.96 0.005 260);
+  --muted-foreground: oklch(0.5 0.01 260);
+  --accent: oklch(0.96 0.005 260);
+  --accent-foreground: oklch(0.2 0.01 260);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
+  --border: oklch(0.9 0.005 260);
+  --input: oklch(0.9 0.005 260);
+  --ring: oklch(0.45 0.12 255);
+  --chart-1: oklch(0.35 0.12 255);
   --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-3: oklch(0.65 0.2 30);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.97 0.005 260);
+  --sidebar-foreground: oklch(0.15 0.01 260);
+  --sidebar-primary: oklch(0.35 0.12 255);
+  --sidebar-primary-foreground: oklch(0.98 0 0);
+  --sidebar-accent: oklch(0.94 0.01 260);
+  --sidebar-accent-foreground: oklch(0.2 0.01 260);
+  --sidebar-border: oklch(0.9 0.005 260);
+  --sidebar-ring: oklch(0.45 0.12 255);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --brand: oklch(0.65 0.15 255);
+  --brand-foreground: oklch(0.98 0 0);
+  --brand-muted: oklch(0.25 0.05 255);
+  --live: oklch(0.7 0.2 30);
+  --live-muted: oklch(0.25 0.08 30);
+
+  --background: oklch(0.13 0.015 260);
+  --foreground: oklch(0.93 0.005 260);
+  --card: oklch(0.17 0.015 260);
+  --card-foreground: oklch(0.93 0.005 260);
+  --popover: oklch(0.17 0.015 260);
+  --popover-foreground: oklch(0.93 0.005 260);
+  --primary: oklch(0.65 0.15 255);
+  --primary-foreground: oklch(0.98 0 0);
+  --secondary: oklch(0.22 0.015 260);
+  --secondary-foreground: oklch(0.93 0.005 260);
+  --muted: oklch(0.22 0.015 260);
+  --muted-foreground: oklch(0.6 0.01 260);
+  --accent: oklch(0.22 0.015 260);
+  --accent-foreground: oklch(0.93 0.005 260);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
+  --border: oklch(0.28 0.015 260);
+  --input: oklch(0.28 0.015 260);
+  --ring: oklch(0.55 0.12 255);
+  --chart-1: oklch(0.55 0.2 255);
   --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-3: oklch(0.7 0.2 30);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.15 0.015 260);
+  --sidebar-foreground: oklch(0.93 0.005 260);
+  --sidebar-primary: oklch(0.55 0.2 255);
+  --sidebar-primary-foreground: oklch(0.98 0 0);
+  --sidebar-accent: oklch(0.22 0.015 260);
+  --sidebar-accent-foreground: oklch(0.93 0.005 260);
+  --sidebar-border: oklch(0.28 0.015 260);
+  --sidebar-ring: oklch(0.55 0.12 255);
 }
 
 @layer base {
@@ -125,10 +144,6 @@
   }
 }
 
-html {
-  background-color: white;
-}
-
 /* Hide scrollbar but keep scroll functionality */
 @layer utilities {
   .scrollbar-hide {
@@ -138,4 +153,28 @@ html {
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
+}
+
+/* LIVE blink animation */
+@keyframes live-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+.animate-live-blink {
+  animation: live-blink 1.2s ease-in-out infinite;
+}
+
+/* Card fade-in animation */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.animate-fade-in-up {
+  animation: fade-in-up 0.3s ease-out both;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeProvider } from "next-themes";
 import { SessionProvider } from "@/components/auth/SessionProvider";
 import "./globals.css";
 
@@ -17,7 +18,10 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#ffffff",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#1e3a5f" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f172a" },
+  ],
 };
 
 export const metadata: Metadata = {
@@ -50,11 +54,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="zh-TW" className="bg-white">
+    <html lang="zh-TW" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <SessionProvider>{children}</SessionProvider>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <SessionProvider>{children}</SessionProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -28,6 +28,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 1,
   });
 
+  // Static pages
+  const staticPages = [
+    { path: "/scores", changeFrequency: "hourly" as const, priority: 0.9 },
+    { path: "/odds", changeFrequency: "hourly" as const, priority: 0.8 },
+    { path: "/standings/nba", changeFrequency: "daily" as const, priority: 0.7 },
+    { path: "/install", changeFrequency: "monthly" as const, priority: 0.3 },
+    { path: "/privacy", changeFrequency: "yearly" as const, priority: 0.2 },
+  ];
+
+  for (const page of staticPages) {
+    entries.push({
+      url: `${SITE_URL}${page.path}`,
+      lastModified: new Date(),
+      changeFrequency: page.changeFrequency,
+      priority: page.priority,
+    });
+  }
+
   // Category pages
   const categories = ["nba", "mlb", "soccer", "general"];
   for (const cat of categories) {

--- a/src/components/admin/ArticlesTable.tsx
+++ b/src/components/admin/ArticlesTable.tsx
@@ -15,13 +15,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_VARIANT } from "@/lib/constants";
+import { ARTICLE_STATUS_LABELS, ARTICLE_STATUS_VARIANT, CATEGORY_COLORS } from "@/lib/constants";
 
 export interface Article {
   id: string;
   title: string;
   content: string;
   status: string;
+  category: string | null;
   created_at: string;
   published_at: string | null;
   scheduled_at: string | null;
@@ -163,6 +164,7 @@ export function ArticlesTable({
                 />
               </TableHead>
               <TableHead>標題</TableHead>
+              <TableHead className="w-[80px] hidden md:table-cell">分類</TableHead>
               <TableHead className="w-[100px] hidden md:table-cell">寫手</TableHead>
               <TableHead className="w-[70px]">狀態</TableHead>
               <TableHead className="w-[150px] hidden lg:table-cell">建立時間</TableHead>
@@ -217,6 +219,15 @@ export function ArticlesTable({
                         )}
                       </div>
                     </div>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    {article.category ? (
+                      <span className={`inline-block px-2 py-0.5 text-xs font-medium ${CATEGORY_COLORS[article.category] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg"}`}>
+                        {article.category}
+                      </span>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
                   </TableCell>
                   <TableCell className="truncate hidden md:table-cell">
                     {article.writer_personas?.name || "-"}
@@ -303,6 +314,11 @@ export function ArticlesTable({
                       {statusLabel}
                     </Badge>
                   </div>
+                  {article.category && (
+                    <span className={`inline-block px-2 py-0.5 text-xs font-medium mt-1 ${CATEGORY_COLORS[article.category] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg"}`}>
+                      {article.category}
+                    </span>
+                  )}
                   {article.scheduled_at && (
                     <div className="text-blue-600 text-xs mt-1">
                       排程：{new Date(article.scheduled_at).toLocaleString("zh-TW")}

--- a/src/components/admin/personas/PersonaCard.tsx
+++ b/src/components/admin/personas/PersonaCard.tsx
@@ -24,6 +24,17 @@ export function PersonaCard({
       <CardHeader>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
+            {persona.avatar_url ? (
+              <img
+                src={persona.avatar_url}
+                alt={persona.name}
+                className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+              />
+            ) : (
+              <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-white text-sm font-bold flex-shrink-0">
+                {persona.name.charAt(0)}
+              </div>
+            )}
             <CardTitle className="text-lg">{persona.name}</CardTitle>
             <Badge variant="outline">
               {TYPE_LABELS[persona.writer_type] || persona.writer_type}
@@ -71,6 +82,15 @@ export function PersonaCard({
                 ))}
               </div>
             )}
+          </div>
+        )}
+
+        {persona.specialty_tags && persona.specialty_tags.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1">
+            <span className="text-xs text-gray-400 mr-1">專長:</span>
+            {persona.specialty_tags.map((tag) => (
+              <Badge key={tag} className="text-xs bg-purple-100 text-purple-800">{tag}</Badge>
+            ))}
           </div>
         )}
 

--- a/src/components/admin/personas/PersonaForm.tsx
+++ b/src/components/admin/personas/PersonaForm.tsx
@@ -123,6 +123,27 @@ export function PersonaForm({
           />
         </div>
 
+        <div className="grid md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>頭像 URL</Label>
+            <Input
+              value={form.avatar_url}
+              onChange={(e) => onFormChange((f) => ({ ...f, avatar_url: e.target.value }))}
+              placeholder="https://example.com/avatar.jpg（預留欄位）"
+            />
+            <p className="text-xs text-gray-400">目前僅 UI 預留，DB 欄位尚未建立</p>
+          </div>
+          <div className="space-y-2">
+            <Label>專長標籤</Label>
+            <Input
+              value={form.specialty_tags}
+              onChange={(e) => onFormChange((f) => ({ ...f, specialty_tags: e.target.value }))}
+              placeholder="逗號分隔，例如：數據分析, 戰術解讀, 球員評比"
+            />
+            <p className="text-xs text-gray-400">目前僅 UI 預留，DB 欄位尚未建立</p>
+          </div>
+        </div>
+
         <div className="space-y-2">
           <Label>寫作風格 Prompt</Label>
           <Textarea

--- a/src/components/admin/personas/types.ts
+++ b/src/components/admin/personas/types.ts
@@ -14,6 +14,8 @@ export interface Persona {
   specialties: Specialties;
   max_articles: number;
   created_at: string;
+  avatar_url?: string | null;
+  specialty_tags?: string[] | null;
 }
 
 export interface PersonaFormData {
@@ -24,6 +26,8 @@ export interface PersonaFormData {
   writer_type: string;
   specialties: Specialties;
   max_articles: number;
+  avatar_url: string;
+  specialty_tags: string;
 }
 
 export const SPORT_OPTIONS = ["籃球", "棒球", "美式足球", "足球", "冰球", "網球", "綜合"];
@@ -42,4 +46,6 @@ export const emptyForm: PersonaFormData = {
   writer_type: "columnist",
   specialties: { sports: [], leagues: [], teams: [] },
   max_articles: 2,
+  avatar_url: "",
+  specialty_tags: "",
 };

--- a/src/components/game/GameDetailClient.tsx
+++ b/src/components/game/GameDetailClient.tsx
@@ -8,6 +8,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { MemberGate } from "@/components/auth/MemberGate";
 import { ArrowLeft } from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
 
 interface Play {
   id: string;
@@ -79,6 +89,54 @@ interface TeamLeadersData {
   leaders: GameLeader[];
 }
 
+interface InjuryPlayer {
+  name: string;
+  status: string;
+  description: string;
+}
+
+interface TeamInjuriesData {
+  team: string;
+  teamLogo: string;
+  players: InjuryPlayer[];
+}
+
+interface WinProbPoint {
+  homeWinPct: number;
+  playId: string;
+  secondsLeft: number;
+}
+
+interface SeasonSeriesGame {
+  date: string;
+  homeTeam: string;
+  awayTeam: string;
+  homeScore: string;
+  awayScore: string;
+  status: string;
+}
+
+interface PickCenterItem {
+  provider: string;
+  details: string;
+  homeWinPct: number;
+  awayWinPct: number;
+}
+
+function getGameApiBase(isMember: boolean) {
+  return isMember ? "/api/member/game" : "/api/public/game";
+}
+
+/** Convert secondsLeft to game progress label (Q1-Q4 for NBA) */
+function formatGameProgress(secondsLeft: number, totalSeconds: number): string {
+  const elapsed = totalSeconds - secondsLeft;
+  const pct = (elapsed / totalSeconds) * 100;
+  if (pct <= 25) return "Q1";
+  if (pct <= 50) return "Q2";
+  if (pct <= 75) return "Q3";
+  return "Q4";
+}
+
 export function GameDetailClient({
   sport,
   eventId,
@@ -92,10 +150,15 @@ export function GameDetailClient({
   const [totalPlays, setTotalPlays] = useState(0);
   const [boxscore, setBoxscore] = useState<BoxScoreData | null>(null);
   const [leaders, setLeaders] = useState<TeamLeadersData[]>([]);
+  const [injuries, setInjuries] = useState<TeamInjuriesData[]>([]);
+  const [winProb, setWinProb] = useState<WinProbPoint[]>([]);
+  const [seasonSeries, setSeasonSeries] = useState<SeasonSeriesGame[]>([]);
+  const [pickCenter, setPickCenter] = useState<PickCenterItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState("summary");
 
   const isMember = !!session?.user;
+  const apiBase = getGameApiBase(isMember);
 
   // Fetch game info from scoreboard
   useEffect(() => {
@@ -111,51 +174,69 @@ export function GameDetailClient({
 
   // Fetch leaders on mount
   useEffect(() => {
-    const endpoint = isMember
-      ? `/api/member/game?eventId=${eventId}&league=${sport}&type=leaders`
-      : `/api/public/game?eventId=${eventId}&league=${sport}&type=leaders`;
-
-    fetch(endpoint)
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=leaders`)
       .then((r) => r.json())
       .then((d) => setLeaders(d.leaders ?? []))
       .catch(() => {});
-  }, [eventId, sport, isMember]);
+  }, [eventId, sport, apiBase]);
+
+  // Fetch win probability + season series + pick center on summary tab
+  useEffect(() => {
+    if (tab !== "summary") return;
+
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=winprobability`)
+      .then((r) => r.json())
+      .then((d) => setWinProb(d.winprobability ?? []))
+      .catch(() => {});
+
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=seasonseries`)
+      .then((r) => r.json())
+      .then((d) => setSeasonSeries(d.seasonseries ?? []))
+      .catch(() => {});
+
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=pickcenter`)
+      .then((r) => r.json())
+      .then((d) => setPickCenter(d.pickcenter ?? []))
+      .catch(() => {});
+  }, [tab, eventId, sport, apiBase]);
 
   // Fetch PBP when tab switches
   useEffect(() => {
     if (tab !== "pbp") return;
 
-    const endpoint = isMember
-      ? `/api/member/game?eventId=${eventId}&league=${sport}&type=plays`
-      : `/api/public/game?eventId=${eventId}&league=${sport}&type=plays`;
-
-    fetch(endpoint)
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=plays`)
       .then((r) => r.json())
       .then((d) => {
         setPlays(d.plays ?? []);
         setTotalPlays(d.totalCount ?? 0);
       })
       .catch(() => {});
-  }, [tab, eventId, sport, isMember]);
+  }, [tab, eventId, sport, apiBase]);
 
   // Fetch boxscore when tab switches
   useEffect(() => {
     if (tab !== "boxscore") return;
 
-    const endpoint = isMember
-      ? `/api/member/game?eventId=${eventId}&league=${sport}&type=boxscore`
-      : `/api/public/game?eventId=${eventId}&league=${sport}&type=boxscore`;
-
-    fetch(endpoint)
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=boxscore`)
       .then((r) => r.json())
       .then((d) => setBoxscore(d.boxscore ?? null))
       .catch(() => {});
-  }, [tab, eventId, sport, isMember]);
+  }, [tab, eventId, sport, apiBase]);
+
+  // Fetch injuries when tab switches
+  useEffect(() => {
+    if (tab !== "injuries") return;
+
+    fetch(`${apiBase}?eventId=${eventId}&league=${sport}&type=injuries`)
+      .then((r) => r.json())
+      .then((d) => setInjuries(d.injuries ?? []))
+      .catch(() => {});
+  }, [tab, eventId, sport, apiBase]);
 
   if (loading) {
     return (
       <div className="flex justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
     );
   }
@@ -163,8 +244,8 @@ export function GameDetailClient({
   if (!game) {
     return (
       <div className="text-center py-12">
-        <p className="text-slate-500">找不到此比賽</p>
-        <Link href="/scores" className="text-blue-600 text-sm mt-2 inline-block">
+        <p className="text-muted-foreground">找不到此比賽</p>
+        <Link href="/scores" className="text-primary text-sm mt-2 inline-block">
           返回比分頁
         </Link>
       </div>
@@ -175,14 +256,22 @@ export function GameDetailClient({
     game.status === "in_progress"
       ? "bg-green-100 text-green-700"
       : game.status === "final"
-        ? "bg-slate-100 text-slate-700"
+        ? "bg-muted text-muted-foreground"
         : "bg-blue-100 text-blue-700";
+
+  // Prepare win probability chart data
+  const maxSeconds = winProb.length > 0 ? Math.max(...winProb.map((p) => p.secondsLeft)) : 2880;
+  const chartData = winProb.map((p) => ({
+    ...p,
+    progress: formatGameProgress(p.secondsLeft, maxSeconds),
+    elapsed: maxSeconds - p.secondsLeft,
+  }));
 
   return (
     <div className="space-y-6">
       <Link
         href="/scores"
-        className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-blue-600"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-primary"
       >
         <ArrowLeft className="w-4 h-4" />
         返回比分
@@ -198,16 +287,16 @@ export function GameDetailClient({
               )}
               <p className="text-sm font-medium mt-1">{game.awayTeam.name}</p>
               {game.awayTeam.record && (
-                <p className="text-xs text-slate-400">{game.awayTeam.record}</p>
+                <p className="text-xs text-muted-foreground">{game.awayTeam.record}</p>
               )}
             </Link>
             <div className="text-center">
               <div className="flex items-center gap-3">
-                <span className="text-3xl font-bold text-slate-900">
+                <span className="text-3xl font-bold text-foreground tabular-nums">
                   {game.awayTeam.score}
                 </span>
-                <span className="text-slate-400 text-lg">-</span>
-                <span className="text-3xl font-bold text-slate-900">
+                <span className="text-muted-foreground text-lg">-</span>
+                <span className="text-3xl font-bold text-foreground tabular-nums">
                   {game.homeTeam.score}
                 </span>
               </div>
@@ -221,7 +310,7 @@ export function GameDetailClient({
               )}
               <p className="text-sm font-medium mt-1">{game.homeTeam.name}</p>
               {game.homeTeam.record && (
-                <p className="text-xs text-slate-400">{game.homeTeam.record}</p>
+                <p className="text-xs text-muted-foreground">{game.homeTeam.record}</p>
               )}
             </Link>
           </div>
@@ -230,13 +319,14 @@ export function GameDetailClient({
 
       {/* Tabs */}
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
+        <TabsList className="flex-wrap">
           <TabsTrigger value="summary">摘要</TabsTrigger>
           {game.status !== "scheduled" && (
             <TabsTrigger value="boxscore">數據</TabsTrigger>
           )}
           <TabsTrigger value="pbp">逐球紀錄</TabsTrigger>
           <TabsTrigger value="odds">賠率</TabsTrigger>
+          <TabsTrigger value="injuries">傷兵</TabsTrigger>
         </TabsList>
 
         {/* Summary */}
@@ -249,19 +339,73 @@ export function GameDetailClient({
               <CardContent>
                 <div className="grid grid-cols-3 text-center text-sm">
                   <div>
-                    <p className="text-3xl font-bold">{game.awayTeam.score}</p>
-                    <p className="text-slate-500">{game.awayTeam.abbreviation}</p>
+                    <p className="text-3xl font-bold tabular-nums">{game.awayTeam.score}</p>
+                    <p className="text-muted-foreground">{game.awayTeam.abbreviation}</p>
                   </div>
-                  <div className="flex items-center justify-center text-slate-400 text-lg">
+                  <div className="flex items-center justify-center text-muted-foreground text-lg">
                     VS
                   </div>
                   <div>
-                    <p className="text-3xl font-bold">{game.homeTeam.score}</p>
-                    <p className="text-slate-500">{game.homeTeam.abbreviation}</p>
+                    <p className="text-3xl font-bold tabular-nums">{game.homeTeam.score}</p>
+                    <p className="text-muted-foreground">{game.homeTeam.abbreviation}</p>
                   </div>
                 </div>
               </CardContent>
             </Card>
+
+            {/* Win Probability Chart */}
+            {chartData.length > 0 && game.status !== "scheduled" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">勝率走勢</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    主隊（{game.homeTeam.name}）勝率
+                  </p>
+                  <ResponsiveContainer width="100%" height={220}>
+                    <AreaChart data={chartData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                      <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                      <XAxis
+                        dataKey="elapsed"
+                        tickFormatter={(val: number) => {
+                          const pct = (val / maxSeconds) * 100;
+                          if (pct <= 1) return "開始";
+                          if (Math.abs(pct - 25) < 3) return "Q1";
+                          if (Math.abs(pct - 50) < 3) return "Q2";
+                          if (Math.abs(pct - 75) < 3) return "Q3";
+                          if (pct >= 97) return "Q4";
+                          return "";
+                        }}
+                        tick={{ fontSize: 11 }}
+                        className="text-muted-foreground"
+                      />
+                      <YAxis
+                        domain={[0, 100]}
+                        tick={{ fontSize: 11 }}
+                        tickFormatter={(val: number) => `${val}%`}
+                        className="text-muted-foreground"
+                      />
+                      <Tooltip
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any) => [`${Number(value).toFixed(1)}%`, "主隊勝率"]}
+                        labelFormatter={() => ""}
+                        contentStyle={{ fontSize: 12 }}
+                      />
+                      <ReferenceLine y={50} stroke="hsl(var(--muted-foreground))" strokeDasharray="4 4" />
+                      <Area
+                        type="monotone"
+                        dataKey="homeWinPct"
+                        stroke="hsl(var(--primary))"
+                        fill="hsl(var(--primary))"
+                        fillOpacity={0.15}
+                        strokeWidth={2}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+            )}
 
             {/* Leaders */}
             {leaders.length > 0 && game.status !== "scheduled" && (
@@ -277,15 +421,82 @@ export function GameDetailClient({
                           {team.logo && (
                             <img src={team.logo} alt="" className="w-5 h-5" />
                           )}
-                          <span className="text-sm font-medium text-slate-700">{team.teamName}</span>
+                          <span className="text-sm font-medium text-foreground">{team.teamName}</span>
                         </div>
                         <div className="space-y-1">
                           {team.leaders.slice(0, 3).map((l) => (
-                            <p key={l.category} className="text-xs text-slate-600">
-                              <span className="font-medium">{l.displayName}</span>
-                              <span className="text-slate-400 ml-1">{l.displayValue}</span>
+                            <p key={l.category} className="text-xs text-muted-foreground">
+                              <span className="font-medium text-foreground">{l.displayName}</span>
+                              <span className="ml-1">{l.displayValue}</span>
                             </p>
                           ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Season Series (Head-to-Head) */}
+            {seasonSeries.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">本季交手紀錄</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-2">
+                    {seasonSeries.map((g, idx) => (
+                      <div key={idx} className="flex items-center justify-between text-sm border-b border-border last:border-0 pb-2">
+                        <span className="text-muted-foreground text-xs">
+                          {g.date ? new Date(g.date).toLocaleDateString("zh-TW", { month: "short", day: "numeric" }) : "-"}
+                        </span>
+                        <span className="font-medium">
+                          {g.awayTeam} <span className="tabular-nums">{g.awayScore}</span>
+                        </span>
+                        <span className="text-muted-foreground">@</span>
+                        <span className="font-medium">
+                          {g.homeTeam} <span className="tabular-nums">{g.homeScore}</span>
+                        </span>
+                        <span className="text-xs text-muted-foreground">{g.status}</span>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Pick Center */}
+            {pickCenter.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">專家預測</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    {pickCenter.map((p, idx) => (
+                      <div key={idx} className="text-sm">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="text-muted-foreground">{p.provider || "ESPN"}</span>
+                          <span className="text-xs text-muted-foreground">{p.details}</span>
+                        </div>
+                        <div className="flex h-5 rounded-full overflow-hidden bg-muted">
+                          <div
+                            className="bg-red-500/80 flex items-center justify-center text-xs text-white font-medium"
+                            style={{ width: `${Math.max(p.awayWinPct * 100, 5)}%` }}
+                          >
+                            {(p.awayWinPct * 100).toFixed(0)}%
+                          </div>
+                          <div
+                            className="bg-blue-500/80 flex items-center justify-center text-xs text-white font-medium"
+                            style={{ width: `${Math.max(p.homeWinPct * 100, 5)}%` }}
+                          >
+                            {(p.homeWinPct * 100).toFixed(0)}%
+                          </div>
+                        </div>
+                        <div className="flex justify-between text-xs text-muted-foreground mt-0.5">
+                          <span>{game.awayTeam.abbreviation}</span>
+                          <span>{game.homeTeam.abbreviation}</span>
                         </div>
                       </div>
                     ))}
@@ -303,23 +514,23 @@ export function GameDetailClient({
                 <CardContent>
                   <div className="grid grid-cols-3 gap-4 text-center text-sm">
                     <div>
-                      <p className="font-medium text-slate-600">Spread</p>
-                      <p className="text-lg">{game.odds.details || "-"}</p>
+                      <p className="font-medium text-muted-foreground">Spread</p>
+                      <p className="text-lg tabular-nums">{game.odds.details || "-"}</p>
                     </div>
                     <div>
-                      <p className="font-medium text-slate-600">O/U</p>
-                      <p className="text-lg">{game.odds.overUnder || "-"}</p>
+                      <p className="font-medium text-muted-foreground">O/U</p>
+                      <p className="text-lg tabular-nums">{game.odds.overUnder || "-"}</p>
                     </div>
                     <MemberGate message="登入查看 Money Line">
                       <div>
-                        <p className="font-medium text-slate-600">ML</p>
-                        <p className="text-lg">
+                        <p className="font-medium text-muted-foreground">ML</p>
+                        <p className="text-lg tabular-nums">
                           {game.odds.awayMoneyLine} / {game.odds.homeMoneyLine}
                         </p>
                       </div>
                     </MemberGate>
                   </div>
-                  <p className="text-xs text-slate-400 mt-2 text-center">
+                  <p className="text-xs text-muted-foreground mt-2 text-center">
                     來源：{game.odds.provider}
                   </p>
                 </CardContent>
@@ -332,7 +543,7 @@ export function GameDetailClient({
         <TabsContent value="boxscore">
           {!boxscore ? (
             <Card>
-              <CardContent className="p-6 text-center text-slate-500">
+              <CardContent className="p-6 text-center text-muted-foreground">
                 暫無數據
               </CardContent>
             </Card>
@@ -347,21 +558,21 @@ export function GameDetailClient({
                   <CardContent>
                     <table className="w-full text-sm">
                       <thead>
-                        <tr className="border-b bg-slate-50">
-                          <th className="text-center py-2 px-2 font-medium text-slate-600 w-1/4">
+                        <tr className="border-b bg-muted">
+                          <th className="text-center py-2 px-2 font-medium text-muted-foreground w-1/4">
                             {boxscore.teams[0].teamName}
                           </th>
-                          <th className="text-center py-2 px-2 font-medium text-slate-600">項目</th>
-                          <th className="text-center py-2 px-2 font-medium text-slate-600 w-1/4">
+                          <th className="text-center py-2 px-2 font-medium text-muted-foreground">項目</th>
+                          <th className="text-center py-2 px-2 font-medium text-muted-foreground w-1/4">
                             {boxscore.teams[1].teamName}
                           </th>
                         </tr>
                       </thead>
                       <tbody>
                         {boxscore.teams[0].stats.map((stat, idx) => (
-                          <tr key={stat.label} className={idx % 2 === 0 ? "bg-white" : "bg-slate-50/50"}>
+                          <tr key={stat.label} className={idx % 2 === 0 ? "bg-card" : "bg-muted/50"}>
                             <td className="text-center py-1.5 px-2 tabular-nums">{stat.value}</td>
-                            <td className="text-center py-1.5 px-2 text-slate-500 text-xs">{stat.label}</td>
+                            <td className="text-center py-1.5 px-2 text-muted-foreground text-xs">{stat.label}</td>
                             <td className="text-center py-1.5 px-2 tabular-nums">
                               {boxscore.teams[1].stats[idx]?.value ?? "-"}
                             </td>
@@ -383,12 +594,12 @@ export function GameDetailClient({
                     <div className="overflow-x-auto">
                       <table className="w-full text-xs">
                         <thead>
-                          <tr className="border-b bg-slate-50">
-                            <th className="text-left py-2 px-2 font-medium text-slate-600 sticky left-0 bg-slate-50 min-w-[100px]">
+                          <tr className="border-b bg-muted">
+                            <th className="text-left py-2 px-2 font-medium text-muted-foreground sticky left-0 bg-muted min-w-[100px]">
                               球員
                             </th>
                             {group.labels.map((label) => (
-                              <th key={label} className="text-center py-2 px-1.5 font-medium text-slate-600 min-w-[36px]">
+                              <th key={label} className="text-center py-2 px-1.5 font-medium text-muted-foreground min-w-[36px]">
                                 {label}
                               </th>
                             ))}
@@ -398,7 +609,7 @@ export function GameDetailClient({
                           {/* Starters */}
                           {group.athletes.filter((a) => a.starter).length > 0 && (
                             <tr>
-                              <td colSpan={group.labels.length + 1} className="text-xs text-slate-400 font-medium px-2 py-1 bg-slate-100">
+                              <td colSpan={group.labels.length + 1} className="text-xs text-muted-foreground font-medium px-2 py-1 bg-muted/70">
                                 先發
                               </td>
                             </tr>
@@ -406,10 +617,10 @@ export function GameDetailClient({
                           {group.athletes
                             .filter((a) => a.starter)
                             .map((athlete) => (
-                              <tr key={athlete.name} className="border-b border-slate-100">
-                                <td className="py-1.5 px-2 sticky left-0 bg-white">
+                              <tr key={athlete.name} className="border-b border-border">
+                                <td className="py-1.5 px-2 sticky left-0 bg-card">
                                   <span className="font-medium">{athlete.name}</span>
-                                  <span className="text-slate-400 ml-1">{athlete.position}</span>
+                                  <span className="text-muted-foreground ml-1">{athlete.position}</span>
                                 </td>
                                 {athlete.stats.map((s, i) => (
                                   <td key={i} className="text-center py-1.5 px-1.5 tabular-nums">{s}</td>
@@ -419,7 +630,7 @@ export function GameDetailClient({
                           {/* Bench */}
                           {group.athletes.filter((a) => !a.starter).length > 0 && (
                             <tr>
-                              <td colSpan={group.labels.length + 1} className="text-xs text-slate-400 font-medium px-2 py-1 bg-slate-100">
+                              <td colSpan={group.labels.length + 1} className="text-xs text-muted-foreground font-medium px-2 py-1 bg-muted/70">
                                 替補
                               </td>
                             </tr>
@@ -427,10 +638,10 @@ export function GameDetailClient({
                           {group.athletes
                             .filter((a) => !a.starter)
                             .map((athlete) => (
-                              <tr key={athlete.name} className="border-b border-slate-100">
-                                <td className="py-1.5 px-2 sticky left-0 bg-white">
+                              <tr key={athlete.name} className="border-b border-border">
+                                <td className="py-1.5 px-2 sticky left-0 bg-card">
                                   <span className="font-medium">{athlete.name}</span>
-                                  <span className="text-slate-400 ml-1">{athlete.position}</span>
+                                  <span className="text-muted-foreground ml-1">{athlete.position}</span>
                                 </td>
                                 {athlete.stats.map((s, i) => (
                                   <td key={i} className="text-center py-1.5 px-1.5 tabular-nums">{s}</td>
@@ -451,7 +662,7 @@ export function GameDetailClient({
         <TabsContent value="pbp">
           {plays.length === 0 ? (
             <Card>
-              <CardContent className="p-6 text-center text-slate-500">
+              <CardContent className="p-6 text-center text-muted-foreground">
                 暫無逐球紀錄
               </CardContent>
             </Card>
@@ -461,16 +672,16 @@ export function GameDetailClient({
                 {plays.map((play) => (
                   <Card key={play.id}>
                     <CardContent className="p-3 flex items-start gap-3">
-                      <div className="text-xs text-slate-400 whitespace-nowrap pt-0.5">
+                      <div className="text-xs text-muted-foreground whitespace-nowrap pt-0.5">
                         {play.period} {play.clock}
                       </div>
                       <div className="flex-1">
                         <p
-                          className={`text-sm ${play.scoringPlay ? "font-medium text-green-700" : "text-slate-700"}`}
+                          className={`text-sm ${play.scoringPlay ? "font-medium text-green-700" : "text-foreground"}`}
                         >
                           {play.text}
                         </p>
-                        <p className="text-xs text-slate-400 mt-0.5">
+                        <p className="text-xs text-muted-foreground mt-0.5 tabular-nums">
                           {play.awayScore} - {play.homeScore}
                         </p>
                       </div>
@@ -501,22 +712,22 @@ export function GameDetailClient({
               <CardContent>
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b bg-slate-50">
-                      <th className="text-left py-2 px-3">項目</th>
-                      <th className="text-center py-2 px-3">數值</th>
+                    <tr className="border-b bg-muted">
+                      <th className="text-left py-2 px-3 text-muted-foreground">項目</th>
+                      <th className="text-center py-2 px-3 text-muted-foreground">數值</th>
                     </tr>
                   </thead>
                   <tbody>
                     <tr className="border-b">
-                      <td className="py-2 px-3 text-slate-600">Spread</td>
-                      <td className="text-center py-2 px-3">{game.odds.details}</td>
+                      <td className="py-2 px-3 text-muted-foreground">Spread</td>
+                      <td className="text-center py-2 px-3 tabular-nums">{game.odds.details}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="py-2 px-3 text-slate-600">Over/Under</td>
-                      <td className="text-center py-2 px-3">{game.odds.overUnder}</td>
+                      <td className="py-2 px-3 text-muted-foreground">Over/Under</td>
+                      <td className="text-center py-2 px-3 tabular-nums">{game.odds.overUnder}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="py-2 px-3 text-slate-600">來源</td>
+                      <td className="py-2 px-3 text-muted-foreground">來源</td>
                       <td className="text-center py-2 px-3">{game.odds.provider}</td>
                     </tr>
                   </tbody>
@@ -524,19 +735,19 @@ export function GameDetailClient({
                 <MemberGate message="登入查看完整 Money Line 賠率">
                   <table className="w-full text-sm mt-4">
                     <thead>
-                      <tr className="border-b bg-slate-50">
-                        <th className="text-left py-2 px-3">Money Line</th>
-                        <th className="text-center py-2 px-3">客隊</th>
-                        <th className="text-center py-2 px-3">主隊</th>
+                      <tr className="border-b bg-muted">
+                        <th className="text-left py-2 px-3 text-muted-foreground">Money Line</th>
+                        <th className="text-center py-2 px-3 text-muted-foreground">客隊</th>
+                        <th className="text-center py-2 px-3 text-muted-foreground">主隊</th>
                       </tr>
                     </thead>
                     <tbody>
                       <tr>
-                        <td className="py-2 px-3 text-slate-600">Close</td>
-                        <td className="text-center py-2 px-3 font-medium">
+                        <td className="py-2 px-3 text-muted-foreground">Close</td>
+                        <td className="text-center py-2 px-3 font-medium tabular-nums">
                           {game.odds.awayMoneyLine}
                         </td>
-                        <td className="text-center py-2 px-3 font-medium">
+                        <td className="text-center py-2 px-3 font-medium tabular-nums">
                           {game.odds.homeMoneyLine}
                         </td>
                       </tr>
@@ -547,10 +758,66 @@ export function GameDetailClient({
             </Card>
           ) : (
             <Card>
-              <CardContent className="p-6 text-center text-slate-500">
+              <CardContent className="p-6 text-center text-muted-foreground">
                 暫無賠率資料
               </CardContent>
             </Card>
+          )}
+        </TabsContent>
+
+        {/* Injuries */}
+        <TabsContent value="injuries">
+          {injuries.length === 0 ? (
+            <Card>
+              <CardContent className="p-6 text-center text-muted-foreground">
+                暫無傷兵資料
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {injuries.map((team) => (
+                <Card key={team.team}>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      {team.teamLogo && (
+                        <img src={team.teamLogo} alt="" className="w-5 h-5" />
+                      )}
+                      {team.team}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {team.players.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">無傷兵</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {team.players.map((p, idx) => (
+                          <div key={idx} className="flex items-start gap-3 border-b border-border last:border-0 pb-2">
+                            <div className="flex-1">
+                              <p className="text-sm font-medium text-foreground">{p.name}</p>
+                              {p.description && (
+                                <p className="text-xs text-muted-foreground">{p.description}</p>
+                              )}
+                            </div>
+                            <Badge
+                              variant="outline"
+                              className={
+                                p.status.toLowerCase().includes("out")
+                                  ? "border-red-300 text-red-600"
+                                  : p.status.toLowerCase().includes("day-to-day") || p.status.toLowerCase().includes("questionable")
+                                    ? "border-yellow-300 text-yellow-700"
+                                    : "border-border text-muted-foreground"
+                              }
+                            >
+                              {p.status}
+                            </Badge>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
           )}
         </TabsContent>
       </Tabs>

--- a/src/components/odds/OddsClient.tsx
+++ b/src/components/odds/OddsClient.tsx
@@ -16,6 +16,18 @@ interface GameOdds {
   awayMoneyLine: string;
 }
 
+interface OddsLine {
+  provider: string;
+  details: string;
+  overUnder: number;
+  spread: number;
+  homeMoneyLine: number;
+  awayMoneyLine: number;
+  homeSpreadOdds: number;
+  awaySpreadOdds: number;
+  homeFavorite: boolean;
+}
+
 interface Game {
   id: string;
   date: string;
@@ -62,6 +74,7 @@ export function OddsClient() {
   const { data: session } = useSession();
   const [league, setLeague] = useState("nba");
   const [games, setGames] = useState<Game[]>([]);
+  const [multiOdds, setMultiOdds] = useState<Record<string, OddsLine[]>>({});
   const [loading, setLoading] = useState(true);
 
   const isMember = !!session?.user;
@@ -74,6 +87,32 @@ export function OddsClient() {
       .catch(() => setGames([]))
       .finally(() => setLoading(false));
   }, [league]);
+
+  // Fetch multi-provider odds for members
+  useEffect(() => {
+    if (!isMember || games.length === 0) return;
+
+    const fetchAllOdds = async () => {
+      const results: Record<string, OddsLine[]> = {};
+      await Promise.all(
+        games.map(async (game) => {
+          try {
+            const res = await fetch(
+              `/api/member/game?eventId=${game.id}&league=${league}&type=odds`
+            );
+            if (res.ok) {
+              const d = await res.json();
+              results[game.id] = d.odds ?? [];
+            }
+          } catch {
+            // ignore per-game fetch errors
+          }
+        })
+      );
+      setMultiOdds(results);
+    };
+    fetchAllOdds();
+  }, [isMember, games, league]);
 
   return (
     <Tabs value={league} onValueChange={setLeague}>
@@ -89,74 +128,105 @@ export function OddsClient() {
         <TabsContent key={opt.value} value={opt.value}>
           {loading ? (
             <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
             </div>
           ) : games.length === 0 ? (
-            <p className="text-slate-500 text-center py-8">今日暫無賽事</p>
+            <p className="text-muted-foreground text-center py-8">今日暫無賽事</p>
           ) : (
             <div className="space-y-3 mt-4">
-              {games.map((game) => (
-                <Card key={game.id}>
-                  <CardContent className="p-4">
-                    {/* Game header */}
-                    <div className="flex items-center justify-between mb-3">
-                      <Link
-                        href={`/game/${league}/${game.id}`}
-                        className="flex items-center gap-2 hover:opacity-80"
-                      >
-                        {game.awayTeam.logo && (
-                          <img src={game.awayTeam.logo} alt="" className="w-6 h-6" />
-                        )}
-                        <span className="font-medium">{game.awayTeam.abbreviation}</span>
-                        <span className="text-slate-400">@</span>
-                        {game.homeTeam.logo && (
-                          <img src={game.homeTeam.logo} alt="" className="w-6 h-6" />
-                        )}
-                        <span className="font-medium">{game.homeTeam.abbreviation}</span>
-                      </Link>
-                      <span className="text-xs text-slate-500">{formatStatusDetail(game.statusDetail)}</span>
-                    </div>
+              {games.map((game) => {
+                const gameMultiOdds = multiOdds[game.id] ?? [];
+                const showMulti = isMember && gameMultiOdds.length > 1;
 
-                    {/* Odds table */}
-                    {game.odds ? (
-                      <div className="overflow-x-auto">
-                        <table className="w-full text-sm">
-                          <thead>
-                            <tr className="text-xs text-slate-500 border-b">
-                              <th className="text-left py-1">來源</th>
-                              <th className="text-center py-1">Spread</th>
-                              <th className="text-center py-1">O/U</th>
-                              {isMember && <th className="text-center py-1">ML</th>}
-                            </tr>
-                          </thead>
-                          <tbody>
-                            <tr className="border-b last:border-0">
-                              <td className="py-1.5 text-slate-600">{game.odds.provider}</td>
-                              <td className="text-center py-1.5">{game.odds.details}</td>
-                              <td className="text-center py-1.5">{game.odds.overUnder}</td>
-                              {isMember && (
-                                <td className="text-center py-1.5 text-xs">
-                                  {game.odds.awayMoneyLine} / {game.odds.homeMoneyLine}
-                                </td>
-                              )}
-                            </tr>
-                          </tbody>
-                        </table>
+                return (
+                  <Card key={game.id}>
+                    <CardContent className="p-4">
+                      {/* Game header */}
+                      <div className="flex items-center justify-between mb-3">
+                        <Link
+                          href={`/game/${league}/${game.id}`}
+                          className="flex items-center gap-2 hover:opacity-80"
+                        >
+                          {game.awayTeam.logo && (
+                            <img src={game.awayTeam.logo} alt="" className="w-6 h-6" />
+                          )}
+                          <span className="font-medium">{game.awayTeam.abbreviation}</span>
+                          <span className="text-muted-foreground">@</span>
+                          {game.homeTeam.logo && (
+                            <img src={game.homeTeam.logo} alt="" className="w-6 h-6" />
+                          )}
+                          <span className="font-medium">{game.homeTeam.abbreviation}</span>
+                        </Link>
+                        <span className="text-xs text-muted-foreground">{formatStatusDetail(game.statusDetail)}</span>
                       </div>
-                    ) : (
-                      <p className="text-sm text-slate-400">暫無賠率資料</p>
-                    )}
 
-                    {/* Lock hint for non-members */}
-                    {!isMember && game.odds && (
-                      <div className="mt-2 flex items-center gap-1 text-xs text-blue-600">
-                        <Lock className="w-3 h-3" />
-                        <span>登入查看 Money Line 賠率</span>
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              ))}
+                      {/* Multi-provider odds table (member) */}
+                      {showMulti ? (
+                        <div className="overflow-x-auto">
+                          <table className="w-full text-sm">
+                            <thead>
+                              <tr className="text-xs text-muted-foreground border-b">
+                                <th className="text-left py-1">來源</th>
+                                <th className="text-center py-1">Spread</th>
+                                <th className="text-center py-1">O/U</th>
+                                <th className="text-center py-1">ML (客)</th>
+                                <th className="text-center py-1">ML (主)</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {gameMultiOdds.map((odds, idx) => (
+                                <tr key={idx} className="border-b last:border-0">
+                                  <td className="py-1.5 text-muted-foreground">{odds.provider}</td>
+                                  <td className="text-center py-1.5 tabular-nums">{odds.details}</td>
+                                  <td className="text-center py-1.5 tabular-nums">{odds.overUnder}</td>
+                                  <td className="text-center py-1.5 tabular-nums text-xs">{odds.awayMoneyLine || "-"}</td>
+                                  <td className="text-center py-1.5 tabular-nums text-xs">{odds.homeMoneyLine || "-"}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      ) : game.odds ? (
+                        /* Single provider (visitor or single provider) */
+                        <div className="overflow-x-auto">
+                          <table className="w-full text-sm">
+                            <thead>
+                              <tr className="text-xs text-muted-foreground border-b">
+                                <th className="text-left py-1">來源</th>
+                                <th className="text-center py-1">Spread</th>
+                                <th className="text-center py-1">O/U</th>
+                                {isMember && <th className="text-center py-1">ML</th>}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr className="border-b last:border-0">
+                                <td className="py-1.5 text-muted-foreground">{game.odds.provider}</td>
+                                <td className="text-center py-1.5 tabular-nums">{game.odds.details}</td>
+                                <td className="text-center py-1.5 tabular-nums">{game.odds.overUnder}</td>
+                                {isMember && (
+                                  <td className="text-center py-1.5 text-xs tabular-nums">
+                                    {game.odds.awayMoneyLine} / {game.odds.homeMoneyLine}
+                                  </td>
+                                )}
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">暫無賠率資料</p>
+                      )}
+
+                      {/* Lock hint for non-members */}
+                      {!isMember && game.odds && (
+                        <div className="mt-2 flex items-center gap-1 text-xs text-primary">
+                          <Lock className="w-3 h-3" />
+                          <span>登入查看 Money Line 及多家賠率比較</span>
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+                );
+              })}
             </div>
           )}
         </TabsContent>

--- a/src/components/player/PlayerDetailClient.tsx
+++ b/src/components/player/PlayerDetailClient.tsx
@@ -32,6 +32,18 @@ interface PlayerStat {
   value: string;
 }
 
+interface GameLogEntry {
+  date: string;
+  opponent: string;
+  result: string;
+  stats: Record<string, string>;
+}
+
+interface PlayerGameLog {
+  labels: string[];
+  entries: GameLogEntry[];
+}
+
 export function PlayerDetailClient({
   sport,
   playerId,
@@ -41,7 +53,9 @@ export function PlayerDetailClient({
 }) {
   const [player, setPlayer] = useState<PlayerInfo | null>(null);
   const [stats, setStats] = useState<PlayerStat[]>([]);
+  const [gamelog, setGamelog] = useState<PlayerGameLog | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showGameLog, setShowGameLog] = useState(false);
 
   useEffect(() => {
     fetch(`/api/public/player?sport=${sport}&id=${playerId}`)
@@ -54,10 +68,20 @@ export function PlayerDetailClient({
       .finally(() => setLoading(false));
   }, [sport, playerId]);
 
+  // Fetch game log on demand
+  useEffect(() => {
+    if (!showGameLog || gamelog) return;
+
+    fetch(`/api/public/player?sport=${sport}&id=${playerId}&type=gamelog`)
+      .then((r) => r.json())
+      .then((d) => setGamelog(d.gamelog ?? { labels: [], entries: [] }))
+      .catch(() => setGamelog({ labels: [], entries: [] }));
+  }, [showGameLog, sport, playerId, gamelog]);
+
   if (loading) {
     return (
       <div className="flex justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
     );
   }
@@ -65,7 +89,7 @@ export function PlayerDetailClient({
   if (!player) {
     return (
       <div className="text-center py-12">
-        <p className="text-slate-500">找不到此球員</p>
+        <p className="text-muted-foreground">找不到此球員</p>
       </div>
     );
   }
@@ -75,7 +99,7 @@ export function PlayerDetailClient({
       {player.team && (
         <Link
           href={`/team/${sport}/${player.team.id}`}
-          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-blue-600"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-primary"
         >
           <ArrowLeft className="w-4 h-4" />
           返回 {player.team.displayName}
@@ -94,7 +118,7 @@ export function PlayerDetailClient({
               />
             )}
             <div className="flex-1">
-              <h1 className="text-2xl font-bold text-slate-900">
+              <h1 className="text-2xl font-bold text-foreground">
                 {player.displayName}
               </h1>
               <div className="flex items-center gap-2 mt-1 flex-wrap">
@@ -103,7 +127,7 @@ export function PlayerDetailClient({
                 {player.team && (
                   <Link
                     href={`/team/${sport}/${player.team.id}`}
-                    className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                    className="flex items-center gap-1 text-sm text-primary hover:underline"
                   >
                     {player.team.logo && (
                       <img src={player.team.logo} alt="" className="w-4 h-4" />
@@ -112,7 +136,7 @@ export function PlayerDetailClient({
                   </Link>
                 )}
               </div>
-              <div className="flex items-center gap-4 mt-2 text-sm text-slate-500">
+              <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
                 {player.height && <span>{player.height}</span>}
                 {player.weight && <span>{player.weight}</span>}
                 {player.age > 0 && <span>{player.age} 歲</span>}
@@ -136,15 +160,15 @@ export function PlayerDetailClient({
                 <div className="grid grid-cols-3 sm:grid-cols-5 gap-4">
                   {stats.slice(0, 3).map((s) => (
                     <div key={s.name} className="text-center">
-                      <p className="text-2xl font-bold text-slate-900">
+                      <p className="text-2xl font-bold text-foreground tabular-nums">
                         {s.value}
                       </p>
-                      <p className="text-xs text-slate-500">{s.displayName}</p>
+                      <p className="text-xs text-muted-foreground">{s.displayName}</p>
                     </div>
                   ))}
                   {stats.slice(3, 5).map((s) => (
                     <div key={s.name} className="text-center blur-sm">
-                      <p className="text-2xl font-bold">{s.value}</p>
+                      <p className="text-2xl font-bold tabular-nums">{s.value}</p>
                       <p className="text-xs">{s.displayName}</p>
                     </div>
                   ))}
@@ -163,10 +187,10 @@ export function PlayerDetailClient({
               <div className="grid grid-cols-3 sm:grid-cols-5 gap-4">
                 {stats.map((s) => (
                   <div key={s.name} className="text-center">
-                    <p className="text-2xl font-bold text-slate-900">
+                    <p className="text-2xl font-bold text-foreground tabular-nums">
                       {s.value}
                     </p>
-                    <p className="text-xs text-slate-500">{s.displayName}</p>
+                    <p className="text-xs text-muted-foreground">{s.displayName}</p>
                   </div>
                 ))}
               </div>
@@ -174,6 +198,79 @@ export function PlayerDetailClient({
           </Card>
         )}
       </MemberGate>
+
+      {/* Game Log */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">比賽紀錄</CardTitle>
+            {!showGameLog && (
+              <button
+                onClick={() => setShowGameLog(true)}
+                className="text-sm text-primary hover:underline"
+              >
+                載入 Game Log
+              </button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {!showGameLog ? (
+            <p className="p-6 text-muted-foreground text-center text-sm">
+              點擊上方按鈕載入比賽紀錄
+            </p>
+          ) : !gamelog ? (
+            <div className="flex justify-center py-6">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+            </div>
+          ) : gamelog.entries.length === 0 ? (
+            <p className="p-6 text-muted-foreground text-center text-sm">暫無比賽紀錄</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b bg-muted">
+                    <th className="text-left py-2 px-2 font-medium text-muted-foreground sticky left-0 bg-muted min-w-[80px]">
+                      日期
+                    </th>
+                    <th className="text-left py-2 px-2 font-medium text-muted-foreground min-w-[60px]">
+                      對手
+                    </th>
+                    <th className="text-center py-2 px-2 font-medium text-muted-foreground min-w-[36px]">
+                      結果
+                    </th>
+                    {gamelog.labels.map((label) => (
+                      <th key={label} className="text-center py-2 px-1.5 font-medium text-muted-foreground min-w-[36px]">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {gamelog.entries.map((entry, idx) => (
+                    <tr key={idx} className={`border-b border-border ${idx % 2 === 0 ? "bg-card" : "bg-muted/50"}`}>
+                      <td className="py-1.5 px-2 sticky left-0 bg-card text-muted-foreground whitespace-nowrap">
+                        {entry.date
+                          ? new Date(entry.date).toLocaleDateString("zh-TW", { month: "numeric", day: "numeric" })
+                          : "-"}
+                      </td>
+                      <td className="py-1.5 px-2 font-medium">{entry.opponent}</td>
+                      <td className={`text-center py-1.5 px-2 font-medium ${entry.result?.startsWith("W") ? "text-green-600" : entry.result?.startsWith("L") ? "text-red-500" : ""}`}>
+                        {entry.result || "-"}
+                      </td>
+                      {gamelog.labels.map((label) => (
+                        <td key={label} className="text-center py-1.5 px-1.5 tabular-nums">
+                          {entry.stats[label] ?? "-"}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/public/ArticleContent.tsx
+++ b/src/components/public/ArticleContent.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Components } from "react-markdown";
+
+function getYouTubeId(url: string): string | null {
+  const match = url.match(
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/
+  );
+  return match ? match[1] : null;
+}
+
+function isTwitterUrl(url: string): boolean {
+  return /^https?:\/\/(twitter\.com|x\.com)\//.test(url);
+}
+
+const markdownComponents: Components = {
+  h1: ({ children }) => (
+    <h1
+      id={String(children).toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "")}
+      className="text-2xl font-bold text-foreground mt-10 mb-4 scroll-mt-20"
+    >
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2
+      id={String(children).toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "")}
+      className="text-xl font-bold text-foreground mt-8 mb-3 scroll-mt-20"
+    >
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3
+      id={String(children).toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "")}
+      className="text-lg font-semibold text-foreground mt-6 mb-2 scroll-mt-20"
+    >
+      {children}
+    </h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="text-base font-semibold text-foreground mt-5 mb-2">
+      {children}
+    </h4>
+  ),
+  p: ({ children }) => (
+    <p className="text-foreground/90 leading-relaxed mb-4">{children}</p>
+  ),
+  a: ({ href, children }) => {
+    if (href) {
+      const youtubeId = getYouTubeId(href);
+      if (youtubeId) {
+        return (
+          <span className="block my-6">
+            <iframe
+              src={`https://www.youtube.com/embed/${youtubeId}`}
+              title={String(children) || "YouTube video"}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="w-full aspect-video rounded-lg"
+            />
+          </span>
+        );
+      }
+      if (isTwitterUrl(href)) {
+        return (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-muted rounded-lg text-sm text-foreground hover:bg-muted/80 transition-colors border border-border my-1"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+            </svg>
+            {children}
+          </a>
+        );
+      }
+    }
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 hover:text-blue-800 underline underline-offset-2 transition-colors"
+      >
+        {children}
+      </a>
+    );
+  },
+  img: ({ src, alt }) => (
+    <span className="block my-6">
+      <img
+        src={src}
+        alt={alt || ""}
+        className="rounded-lg max-w-full h-auto mx-auto"
+        loading="lazy"
+      />
+      {alt && (
+        <span className="block text-xs text-muted-foreground mt-2 text-center">
+          {alt}
+        </span>
+      )}
+    </span>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-4 border-blue-400 bg-blue-50/50 dark:bg-blue-950/20 pl-4 py-2 italic text-muted-foreground my-4">
+      {children}
+    </blockquote>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc list-inside space-y-1 mb-4 text-foreground/90">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal list-inside space-y-1 mb-4 text-foreground/90">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  table: ({ children }) => (
+    <div className="overflow-x-auto my-6">
+      <table className="w-full text-sm border-collapse border border-border">
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children }) => (
+    <thead className="bg-muted">{children}</thead>
+  ),
+  th: ({ children }) => (
+    <th className="border border-border px-3 py-2 text-left font-semibold text-foreground">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border border-border px-3 py-2 text-foreground/90">
+      {children}
+    </td>
+  ),
+  code: ({ children, className }) => {
+    const isBlock = className?.includes("language-");
+    if (isBlock) {
+      return (
+        <code className={`${className} block bg-muted rounded-lg p-4 overflow-x-auto text-sm my-4`}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code className="bg-muted rounded px-1.5 py-0.5 text-sm font-mono">
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => (
+    <pre className="bg-muted rounded-lg p-4 overflow-x-auto text-sm my-4">
+      {children}
+    </pre>
+  ),
+  hr: () => <hr className="border-border my-8" />,
+  strong: ({ children }) => (
+    <strong className="font-semibold text-foreground">{children}</strong>
+  ),
+};
+
+export function ArticleContent({ content }: { content: string }) {
+  return (
+    <div className="prose prose-lg max-w-none mb-12">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+/** Extract headings from markdown content for TOC */
+export function extractHeadings(
+  content: string
+): { id: string; text: string; level: number }[] {
+  const headings: { id: string; text: string; level: number }[] = [];
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const match = line.match(/^(#{1,3})\s+(.+)$/);
+    if (match) {
+      const level = match[1].length;
+      const text = match[2].replace(/[#*_\[\]()>`~]/g, "").trim();
+      const id = text.toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "");
+      headings.push({ id, text, level });
+    }
+  }
+  return headings;
+}

--- a/src/components/public/BookmarkButton.tsx
+++ b/src/components/public/BookmarkButton.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { LoginModal } from "@/components/auth/LoginModal";
+
+interface BookmarkButtonProps {
+  articleId: string;
+}
+
+export function BookmarkButton({ articleId }: BookmarkButtonProps) {
+  const { data: session } = useSession();
+  const [bookmarked, setBookmarked] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loginOpen, setLoginOpen] = useState(false);
+
+  const isMember = !!session?.user;
+
+  // Check bookmark status on mount
+  useEffect(() => {
+    if (!isMember) return;
+    fetch(`/api/member/bookmarks?article_id=${articleId}`)
+      .then((r) => r.json())
+      .then((d) => setBookmarked(d.bookmarked || false))
+      .catch(() => {});
+  }, [articleId, isMember]);
+
+  const handleToggle = async () => {
+    if (!isMember) {
+      setLoginOpen(true);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const method = bookmarked ? "DELETE" : "POST";
+      const res = await fetch("/api/member/bookmarks", {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ article_id: articleId }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setBookmarked(data.bookmarked);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleToggle}
+        disabled={loading}
+        className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 text-sm font-medium transition-all ${
+          bookmarked
+            ? "border-yellow-400 bg-yellow-50 text-yellow-700"
+            : "border-slate-300 bg-white text-slate-600 hover:border-slate-400 hover:text-slate-700"
+        } ${loading ? "opacity-50" : ""}`}
+        title={bookmarked ? "取消收藏" : "收藏文章"}
+      >
+        <svg
+          className="w-5 h-5"
+          fill={bookmarked ? "currentColor" : "none"}
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+          />
+        </svg>
+        {bookmarked ? "已收藏" : "收藏"}
+      </button>
+
+      <LoginModal open={loginOpen} onOpenChange={setLoginOpen} />
+    </>
+  );
+}

--- a/src/components/public/HeroSection.tsx
+++ b/src/components/public/HeroSection.tsx
@@ -31,20 +31,20 @@ export function HeroSection({
       <div className="hidden sm:grid grid-cols-3 gap-4">
         {/* Main hero */}
         <Link href={getHref(hero)} className="col-span-2 block group">
-          <article className="relative rounded-2xl bg-gradient-to-br from-slate-800 to-slate-700 text-white overflow-hidden h-full min-h-[320px] flex items-end active:scale-[0.99] transition-transform duration-150">
+          <article className="relative rounded-xl bg-gradient-to-br from-slate-800 to-slate-700 text-white overflow-hidden h-full min-h-[320px] flex items-end active:scale-[0.99] transition-transform duration-150">
             <img
               src={heroImage}
               alt=""
-              className="absolute inset-0 w-full h-full object-cover"
+              className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
             <div className="relative z-10 p-8">
               {hero.category && (
-                <span className="inline-block px-3 py-1 text-xs font-semibold rounded-full bg-blue-600 text-white mb-3">
+                <span className="inline-block px-3 py-1 text-xs font-semibold rounded-md bg-brand text-brand-foreground mb-3">
                   {hero.category}
                 </span>
               )}
-              <h1 className="text-2xl lg:text-3xl font-bold leading-tight mb-2 group-hover:text-blue-300 transition-colors">
+              <h1 className="text-3xl lg:text-4xl font-bold leading-tight mb-2 group-hover:text-blue-300 transition-colors">
                 {hero.title}
               </h1>
               <p className="text-gray-300 text-sm line-clamp-2 max-w-2xl mb-3">
@@ -69,12 +69,12 @@ export function HeroSection({
                   <img
                     src={thumb}
                     alt=""
-                    className="absolute inset-0 w-full h-full object-cover"
+                    className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
                   <div className="relative z-10 p-4">
                     {article.category && (
-                      <span className="inline-block px-2 py-0.5 text-[10px] font-semibold rounded-full bg-blue-600 text-white mb-2">
+                      <span className="inline-block px-2 py-0.5 text-[10px] font-semibold rounded-md bg-brand text-brand-foreground mb-2">
                         {article.category}
                       </span>
                     )}
@@ -95,7 +95,7 @@ export function HeroSection({
       {/* Mobile: hero full width + 2 small grid */}
       <div className="sm:hidden space-y-3">
         <Link href={getHref(hero)} className="block group">
-          <article className="relative rounded-2xl bg-slate-800 text-white overflow-hidden min-h-[200px] flex items-end active:scale-[0.99] transition-transform duration-150">
+          <article className="relative rounded-xl bg-slate-800 text-white overflow-hidden min-h-[200px] flex items-end active:scale-[0.99] transition-transform duration-150">
             <img
               src={heroImage}
               alt=""
@@ -104,7 +104,7 @@ export function HeroSection({
             <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
             <div className="relative z-10 p-5">
               {hero.category && (
-                <span className="inline-block px-2.5 py-0.5 text-xs font-semibold rounded-full bg-blue-600 text-white mb-2">
+                <span className="inline-block px-2.5 py-0.5 text-xs font-semibold rounded-md bg-brand text-brand-foreground mb-2">
                   {hero.category}
                 </span>
               )}
@@ -134,7 +134,7 @@ export function HeroSection({
                   <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
                   <div className="relative z-10 p-3">
                     {article.category && (
-                      <span className="inline-block px-2 py-0.5 text-[10px] font-semibold rounded-full bg-blue-600 text-white mb-1">
+                      <span className="inline-block px-2 py-0.5 text-[10px] font-semibold rounded-md bg-brand text-brand-foreground mb-1">
                         {article.category}
                       </span>
                     )}

--- a/src/components/public/HomeArticleSection.tsx
+++ b/src/components/public/HomeArticleSection.tsx
@@ -24,6 +24,7 @@ export function HomeArticleSection({
   articles: ArticleItem[];
 }) {
   const [activeCategory, setActiveCategory] = useState("all");
+  const [transitioning, setTransitioning] = useState(false);
 
   const filtered = useMemo(() => {
     if (activeCategory === "all") return articles;
@@ -32,31 +33,41 @@ export function HomeArticleSection({
 
   const showMoreLink = activeCategory !== "all" && filtered.length < 4;
 
+  function handleCategoryChange(cat: string) {
+    setTransitioning(true);
+    setTimeout(() => {
+      setActiveCategory(cat);
+      setTransitioning(false);
+    }, 150);
+  }
+
   return (
     <section className="mb-10">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-bold text-slate-900 border-l-4 border-blue-600 pl-3">
+        <h2 className="text-xl font-bold text-foreground border-l-4 border-brand pl-3">
           最新報導
         </h2>
       </div>
 
       <div className="mb-5">
-        <HomeCategoryFilter active={activeCategory} onChange={setActiveCategory} />
+        <HomeCategoryFilter active={activeCategory} onChange={handleCategoryChange} />
       </div>
 
-      {filtered.length === 0 ? (
-        <p className="text-slate-500 text-sm py-8 text-center">
-          此分類目前沒有文章
-        </p>
-      ) : (
-        <PersonalizedArticleGrid articles={filtered} />
-      )}
+      <div className={`transition-opacity duration-150 ${transitioning ? "opacity-0" : "opacity-100"}`}>
+        {filtered.length === 0 ? (
+          <p className="text-muted-foreground text-sm py-8 text-center">
+            此分類目前沒有文章
+          </p>
+        ) : (
+          <PersonalizedArticleGrid articles={filtered} />
+        )}
+      </div>
 
       {showMoreLink && (
         <div className="mt-4 text-center">
           <Link
             href={`/category/${getCategorySlug(activeCategory)}`}
-            className="text-sm text-blue-600 hover:underline"
+            className="text-sm text-brand hover:underline"
           >
             查看更多{activeCategory}文章 →
           </Link>

--- a/src/components/public/HomeCategoryFilter.tsx
+++ b/src/components/public/HomeCategoryFilter.tsx
@@ -23,8 +23,8 @@ export function HomeCategoryFilter({
           onClick={() => onChange(cat.key)}
           className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-colors duration-150 ${
             active === cat.key
-              ? "bg-blue-600 text-white"
-              : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+              ? "bg-brand text-brand-foreground"
+              : "bg-secondary text-muted-foreground hover:bg-accent hover:text-foreground"
           }`}
         >
           {cat.label}

--- a/src/components/public/LiveScoreTicker.tsx
+++ b/src/components/public/LiveScoreTicker.tsx
@@ -17,20 +17,23 @@ function TickerGameCard({ game, league }: { game: Game; league: string }) {
   return (
     <Link
       href={`/game/${league}/${game.id}`}
-      className="flex-shrink-0 w-[150px] rounded-lg border border-slate-200 bg-white p-2.5 hover:border-blue-300 hover:shadow-sm active:scale-[0.97] transition-all duration-150"
+      className={`flex-shrink-0 w-[150px] rounded-xl border bg-card p-2.5 hover:shadow-lg hover:scale-[1.03] active:scale-[0.97] transition-all duration-200 ${
+        isLive ? "border-live/40 ring-1 ring-live/20" : "border-border hover:border-brand/40"
+      }`}
     >
       {/* Status badge */}
       <div className="flex items-center justify-between mb-1.5">
         {isLive ? (
-          <span className="text-[10px] font-semibold text-red-600 bg-red-50 px-1.5 py-0.5 rounded animate-pulse">
+          <span className="flex items-center gap-1 text-[10px] font-bold text-live">
+            <span className="w-1.5 h-1.5 rounded-full bg-live animate-live-blink" />
             LIVE
           </span>
         ) : isFinal ? (
-          <span className="text-[10px] font-medium text-slate-500">
+          <span className="text-[10px] font-medium text-muted-foreground">
             終場
           </span>
         ) : (
-          <span className="text-[10px] text-slate-400">
+          <span className="text-[10px] text-muted-foreground">
             {new Date(game.date).toLocaleTimeString("zh-TW", {
               hour: "2-digit",
               minute: "2-digit",
@@ -45,11 +48,11 @@ function TickerGameCard({ game, league }: { game: Game; league: string }) {
           {game.awayTeam.logo && (
             <img src={game.awayTeam.logo} alt="" className="w-4 h-4 flex-shrink-0" />
           )}
-          <span className="truncate font-medium text-slate-700">
+          <span className="truncate font-medium text-foreground">
             {game.awayTeam.abbreviation}
           </span>
         </div>
-        <span className={`font-bold tabular-nums ${isLive ? "text-red-600" : "text-slate-900"}`}>
+        <span className={`font-bold tabular-nums ${isLive ? "text-live" : "text-foreground"}`}>
           {game.awayTeam.score}
         </span>
       </div>
@@ -60,11 +63,11 @@ function TickerGameCard({ game, league }: { game: Game; league: string }) {
           {game.homeTeam.logo && (
             <img src={game.homeTeam.logo} alt="" className="w-4 h-4 flex-shrink-0" />
           )}
-          <span className="truncate font-medium text-slate-700">
+          <span className="truncate font-medium text-foreground">
             {game.homeTeam.abbreviation}
           </span>
         </div>
-        <span className={`font-bold tabular-nums ${isLive ? "text-red-600" : "text-slate-900"}`}>
+        <span className={`font-bold tabular-nums ${isLive ? "text-live" : "text-foreground"}`}>
           {game.homeTeam.score}
         </span>
       </div>
@@ -138,8 +141,8 @@ export function LiveScoreTicker({ leagues }: { leagues: League[] }) {
   return (
     <section className="mb-6">
       <div className="flex items-center gap-2 mb-2">
-        <span className="text-sm font-semibold text-slate-700">即時比分</span>
-        <Link href="/scores" className="text-xs text-blue-600 hover:underline">
+        <span className="text-sm font-semibold text-foreground">即時比分</span>
+        <Link href="/scores" className="text-xs text-brand hover:underline">
           查看全部
         </Link>
       </div>
@@ -147,7 +150,7 @@ export function LiveScoreTicker({ leagues }: { leagues: League[] }) {
       {loading ? (
         <div className="flex gap-3 overflow-hidden">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="flex-shrink-0 w-[150px] h-[82px] rounded-lg bg-slate-100 animate-pulse" />
+            <div key={i} className="flex-shrink-0 w-[150px] h-[82px] rounded-xl bg-muted animate-pulse" />
           ))}
         </div>
       ) : (
@@ -158,7 +161,7 @@ export function LiveScoreTicker({ leagues }: { leagues: League[] }) {
             ))}
           </div>
           {/* 右側漸層遮罩提示可滾動 */}
-          <div className="absolute top-0 right-0 bottom-1 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none" />
+          <div className="absolute top-0 right-0 bottom-1 w-8 bg-gradient-to-l from-background to-transparent pointer-events-none" />
         </div>
       )}
     </section>

--- a/src/components/public/PersonalizedArticleGrid.tsx
+++ b/src/components/public/PersonalizedArticleGrid.tsx
@@ -24,6 +24,18 @@ interface ArticleItem {
   writerName: string | null;
 }
 
+function getExcerpt(content: string | null): string {
+  if (!content) return "";
+  const lines = content.split("\n").filter(Boolean);
+  const firstParagraph = lines.find(
+    (line) => !line.startsWith("#") && !line.startsWith("-") && !line.startsWith(">") && line.trim().length > 20
+  );
+  if (firstParagraph) {
+    return firstParagraph.replace(/[#*_\[\]()>`~]/g, "").trim().slice(0, 120);
+  }
+  return content.replace(/[#*_>\-\n\[\]()>`~]/g, " ").trim().slice(0, 120);
+}
+
 export function PersonalizedArticleGrid({
   articles,
 }: {
@@ -43,7 +55,6 @@ export function PersonalizedArticleGrid({
   const sortedArticles = useMemo(() => {
     if (favorites.length === 0) return articles;
     const favoriteNames = favorites.map((f) => f.name);
-    // Stable sort: favorites first
     return [...articles].sort((a, b) => {
       const aMatch = favoriteNames.some((name) => a.title.includes(name)) ? 1 : 0;
       const bMatch = favoriteNames.some((name) => b.title.includes(name)) ? 1 : 0;
@@ -57,9 +68,9 @@ export function PersonalizedArticleGrid({
   );
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-      {sortedArticles.map((article) => {
-        const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-slate-100 text-slate-600 border border-slate-300 rounded-lg";
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-5">
+      {sortedArticles.map((article, index) => {
+        const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-muted text-muted-foreground rounded-md";
         const thumbnail = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
         const isFavorite = favoriteNames.some((name) => article.title.includes(name));
 
@@ -67,15 +78,16 @@ export function PersonalizedArticleGrid({
           <Link
             key={article.id}
             href={`/news/${article.slug || article.id}`}
-            className="group block"
+            className="group block animate-fade-in-up"
+            style={{ animationDelay: `${Math.min(index, 11) * 50}ms` }}
           >
             {/* Desktop: vertical card */}
-            <article className="hidden sm:block h-full rounded-xl border border-slate-200 bg-white overflow-hidden hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
-              <div className="aspect-video bg-slate-100 relative">
+            <article className="hidden sm:block h-full rounded-xl border border-border bg-card overflow-hidden hover:shadow-lg hover:scale-[1.02] hover:border-brand/30 active:scale-[0.98] transition-all duration-200">
+              <div className="aspect-video bg-muted relative overflow-hidden">
                 <img
                   src={thumbnail}
                   alt=""
-                  className="w-full h-full object-cover"
+                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
                 />
                 {isFavorite && (
                   <span className="absolute top-2 right-2 bg-yellow-400 text-yellow-900 rounded-full p-1">
@@ -83,25 +95,25 @@ export function PersonalizedArticleGrid({
                   </span>
                 )}
               </div>
-              <div className="p-5">
-                <div className="flex items-center gap-2 mb-3">
+              <div className="p-4">
+                <div className="flex items-center gap-2 mb-2.5">
                   {article.category && (
-                    <span className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+                    <span className={`inline-block px-2 py-0.5 text-xs font-semibold ${colorClass}`}>
                       {article.category}
                     </span>
                   )}
-                  <span className="text-xs text-slate-400">
+                  <span className="text-xs text-muted-foreground">
                     {formatRelativeTime(article.published_at)}
                   </span>
                 </div>
-                <h3 className="text-base font-semibold text-slate-900 leading-snug mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors">
+                <h3 className="text-lg font-semibold text-card-foreground leading-snug mb-2 line-clamp-2 group-hover:text-brand transition-colors">
                   {article.title}
                 </h3>
-                <p className="text-sm text-slate-500 line-clamp-2 mb-3">
-                  {article.content?.replace(/[#*_>\-\n]/g, " ").slice(0, 120)}
+                <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+                  {getExcerpt(article.content)}
                 </p>
                 {article.writerName && (
-                  <div className="text-xs text-slate-400">
+                  <div className="text-xs text-muted-foreground">
                     <span>{article.writerName}</span>
                   </div>
                 )}
@@ -109,7 +121,7 @@ export function PersonalizedArticleGrid({
             </article>
 
             {/* Mobile: horizontal card */}
-            <article className="sm:hidden rounded-xl border border-slate-200 bg-white p-4 hover:shadow-md hover:border-blue-300 active:scale-[0.98] transition-all duration-150">
+            <article className="sm:hidden rounded-xl border border-border bg-card p-4 hover:shadow-md hover:border-brand/30 active:scale-[0.98] transition-all duration-200">
               <div className="flex items-start gap-3">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1.5">
@@ -117,19 +129,19 @@ export function PersonalizedArticleGrid({
                       <Star className="w-3 h-3 text-yellow-500 fill-yellow-400 flex-shrink-0" />
                     )}
                     {article.category && (
-                      <span className={`inline-block px-2 py-0.5 text-xs font-medium ${colorClass}`}>
+                      <span className={`inline-block px-2 py-0.5 text-xs font-semibold ${colorClass}`}>
                         {article.category}
                       </span>
                     )}
-                    <span className="text-xs text-slate-400">
+                    <span className="text-xs text-muted-foreground">
                       {formatRelativeTime(article.published_at)}
                     </span>
                   </div>
-                  <h3 className="text-sm font-semibold text-slate-900 leading-snug mb-1 line-clamp-2 group-hover:text-blue-600 transition-colors">
+                  <h3 className="text-sm font-semibold text-card-foreground leading-snug mb-1 line-clamp-2 group-hover:text-brand transition-colors">
                     {article.title}
                   </h3>
                   {article.writerName && (
-                    <div className="text-xs text-slate-400">
+                    <div className="text-xs text-muted-foreground">
                       <span>{article.writerName}</span>
                     </div>
                   )}
@@ -137,7 +149,7 @@ export function PersonalizedArticleGrid({
                 <img
                   src={thumbnail}
                   alt=""
-                  className="w-24 h-16 object-cover rounded-lg flex-shrink-0"
+                  className="w-28 h-20 object-cover rounded-lg flex-shrink-0"
                 />
               </div>
             </article>

--- a/src/components/public/PublicHeader.tsx
+++ b/src/components/public/PublicHeader.tsx
@@ -3,23 +3,51 @@
 import { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { Moon, Sun, Search, X } from "lucide-react";
+import { useTheme } from "next-themes";
 import { UserMenu } from "@/components/auth/UserMenu";
 
 const navLinks = [
-  { href: "/", label: "首頁" },
+  { href: "/", label: "首頁", exact: true },
   { href: "/scores", label: "即時比分" },
   { href: "/category/nba", label: "NBA" },
   { href: "/category/mlb", label: "MLB" },
   { href: "/category/soccer", label: "足球" },
   { href: "/category/general", label: "綜合" },
-  { href: "/standings/nba", label: "排名" },
+  { href: "/standings", label: "排名" },
   { href: "/odds", label: "賠率" },
 ];
 
 export function PublicHeader() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { theme, setTheme } = useTheme();
   const [logoHidden, setLogoHidden] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const lastScrollY = useRef(0);
   const ticking = useRef(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (searchOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [searchOpen]);
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = searchQuery.trim();
+    if (q) {
+      router.push(`/search?q=${encodeURIComponent(q)}`);
+      setSearchOpen(false);
+      setSearchQuery("");
+    }
+  };
 
   useEffect(() => {
     const container = document.getElementById("scroll-container");
@@ -33,12 +61,9 @@ export function PublicHeader() {
         const currentY = container.scrollTop;
         const delta = currentY - lastScrollY.current;
 
-        // 向下滾超過 10px → 隱藏 logo
         if (delta > 10 && currentY > 60) {
           setLogoHidden(true);
-        }
-        // 向上滾超過 10px → 顯示 logo
-        else if (delta < -10) {
+        } else if (delta < -10) {
           setLogoHidden(false);
         }
 
@@ -51,15 +76,20 @@ export function PublicHeader() {
     return () => container.removeEventListener("scroll", onScroll);
   }, []);
 
+  function isActive(link: { href: string; exact?: boolean }) {
+    if (link.exact) return pathname === link.href;
+    return pathname === link.href || pathname.startsWith(link.href + "/");
+  }
+
   return (
-    <header className="flex-shrink-0 bg-white/90 backdrop-blur-sm border-b border-slate-200 pt-[env(safe-area-inset-top)]">
-      {/* Row 1: Logo + UserMenu */}
+    <header className="flex-shrink-0 bg-background/90 backdrop-blur-sm border-b border-border pt-[env(safe-area-inset-top)]">
+      {/* Row 1: Logo + Theme Toggle + UserMenu */}
       <div
         className={`overflow-hidden transition-all duration-200 ease-in-out ${
           logoHidden ? "max-h-0 opacity-0" : "max-h-16 opacity-100"
         }`}
       >
-        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <div className="flex items-center justify-between h-12 sm:h-14">
             <Link href="/" className="flex items-center flex-shrink-0">
               <Image
@@ -71,27 +101,71 @@ export function PublicHeader() {
                 priority
               />
             </Link>
-            <UserMenu />
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => setSearchOpen(!searchOpen)}
+                className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                aria-label="搜尋"
+              >
+                {searchOpen ? <X className="w-4 h-4" /> : <Search className="w-4 h-4" />}
+              </button>
+              {mounted && (
+                <button
+                  onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                  aria-label="切換深色模式"
+                >
+                  {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+                </button>
+              )}
+              <UserMenu />
+            </div>
           </div>
         </div>
       </div>
 
+      {/* Search bar */}
+      {searchOpen && (
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-2">
+          <form onSubmit={handleSearchSubmit}>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="搜尋文章..."
+                className="w-full pl-9 pr-4 py-2 bg-muted border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              />
+            </div>
+          </form>
+        </div>
+      )}
+
       {/* Row 2: Nav tabs */}
-      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6">
         <div className="relative">
-          <nav className="flex items-center gap-1 overflow-x-auto scrollbar-hide pb-0.5">
-            {navLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className="px-3 py-2 text-sm font-medium text-slate-600 rounded-md hover:text-blue-600 hover:bg-blue-50 active:scale-[0.97] transition-all duration-150 whitespace-nowrap"
-              >
-                {link.label}
-              </Link>
-            ))}
+          <nav className="flex items-center gap-0.5 overflow-x-auto scrollbar-hide pb-0.5">
+            {navLinks.map((link) => {
+              const active = isActive(link);
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={`min-h-[44px] flex items-center px-3.5 py-2.5 text-sm font-medium rounded-md active:scale-[0.97] transition-all duration-150 whitespace-nowrap ${
+                    active
+                      ? "text-brand bg-brand-muted font-semibold"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent"
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
           </nav>
           {/* Mobile 右側漸層提示可滾動 */}
-          <div className="absolute top-0 right-0 bottom-0 w-6 bg-gradient-to-l from-white to-transparent pointer-events-none sm:hidden" />
+          <div className="absolute top-0 right-0 bottom-0 w-6 bg-gradient-to-l from-background to-transparent pointer-events-none sm:hidden" />
         </div>
       </div>
     </header>

--- a/src/components/public/QuickOdds.tsx
+++ b/src/components/public/QuickOdds.tsx
@@ -13,7 +13,6 @@ export function QuickOdds() {
       .then((r) => r.json())
       .then((d) => {
         const allGames: Game[] = d.games ?? [];
-        // Prefer scheduled or in-progress games
         const upcoming = allGames.filter((g) => g.status !== "final");
         const display = upcoming.length > 0 ? upcoming.slice(0, 3) : allGames.slice(0, 3);
         setGames(display);
@@ -23,10 +22,10 @@ export function QuickOdds() {
   }, []);
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-4">
+    <div className="rounded-xl border border-border bg-card p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-bold text-slate-900">今日賽事</h3>
-        <Link href="/odds" className="text-xs text-blue-600 hover:underline">
+        <h3 className="text-sm font-bold text-card-foreground">今日賽事</h3>
+        <Link href="/odds" className="text-xs text-brand hover:underline">
           查看更多賠率
         </Link>
       </div>
@@ -34,11 +33,11 @@ export function QuickOdds() {
       {loading ? (
         <div className="space-y-2">
           {[...Array(3)].map((_, i) => (
-            <div key={i} className="h-12 rounded bg-slate-100 animate-pulse" />
+            <div key={i} className="h-12 rounded bg-muted animate-pulse" />
           ))}
         </div>
       ) : games.length === 0 ? (
-        <p className="text-xs text-slate-400 text-center py-4">今日無賽事</p>
+        <p className="text-xs text-muted-foreground text-center py-4">今日無賽事</p>
       ) : (
         <div className="space-y-2">
           {games.map((game) => {
@@ -49,15 +48,22 @@ export function QuickOdds() {
               <Link
                 key={game.id}
                 href={`/game/nba/${game.id}`}
-                className="block rounded-lg border border-slate-100 p-2.5 hover:border-blue-200 hover:bg-blue-50/30 transition-colors"
+                className={`block rounded-lg border p-2.5 hover:shadow-md transition-all duration-200 ${
+                  isLive
+                    ? "border-live/30 bg-live-muted/30 hover:border-live/50"
+                    : "border-border hover:border-brand/30 hover:bg-accent"
+                }`}
               >
                 <div className="flex items-center justify-between text-xs mb-1">
                   {isLive ? (
-                    <span className="text-red-600 font-semibold text-[10px]">LIVE</span>
+                    <span className="flex items-center gap-1 text-live font-bold text-[10px]">
+                      <span className="w-1.5 h-1.5 rounded-full bg-live animate-live-blink" />
+                      LIVE
+                    </span>
                   ) : isFinal ? (
-                    <span className="text-slate-400 text-[10px]">終場</span>
+                    <span className="text-muted-foreground text-[10px]">終場</span>
                   ) : (
-                    <span className="text-slate-400 text-[10px]">
+                    <span className="text-muted-foreground text-[10px]">
                       {new Date(game.date).toLocaleTimeString("zh-TW", {
                         hour: "2-digit",
                         minute: "2-digit",
@@ -65,7 +71,7 @@ export function QuickOdds() {
                     </span>
                   )}
                   {game.odds && (
-                    <span className="text-[10px] text-slate-400">
+                    <span className="text-[10px] text-muted-foreground">
                       O/U {game.odds.overUnder}
                     </span>
                   )}
@@ -76,9 +82,9 @@ export function QuickOdds() {
                     {game.awayTeam.logo && (
                       <img src={game.awayTeam.logo} alt="" className="w-3.5 h-3.5" />
                     )}
-                    <span className="text-slate-700">{game.awayTeam.abbreviation}</span>
+                    <span className="text-card-foreground">{game.awayTeam.abbreviation}</span>
                   </div>
-                  <span className={`font-bold tabular-nums ${isLive ? "text-red-600" : "text-slate-900"}`}>
+                  <span className={`font-bold tabular-nums ${isLive ? "text-live" : "text-card-foreground"}`}>
                     {game.awayTeam.score}
                   </span>
                 </div>
@@ -88,9 +94,9 @@ export function QuickOdds() {
                     {game.homeTeam.logo && (
                       <img src={game.homeTeam.logo} alt="" className="w-3.5 h-3.5" />
                     )}
-                    <span className="text-slate-700">{game.homeTeam.abbreviation}</span>
+                    <span className="text-card-foreground">{game.homeTeam.abbreviation}</span>
                   </div>
-                  <span className={`font-bold tabular-nums ${isLive ? "text-red-600" : "text-slate-900"}`}>
+                  <span className={`font-bold tabular-nums ${isLive ? "text-live" : "text-card-foreground"}`}>
                     {game.homeTeam.score}
                   </span>
                 </div>

--- a/src/components/public/QuickStandings.tsx
+++ b/src/components/public/QuickStandings.tsx
@@ -25,7 +25,6 @@ export function QuickStandings() {
       .then((r) => r.json())
       .then((d) => {
         const groups: StandingsGroup[] = d.standings ?? [];
-        // Flatten all entries, sort by wins desc, take top 5
         const all = groups.flatMap((g) => g.entries);
         all.sort((a, b) => {
           const aWins = parseInt(a.stats.wins ?? "0", 10);
@@ -39,10 +38,10 @@ export function QuickStandings() {
   }, []);
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-4">
+    <div className="rounded-xl border border-border bg-card p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-bold text-slate-900">NBA 排名</h3>
-        <Link href="/standings" className="text-xs text-blue-600 hover:underline">
+        <h3 className="text-sm font-bold text-card-foreground">NBA 排名</h3>
+        <Link href="/standings" className="text-xs text-brand hover:underline">
           完整排名
         </Link>
       </div>
@@ -50,15 +49,15 @@ export function QuickStandings() {
       {loading ? (
         <div className="space-y-2">
           {[...Array(5)].map((_, i) => (
-            <div key={i} className="h-8 rounded bg-slate-100 animate-pulse" />
+            <div key={i} className="h-8 rounded bg-muted animate-pulse" />
           ))}
         </div>
       ) : entries.length === 0 ? (
-        <p className="text-xs text-slate-400 text-center py-4">暫無排名資料</p>
+        <p className="text-xs text-muted-foreground text-center py-4">暫無排名資料</p>
       ) : (
         <table className="w-full text-xs">
           <thead>
-            <tr className="text-slate-400 border-b border-slate-100">
+            <tr className="text-muted-foreground border-b border-border">
               <th className="text-left py-1.5 font-medium">#</th>
               <th className="text-left py-1.5 font-medium">球隊</th>
               <th className="text-center py-1.5 font-medium">勝</th>
@@ -67,20 +66,22 @@ export function QuickStandings() {
           </thead>
           <tbody>
             {entries.map((entry, i) => (
-              <tr key={entry.abbreviation} className="border-b border-slate-50 last:border-0">
-                <td className="py-1.5 text-slate-400 font-medium">{i + 1}</td>
+              <tr key={entry.abbreviation} className={`border-b border-border/50 last:border-0 ${i < 3 ? "font-semibold" : ""}`}>
+                <td className={`py-1.5 tabular-nums ${i === 0 ? "text-amber-500" : i === 1 ? "text-gray-400" : i === 2 ? "text-amber-700" : "text-muted-foreground"} font-medium`}>
+                  {i + 1}
+                </td>
                 <td className="py-1.5">
                   <div className="flex items-center gap-1.5">
                     {entry.logo && (
                       <img src={entry.logo} alt="" className="w-4 h-4" />
                     )}
-                    <span className="font-medium text-slate-700 truncate">
+                    <span className="font-medium text-card-foreground truncate">
                       {getTeamNameZh(entry.teamName)}
                     </span>
                   </div>
                 </td>
-                <td className="text-center text-slate-700 font-medium">{entry.stats.wins ?? "-"}</td>
-                <td className="text-center text-slate-700 font-medium">{entry.stats.losses ?? "-"}</td>
+                <td className="text-center text-card-foreground font-medium tabular-nums">{entry.stats.wins ?? "-"}</td>
+                <td className="text-center text-card-foreground font-medium tabular-nums">{entry.stats.losses ?? "-"}</td>
               </tr>
             ))}
           </tbody>

--- a/src/components/public/ReactionButtons.tsx
+++ b/src/components/public/ReactionButtons.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface ReactionButtonsProps {
+  articleId: string;
+}
+
+const REACTIONS = [
+  { type: "love", emoji: "\u2764\uFE0F", label: "愛心" },
+  { type: "fire", emoji: "\uD83D\uDD25", label: "精彩" },
+  { type: "wow", emoji: "\uD83D\uDE2E", label: "驚訝" },
+  { type: "sad", emoji: "\uD83D\uDE22", label: "傷心" },
+] as const;
+
+type ReactionType = (typeof REACTIONS)[number]["type"];
+
+function getStorageKey(articleId: string): string {
+  return `reactions_${articleId}`;
+}
+
+function getStoredReactions(articleId: string): Set<ReactionType> {
+  try {
+    const stored = localStorage.getItem(getStorageKey(articleId));
+    if (stored) return new Set(JSON.parse(stored));
+  } catch {
+    // ignore
+  }
+  return new Set();
+}
+
+function setStoredReactions(articleId: string, reactions: Set<ReactionType>) {
+  try {
+    localStorage.setItem(
+      getStorageKey(articleId),
+      JSON.stringify([...reactions])
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function ReactionButtons({ articleId }: ReactionButtonsProps) {
+  const [selected, setSelected] = useState<Set<ReactionType>>(new Set());
+  const [counts, setCounts] = useState<Record<ReactionType, number>>({
+    love: 0,
+    fire: 0,
+    wow: 0,
+    sad: 0,
+  });
+
+  useEffect(() => {
+    setSelected(getStoredReactions(articleId));
+    // Load counts from localStorage (no backend for reactions)
+    try {
+      const stored = localStorage.getItem(`reaction_counts_${articleId}`);
+      if (stored) setCounts(JSON.parse(stored));
+    } catch {
+      // ignore
+    }
+  }, [articleId]);
+
+  const handleReaction = (type: ReactionType) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+        setCounts((c) => {
+          const updated = { ...c, [type]: Math.max(0, (c[type] || 0) - 1) };
+          try {
+            localStorage.setItem(
+              `reaction_counts_${articleId}`,
+              JSON.stringify(updated)
+            );
+          } catch { /* ignore */ }
+          return updated;
+        });
+      } else {
+        next.add(type);
+        setCounts((c) => {
+          const updated = { ...c, [type]: (c[type] || 0) + 1 };
+          try {
+            localStorage.setItem(
+              `reaction_counts_${articleId}`,
+              JSON.stringify(updated)
+            );
+          } catch { /* ignore */ }
+          return updated;
+        });
+      }
+      setStoredReactions(articleId, next);
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {REACTIONS.map((r) => {
+        const isSelected = selected.has(r.type);
+        const count = counts[r.type] || 0;
+        return (
+          <button
+            key={r.type}
+            onClick={() => handleReaction(r.type)}
+            title={r.label}
+            className={`inline-flex items-center gap-1 px-3 py-1.5 rounded-full border text-sm transition-all ${
+              isSelected
+                ? "border-blue-300 bg-blue-50 scale-105"
+                : "border-border bg-card hover:bg-muted"
+            }`}
+          >
+            <span className="text-base">{r.emoji}</span>
+            {count > 0 && (
+              <span className="text-xs text-muted-foreground">{count}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/public/ShareButtons.tsx
+++ b/src/components/public/ShareButtons.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Link2, MessageCircle, Send } from "lucide-react";
+
+interface ShareButtonsProps {
+  url: string;
+  title: string;
+}
+
+export function ShareButtons({ url, title }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback
+      const textarea = document.createElement("textarea");
+      textarea.value = url;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  const shareLinks = [
+    {
+      label: copied ? "已複製" : "複製連結",
+      onClick: handleCopy,
+      icon: copied ? (
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <Link2 className="w-4 h-4" />
+      ),
+      className: copied
+        ? "bg-green-50 text-green-600 border-green-200"
+        : "bg-muted text-foreground border-border hover:bg-muted/80",
+    },
+    {
+      label: "LINE",
+      href: `https://social-plugins.line.me/lineit/share?url=${encodedUrl}`,
+      icon: <MessageCircle className="w-4 h-4" />,
+      className: "bg-[#06C755]/10 text-[#06C755] border-[#06C755]/20 hover:bg-[#06C755]/20",
+    },
+    {
+      label: "Telegram",
+      href: `https://t.me/share/url?url=${encodedUrl}&text=${encodedTitle}`,
+      icon: <Send className="w-4 h-4" />,
+      className: "bg-[#229ED9]/10 text-[#229ED9] border-[#229ED9]/20 hover:bg-[#229ED9]/20",
+    },
+    {
+      label: "X",
+      href: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+      icon: (
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      ),
+      className: "bg-muted text-foreground border-border hover:bg-muted/80",
+    },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {shareLinks.map((link) =>
+        link.onClick ? (
+          <button
+            key={link.label}
+            onClick={link.onClick}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border transition-all ${link.className}`}
+          >
+            {link.icon}
+            <span>{link.label}</span>
+          </button>
+        ) : (
+          <a
+            key={link.label}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border transition-all ${link.className}`}
+          >
+            {link.icon}
+            <span>{link.label}</span>
+          </a>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/components/public/TableOfContents.tsx
+++ b/src/components/public/TableOfContents.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, List } from "lucide-react";
+
+interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export function TableOfContents({ headings }: { headings: TocItem[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (headings.length < 2) return null;
+
+  const handleClick = (id: string) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    setExpanded(false);
+  };
+
+  return (
+    <>
+      {/* Mobile: collapsible */}
+      <div className="lg:hidden mb-6">
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="flex items-center gap-2 w-full px-4 py-3 bg-muted rounded-lg text-sm font-medium text-foreground"
+        >
+          <List className="w-4 h-4" />
+          <span>文章目錄</span>
+          {expanded ? (
+            <ChevronUp className="w-4 h-4 ml-auto" />
+          ) : (
+            <ChevronDown className="w-4 h-4 ml-auto" />
+          )}
+        </button>
+        {expanded && (
+          <nav className="mt-2 px-4 py-3 bg-muted/50 rounded-lg">
+            <ul className="space-y-1.5">
+              {headings.map((h) => (
+                <li key={h.id} style={{ paddingLeft: `${(h.level - 1) * 12}px` }}>
+                  <button
+                    onClick={() => handleClick(h.id)}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors text-left"
+                  >
+                    {h.text}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+      </div>
+
+      {/* Desktop: floating sidebar */}
+      <div className="hidden lg:block fixed right-[max(1rem,calc((100vw-768px)/2-320px))] top-1/4 w-56 max-h-[60vh] overflow-y-auto">
+        <div className="bg-card border border-border rounded-lg p-4 shadow-sm">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            目錄
+          </h4>
+          <nav>
+            <ul className="space-y-1.5">
+              {headings.map((h) => (
+                <li key={h.id} style={{ paddingLeft: `${(h.level - 1) * 10}px` }}>
+                  <button
+                    onClick={() => handleClick(h.id)}
+                    className="text-xs text-muted-foreground hover:text-foreground transition-colors text-left leading-snug"
+                  >
+                    {h.text}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/public/TrendingArticles.tsx
+++ b/src/components/public/TrendingArticles.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { TrendingUp, Eye } from "lucide-react";
+
+interface TrendingArticle {
+  id: string;
+  title: string;
+  slug: string | null;
+  category: string | null;
+  view_count: number | null;
+  published_at: string | null;
+}
+
+export function TrendingArticles() {
+  const [articles, setArticles] = useState<TrendingArticle[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/public/articles/trending")
+      .then((r) => r.json())
+      .then((d) => setArticles(d.articles ?? []))
+      .catch(() => setArticles([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-5">
+      <h3 className="flex items-center gap-2 text-sm font-semibold text-foreground mb-4">
+        <TrendingUp className="w-4 h-4 text-red-500" />
+        熱門文章
+      </h3>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="animate-pulse">
+              <div className="h-3.5 bg-muted rounded w-full mb-1.5" />
+              <div className="h-3 bg-muted rounded w-1/3" />
+            </div>
+          ))}
+        </div>
+      ) : articles.length === 0 ? (
+        <p className="text-sm text-muted-foreground">暫無資料</p>
+      ) : (
+        <div className="space-y-3">
+          {articles.map((article, idx) => (
+            <Link
+              key={article.id}
+              href={`/news/${article.slug || article.id}`}
+              className="group flex items-start gap-3 hover:bg-muted/50 -mx-2 px-2 py-1.5 rounded-lg transition-colors"
+            >
+              <span className="text-xs font-bold text-muted-foreground/60 mt-0.5 w-5 text-center flex-shrink-0">
+                {idx + 1}
+              </span>
+              <div className="flex-1 min-w-0">
+                <h4 className="text-sm font-medium text-foreground line-clamp-2 group-hover:text-blue-600 transition-colors leading-snug">
+                  {article.title}
+                </h4>
+                <div className="flex items-center gap-2 mt-1">
+                  {article.category && (
+                    <span className="text-xs text-muted-foreground">
+                      {article.category}
+                    </span>
+                  )}
+                  {article.view_count != null && article.view_count > 0 && (
+                    <span className="inline-flex items-center gap-0.5 text-xs text-muted-foreground">
+                      <Eye className="w-3 h-3" />
+                      {article.view_count}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scoreboard/ScoreCard.tsx
+++ b/src/components/scoreboard/ScoreCard.tsx
@@ -77,8 +77,13 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
   const content = (
     <div className={`bg-white border border-slate-200 rounded-xl shadow-sm overflow-hidden ${borderClass} ${league ? "hover:shadow-md transition-all duration-150 active:scale-[0.98] cursor-pointer" : ""}`}>
       {/* Status */}
-      <div className="px-4 pt-3 pb-2">
+      <div className="px-4 pt-3 pb-2 flex items-center justify-between">
         <StatusBadge game={game} />
+        {game.broadcast && (
+          <span className="text-xs text-muted-foreground">
+            {game.broadcast}
+          </span>
+        )}
       </div>
 
       {/* Teams */}
@@ -123,9 +128,16 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
         </div>
       )}
 
+      {/* Odds summary */}
+      {game.odds && (
+        <div className="px-4 pb-2 text-xs text-muted-foreground text-center tabular-nums">
+          {game.odds.details} | O/U {game.odds.overUnder}
+        </div>
+      )}
+
       {/* Records */}
       {(game.homeTeam.record || game.awayTeam.record) && (
-        <div className="px-4 pb-3 text-xs text-slate-400 text-center">
+        <div className="px-4 pb-3 text-xs text-muted-foreground text-center">
           ({game.awayTeam.record}) vs ({game.homeTeam.record})
         </div>
       )}

--- a/src/components/scoreboard/ScoreboardClient.tsx
+++ b/src/components/scoreboard/ScoreboardClient.tsx
@@ -125,8 +125,16 @@ export default function ScoreboardClient({
             currentDate={selectedDate}
             onDateChange={setSelectedDate}
           />
+          {!isToday && (
+            <button
+              onClick={() => setSelectedDate(getTodayStr())}
+              className="px-2 py-1 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              今天
+            </button>
+          )}
           {lastUpdated && isToday && (
-            <span className="text-xs text-slate-400">
+            <span className="text-xs text-muted-foreground">
               上次更新 {lastUpdated}
             </span>
           )}

--- a/src/components/standings/StandingsClient.tsx
+++ b/src/components/standings/StandingsClient.tsx
@@ -45,9 +45,9 @@ export function StandingsClient({
   // NBA/MLB 常見 stat keys
   const statKeys =
     league === "nba"
-      ? ["wins", "losses", "winPercent", "gamesBehind", "Home", "Away", "L10", "streak"]
+      ? ["wins", "losses", "winPercent", "gamesBehind", "Home", "Away", "L10", "streak", "PPG", "OPP PPG", "DIFF"]
       : league === "mlb"
-        ? ["wins", "losses", "winPercent", "gamesBehind", "Home", "Away", "L10"]
+        ? ["wins", "losses", "winPercent", "gamesBehind", "Home", "Away", "L10", "RS", "RA", "DIFF"]
         : ["wins", "losses", "ties", "pointsFor", "pointsAgainst"];
 
   const statLabels: Record<string, string> = {
@@ -63,7 +63,37 @@ export function StandingsClient({
     Away: "客場",
     L10: "近10場",
     OTL: "加時負",
+    PPG: "場均得分",
+    "OPP PPG": "場均失分",
+    DIFF: "分差",
+    RS: "得分",
+    RA: "失分",
   };
+
+  /** Get background style for winPercent cell based on value */
+  function getWinPercentStyle(value: string | undefined): React.CSSProperties | undefined {
+    if (!value) return undefined;
+    const num = parseFloat(value);
+    if (isNaN(num)) return undefined;
+    // Map 0.0-1.0 to a green intensity
+    const intensity = Math.round(num * 100);
+    const alpha = Math.min(0.25, num * 0.3);
+    if (intensity > 50) {
+      return { backgroundColor: `rgba(34, 197, 94, ${alpha})` };
+    }
+    if (intensity < 40) {
+      return { backgroundColor: `rgba(239, 68, 68, ${alpha * 0.6})` };
+    }
+    return undefined;
+  }
+
+  /** Rank badge for top 3 */
+  function getRankBadge(idx: number): React.ReactNode {
+    if (idx === 0) return <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-yellow-400 text-yellow-900 text-xs font-bold">1</span>;
+    if (idx === 1) return <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-slate-300 text-slate-700 text-xs font-bold">2</span>;
+    if (idx === 2) return <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-600 text-white text-xs font-bold">3</span>;
+    return <span className="inline-flex items-center justify-center w-5 h-5 text-xs text-muted-foreground">{idx + 1}</span>;
+  }
 
   return (
     <div className="space-y-4">
@@ -80,10 +110,10 @@ export function StandingsClient({
           <TabsContent key={opt.value} value={opt.value}>
             {loading ? (
               <div className="flex justify-center py-12">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand" />
               </div>
             ) : groups.length === 0 ? (
-              <p className="text-slate-500 text-center py-8">暫無排名數據</p>
+              <p className="text-muted-foreground text-center py-8">暫無排名數據</p>
             ) : (
               <div className="space-y-6">
                 {groups.map((group) => (
@@ -97,14 +127,17 @@ export function StandingsClient({
                       <div className="overflow-x-auto">
                         <table className="w-full text-sm">
                           <thead>
-                            <tr className="border-b bg-slate-50">
-                              <th className="text-left py-2 px-3 font-medium text-slate-600">
+                            <tr className="border-b bg-muted">
+                              <th className="text-center py-2 px-1.5 font-medium text-muted-foreground w-8">
+                                #
+                              </th>
+                              <th className="text-left py-2 px-3 font-medium text-muted-foreground">
                                 球隊
                               </th>
                               {statKeys.map((key) => (
                                 <th
                                   key={key}
-                                  className="text-center py-2 px-2 font-medium text-slate-600"
+                                  className="text-center py-2 px-2 font-medium text-muted-foreground"
                                 >
                                   {statLabels[key] ?? key}
                                 </th>
@@ -112,40 +145,47 @@ export function StandingsClient({
                             </tr>
                           </thead>
                           <tbody>
-                            {group.entries.map((entry, idx) => (
-                              <tr
-                                key={entry.teamId}
-                                className={
-                                  idx % 2 === 0 ? "bg-white" : "bg-slate-50/50"
-                                }
-                              >
-                                <td className="py-2 px-3">
-                                  <Link
-                                    href={`/team/${league}/${entry.teamId}`}
-                                    className="flex items-center gap-2 hover:text-blue-600 transition-colors"
-                                  >
-                                    {entry.logo && (
-                                      <img
-                                        src={entry.logo}
-                                        alt=""
-                                        className="w-5 h-5"
-                                      />
-                                    )}
-                                    <span className="font-medium">
-                                      {entry.teamName}
-                                    </span>
-                                  </Link>
-                                </td>
-                                {statKeys.map((key) => (
-                                  <td
-                                    key={key}
-                                    className="text-center py-2 px-2 text-slate-600"
-                                  >
-                                    {entry.stats[key] ?? "-"}
+                            {group.entries.map((entry, idx) => {
+                              const isTop3 = idx < 3;
+                              return (
+                                <tr
+                                  key={entry.teamId}
+                                  className={`${
+                                    idx % 2 === 0 ? "bg-card" : "bg-muted/50"
+                                  } ${isTop3 ? "font-semibold" : ""}`}
+                                >
+                                  <td className="text-center py-2 px-1.5">
+                                    {getRankBadge(idx)}
                                   </td>
-                                ))}
-                              </tr>
-                            ))}
+                                  <td className="py-2 px-3">
+                                    <Link
+                                      href={`/team/${league}/${entry.teamId}`}
+                                      className="flex items-center gap-2 hover:text-primary transition-colors"
+                                    >
+                                      {entry.logo && (
+                                        <img
+                                          src={entry.logo}
+                                          alt=""
+                                          className="w-5 h-5"
+                                        />
+                                      )}
+                                      <span className={`${isTop3 ? "font-bold text-foreground" : "font-medium text-foreground"}`}>
+                                        {entry.teamName}
+                                      </span>
+                                    </Link>
+                                  </td>
+                                  {statKeys.map((key) => (
+                                    <td
+                                      key={key}
+                                      className="text-center py-2 px-2 text-muted-foreground tabular-nums"
+                                      style={key === "winPercent" ? getWinPercentStyle(entry.stats[key]) : undefined}
+                                    >
+                                      {entry.stats[key] ?? "-"}
+                                    </td>
+                                  ))}
+                                </tr>
+                              );
+                            })}
                           </tbody>
                         </table>
                       </div>

--- a/src/components/team/TeamDetailClient.tsx
+++ b/src/components/team/TeamDetailClient.tsx
@@ -29,6 +29,12 @@ interface RosterPlayer {
   weight: string;
 }
 
+interface TeamATS {
+  wins: number;
+  losses: number;
+  pushes: number;
+}
+
 export function TeamDetailClient({
   sport,
   teamId,
@@ -39,6 +45,7 @@ export function TeamDetailClient({
   const { data: session } = useSession();
   const [team, setTeam] = useState<TeamInfo | null>(null);
   const [roster, setRoster] = useState<RosterPlayer[]>([]);
+  const [ats, setAts] = useState<TeamATS | null>(null);
   const [loading, setLoading] = useState(true);
   const [isFavorite, setIsFavorite] = useState(false);
 
@@ -48,10 +55,12 @@ export function TeamDetailClient({
     Promise.all([
       fetch(`/api/public/team?sport=${sport}&id=${teamId}`).then((r) => r.json()),
       fetch(`/api/public/team?sport=${sport}&id=${teamId}&type=roster`).then((r) => r.json()),
+      fetch(`/api/public/team?sport=${sport}&id=${teamId}&type=ats`).then((r) => r.json()),
     ])
-      .then(([teamData, rosterData]) => {
+      .then(([teamData, rosterData, atsData]) => {
         setTeam(teamData.team ?? null);
         setRoster(rosterData.roster ?? []);
+        setAts(atsData.ats ?? null);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
@@ -159,6 +168,34 @@ export function TeamDetailClient({
           </div>
         </CardContent>
       </Card>
+
+      {/* ATS (Against the Spread) */}
+      {ats && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">ATS 紀錄</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-4 text-center">
+              <div>
+                <p className="text-2xl font-bold text-foreground tabular-nums">{ats.wins}</p>
+                <p className="text-xs text-muted-foreground">勝</p>
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-foreground tabular-nums">{ats.losses}</p>
+                <p className="text-xs text-muted-foreground">負</p>
+              </div>
+              <div>
+                <p className="text-2xl font-bold text-foreground tabular-nums">{ats.pushes}</p>
+                <p className="text-xs text-muted-foreground">平</p>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground text-center mt-2">
+              Against the Spread 本季紀錄
+            </p>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Roster */}
       <Card>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -124,12 +124,12 @@ export const SITE_URL =
 export const TELEGRAM_CHANNEL_URL = "https://t.me/howger_sport_news";
 
 export const CATEGORY_COLORS: Record<string, string> = {
-  NBA: "bg-orange-50 text-orange-700 border border-orange-300 rounded-lg",
-  籃球: "bg-orange-50 text-orange-700 border border-orange-300 rounded-lg",
-  棒球: "bg-green-50 text-green-700 border border-green-300 rounded-lg",
-  MLB: "bg-green-50 text-green-700 border border-green-300 rounded-lg",
-  足球: "bg-blue-50 text-blue-700 border border-blue-300 rounded-lg",
-  綜合: "bg-purple-50 text-purple-700 border border-purple-300 rounded-lg",
+  NBA: "bg-orange-500 text-white rounded-md",
+  籃球: "bg-orange-500 text-white rounded-md",
+  棒球: "bg-emerald-600 text-white rounded-md",
+  MLB: "bg-emerald-600 text-white rounded-md",
+  足球: "bg-sky-600 text-white rounded-md",
+  綜合: "bg-violet-600 text-white rounded-md",
 };
 
 /** 分類名稱 → 分類底圖 fallback（無文章配圖時使用） */

--- a/src/lib/espn/play-by-play.ts
+++ b/src/lib/espn/play-by-play.ts
@@ -230,3 +230,198 @@ export async function fetchLeaders(
 
   return parseLeaders(data);
 }
+
+// ---------- Injuries ----------
+
+export interface InjuryPlayer {
+  name: string;
+  status: string;
+  description: string;
+}
+
+export interface TeamInjuries {
+  team: string;
+  teamLogo: string;
+  players: InjuryPlayer[];
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function parseInjuries(data: any): TeamInjuries[] {
+  const injuries: any[] = data.injuries ?? [];
+  return injuries.map((teamGroup: any) => {
+    const team = teamGroup.team ?? {};
+    const players: InjuryPlayer[] = (teamGroup.injuries ?? []).map((inj: any) => ({
+      name: inj.athlete?.displayName ?? "",
+      status: inj.status ?? inj.type?.description ?? "",
+      description: inj.details?.detail ?? inj.details?.type ?? "",
+    }));
+    return {
+      team: getTeamNameZh(team.displayName ?? ""),
+      teamLogo: team.logo ?? team.logos?.[0]?.href ?? "",
+      players,
+    };
+  });
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * 取得傷兵名單
+ */
+export async function fetchInjuries(
+  league: string,
+  eventId: string,
+  isCompleted = false
+): Promise<TeamInjuries[]> {
+  const sportPath = getSportPath(league);
+  const ttl = isCompleted ? CACHE_TTL.PBP_FINAL : CACHE_TTL.LIVE;
+
+  try {
+    const data = await espnFetch<any>(
+      `${sportPath}/summary`,
+      { ttl, params: { event: eventId } }
+    );
+    return parseInjuries(data);
+  } catch (err) {
+    console.error("[ESPN] fetchInjuries error:", err);
+    return [];
+  }
+}
+
+// ---------- Win Probability ----------
+
+export interface WinProbabilityPoint {
+  homeWinPct: number;
+  playId: string;
+  secondsLeft: number;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function parseWinProbability(data: any): WinProbabilityPoint[] {
+  const items: any[] = data.winprobability ?? [];
+  return items.map((p: any) => ({
+    homeWinPct: (p.homeWinPercentage ?? 0) * 100,
+    playId: p.playId ?? "",
+    secondsLeft: p.secondsLeft ?? 0,
+  }));
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * 取得勝率走勢
+ */
+export async function fetchWinProbability(
+  sport: string,
+  league: string,
+  eventId: string
+): Promise<WinProbabilityPoint[]> {
+  const sportPath = getSportPath(league);
+  const ttl = CACHE_TTL.PBP_FINAL;
+
+  try {
+    const data = await espnFetch<any>(
+      `${sportPath}/summary`,
+      { ttl, params: { event: eventId } }
+    );
+    return parseWinProbability(data);
+  } catch (err) {
+    console.error("[ESPN] fetchWinProbability error:", err);
+    return [];
+  }
+}
+
+// ---------- Season Series ----------
+
+export interface SeasonSeriesGame {
+  date: string;
+  homeTeam: string;
+  awayTeam: string;
+  homeScore: string;
+  awayScore: string;
+  status: string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function parseSeasonSeries(data: any): SeasonSeriesGame[] {
+  const series: any[] = data.seasonseries ?? [];
+  return series.map((g: any) => {
+    const competitors = g.competitors ?? [];
+    const home = competitors.find((c: any) => c.homeAway === "home") ?? competitors[0] ?? {};
+    const away = competitors.find((c: any) => c.homeAway === "away") ?? competitors[1] ?? {};
+    return {
+      date: g.date ?? "",
+      homeTeam: getTeamNameZh(home.team?.displayName ?? ""),
+      awayTeam: getTeamNameZh(away.team?.displayName ?? ""),
+      homeScore: home.score ?? "0",
+      awayScore: away.score ?? "0",
+      status: g.status?.type?.shortDetail ?? "",
+    };
+  });
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * 取得歷史交手紀錄（本季）
+ */
+export async function fetchSeasonSeries(
+  league: string,
+  eventId: string,
+  isCompleted = false
+): Promise<SeasonSeriesGame[]> {
+  const sportPath = getSportPath(league);
+  const ttl = isCompleted ? CACHE_TTL.PBP_FINAL : CACHE_TTL.LIVE;
+
+  try {
+    const data = await espnFetch<any>(
+      `${sportPath}/summary`,
+      { ttl, params: { event: eventId } }
+    );
+    return parseSeasonSeries(data);
+  } catch (err) {
+    console.error("[ESPN] fetchSeasonSeries error:", err);
+    return [];
+  }
+}
+
+// ---------- Pick Center ----------
+
+export interface PickCenterData {
+  provider: string;
+  details: string;
+  homeWinPct: number;
+  awayWinPct: number;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function parsePickCenter(data: any): PickCenterData[] {
+  const picks: any[] = data.pickcenter ?? [];
+  return picks.map((p: any) => ({
+    provider: p.provider?.name ?? "",
+    details: p.details ?? "",
+    homeWinPct: p.homeTeamOdds?.winPercentage ?? p.homeTeamOdds?.averageScore ?? 0,
+    awayWinPct: p.awayTeamOdds?.winPercentage ?? p.awayTeamOdds?.averageScore ?? 0,
+  }));
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * 取得專家預測
+ */
+export async function fetchPickCenter(
+  league: string,
+  eventId: string,
+  isCompleted = false
+): Promise<PickCenterData[]> {
+  const sportPath = getSportPath(league);
+  const ttl = isCompleted ? CACHE_TTL.PBP_FINAL : CACHE_TTL.LIVE;
+
+  try {
+    const data = await espnFetch<any>(
+      `${sportPath}/summary`,
+      { ttl, params: { event: eventId } }
+    );
+    return parsePickCenter(data);
+  } catch (err) {
+    console.error("[ESPN] fetchPickCenter error:", err);
+    return [];
+  }
+}

--- a/src/lib/espn/player.ts
+++ b/src/lib/espn/player.ts
@@ -69,3 +69,67 @@ export async function fetchPlayer(
 
   return parsePlayer(data);
 }
+
+// ---------- Game Log ----------
+
+export interface GameLogEntry {
+  date: string;
+  opponent: string;
+  result: string;
+  stats: Record<string, string>;
+}
+
+export interface PlayerGameLog {
+  labels: string[];
+  entries: GameLogEntry[];
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function parseGameLog(data: any): PlayerGameLog {
+  const categories = data.categories ?? [];
+  const firstCat = categories[0];
+  if (!firstCat) return { labels: [], entries: [] };
+
+  const labels: string[] = (firstCat.labels ?? []).map((l: string) => l);
+  const events: any[] = firstCat.events ?? [];
+
+  const entries: GameLogEntry[] = events.map((ev: any) => {
+    const statsMap: Record<string, string> = {};
+    const statsArr: string[] = ev.stats ?? [];
+    labels.forEach((label, idx) => {
+      statsMap[label] = statsArr[idx] ?? "-";
+    });
+
+    return {
+      date: ev.eventDate ?? "",
+      opponent: ev.opponent?.displayName ?? ev.opponent?.abbreviation ?? "",
+      result: ev.gameResult ?? "",
+      stats: statsMap,
+    };
+  });
+
+  return { labels, entries };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * 取得球員 Game Log
+ */
+export async function fetchPlayerGameLog(
+  sport: string,
+  league: string,
+  playerId: string
+): Promise<PlayerGameLog> {
+  const sportPath = getSportPath(league);
+
+  try {
+    const data = await espnFetch<any>(
+      `${sportPath}/athletes/${playerId}/gamelog`,
+      { ttl: CACHE_TTL.TEAM }
+    );
+    return parseGameLog(data);
+  } catch (err) {
+    console.error("[ESPN] fetchPlayerGameLog error:", err);
+    return { labels: [], entries: [] };
+  }
+}

--- a/src/lib/espn/scoreboard.ts
+++ b/src/lib/espn/scoreboard.ts
@@ -1,7 +1,7 @@
 // 重構 scoreboard — 使用統一 ESPN client
 
 import { espnFetch, CACHE_TTL, getSportPath } from "./client";
-import type { ESPNScoreboardResponse, ESPNOdds } from "./types";
+import type { ESPNScoreboardResponse, ESPNOdds, ESPNCompetition } from "./types";
 import { getTeamNameZh } from "@/lib/constants";
 
 // ---------- 前台使用的型別（保持與現有 scoreboard.ts 相容） ----------
@@ -32,6 +32,7 @@ export interface Game {
   homeTeam: TeamInfo;
   awayTeam: TeamInfo;
   odds?: GameOdds;
+  broadcast?: string;
 }
 
 export interface ScoreboardResponse {
@@ -78,11 +79,16 @@ function parseGames(data: ESPNScoreboardResponse): Game[] {
       };
     }
 
+    // Parse broadcast
+    const broadcastData = (competition as ESPNCompetition)?.broadcasts?.[0];
+    const broadcast = broadcastData?.names?.[0] ?? undefined;
+
     return {
       id: event.id,
       date: event.date,
       status: mapStatus(event.status?.type?.name ?? ""),
       statusDetail: event.status?.type?.shortDetail ?? "",
+      broadcast,
       homeTeam: {
         name: getTeamNameZh(home?.team?.displayName ?? ""),
         abbreviation: home?.team?.abbreviation ?? "",

--- a/src/lib/espn/types.ts
+++ b/src/lib/espn/types.ts
@@ -22,10 +22,16 @@ export interface ESPNEvent {
   competitions: ESPNCompetition[];
 }
 
+export interface ESPNBroadcast {
+  market: string;
+  names: string[];
+}
+
 export interface ESPNCompetition {
   id: string;
   competitors: ESPNCompetitor[];
   odds?: ESPNOdds[];
+  broadcasts?: ESPNBroadcast[];
 }
 
 export interface ESPNCompetitor {

--- a/src/lib/scoreboard.ts
+++ b/src/lib/scoreboard.ts
@@ -32,6 +32,7 @@ export interface Game {
   homeTeam: TeamInfo;
   awayTeam: TeamInfo;
   odds?: GameOdds;
+  broadcast?: string;
 }
 
 export interface ScoreboardResponse {

--- a/supabase/migrations/012_article_tags.sql
+++ b/supabase/migrations/012_article_tags.sql
@@ -1,0 +1,11 @@
+-- Article tags system
+CREATE TABLE IF NOT EXISTS article_tags (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  article_id uuid NOT NULL REFERENCES generated_articles(id) ON DELETE CASCADE,
+  tag_name text NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE(article_id, tag_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_article_tags_article ON article_tags(article_id);
+CREATE INDEX IF NOT EXISTS idx_article_tags_name ON article_tags(tag_name);

--- a/supabase/migrations/013_article_bookmarks.sql
+++ b/supabase/migrations/013_article_bookmarks.sql
@@ -1,0 +1,10 @@
+-- Article bookmarks / favorites system
+CREATE TABLE IF NOT EXISTS article_bookmarks (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  member_id uuid NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+  article_id uuid NOT NULL REFERENCES generated_articles(id) ON DELETE CASCADE,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE(member_id, article_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bookmarks_member ON article_bookmarks(member_id);


### PR DESCRIPTION
## Summary

Issue #35 六角色競品分析的完整實作，涵蓋 7 個 Sprint、48 個項目的全面優化。

### Sprint 1 — UI 基礎建設
- 品牌色系統：深海軍藍主色 + 琥珀色 LIVE 強調，全站硬編碼色替換為語意化 token
- 深色模式：`next-themes` ThemeProvider + Header toggle + 所有前台元件 semantic tokens
- 統一 Design Token（圓角/陰影/邊框）
- 導覽列 Active 狀態指示（`usePathname`）
- 分類標籤改高對比實底色（橘/綠/藍/紫白字）
- 手機版觸控目標 44px
- LIVE 標記強化（閃爍紅點 + ring 邊框）

### Sprint 2 — 首頁佈局重構
- PC 版 Sidebar 佈局（主內容 + 右側 sticky sidebar 放排名/賠率/熱門文章）
- 熱門文章區塊（API + 元件）
- 文章卡片入場動畫 + 分類切換淡入淡出
- Mobile 縮圖放大、大螢幕 4 欄、加強 Hover 效果

### Sprint 3 — 內容體驗
- **Markdown 完整渲染**（`react-markdown` + `remark-gfm` 取代 284 行手動解析）
- **全站搜尋**（Supabase ilike + /search 頁面 + Header 搜尋）
- 社群分享按鈕（LINE/Telegram/X/複製連結）
- 文章摘要品質改進、排序選項、排名表視覺層級、文章目錄 TOC、YouTube 嵌入、反應表情

### Sprint 4+5 — ESPN API 數據擴充
- 排名進階數據（PPG/OPP PPG/DIFF）
- 比分頁日期 < > 按鈕
- 傷兵名單 tab、轉播資訊
- **勝率走勢圖**（recharts AreaChart）
- 比分頁即時賠率、賠率多家比較（會員版）
- Team ATS、H2H 歷史交手、球員 Game Log、Pick Center

### Sprint 6+7 — SEO + 後台
- JSON-LD 結構化資料（SportsEvent/SportsTeam/Person）
- OG Image 自動產生、動態 Sitemap
- 後台：文章分類欄、Persona 頭像/專長、品質監控 Dashboard
- 標籤系統 + 書籤/收藏 migration 和 API

## 新增檔案（16 個）
- `src/components/public/`: ArticleContent, ShareButtons, TrendingArticles, ReactionButtons, BookmarkButton, TableOfContents
- `src/app/`: search page, sitemap.ts, og route
- `src/app/api/`: search, trending, tags, bookmarks
- JSON-LD: GameJsonLd, TeamJsonLd, PlayerJsonLd
- DB: 012_article_tags.sql, 013_article_bookmarks.sql

## 新增依賴
- `react-markdown` + `remark-gfm`: Markdown 完整渲染
- `recharts`: 勝率走勢圖

## Test plan
- [x] TypeScript 零錯誤
- [x] Vitest 245/245 通過
- [x] `npm run build` 成功
- [ ] 瀏覽器驗證：PC 1440×900 + Mobile 430×932
- [ ] 深色模式切換測試
- [ ] 搜尋功能測試
- [ ] ESPN API 新功能驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)