### PR TITLE
fix: 前台文章圖片全顯示代圖 — images 格式 mismatch

### DIFF
--- a/src/app/(public)/category/[slug]/page.tsx
+++ b/src/app/(public)/category/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createServiceClient } from "@/lib/supabase";
-import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_FALLBACK_IMAGES, CATEGORY_LABELS, formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_FALLBACK_IMAGES, CATEGORY_LABELS, formatRelativeTime, getFirstImageUrl } from "@/lib/constants";
 
 export const revalidate = 60;
 
@@ -242,7 +242,7 @@ export default async function CategoryPage({
         <div className="space-y-4 mb-8">
           {(articles as unknown as ArticleWithWriter[]).map((article) => {
             const writerName = article.writer_personas?.name;
-            const thumbnail = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
+            const thumbnail = getFirstImageUrl(article.images) || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
             return (
               <Link
                 key={article.id}

--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createServiceClient } from "@/lib/supabase";
-import { CATEGORY_COLORS, formatDateFull, formatRelativeTime, getCategorySlug, SITE_URL } from "@/lib/constants";
+import { CATEGORY_COLORS, formatDateFull, formatRelativeTime, getCategorySlug, getFirstImageUrl, SITE_URL } from "@/lib/constants";
 import ViewTracker from "./ViewTracker";
 import LikeButton from "./LikeButton";
 import { TelegramArticleCTA } from "@/components/TelegramCTA";
@@ -217,18 +217,19 @@ export default async function ArticlePage({
       </header>
 
       {/* Featured Image */}
-      {article.images?.length > 0 && article.images[0]?.url && (
-        <div className="mb-8 rounded-xl overflow-hidden">
-          <img
-            src={article.images[0].url}
-            alt={article.images[0].caption || article.title}
-            className="w-full max-h-[480px] object-cover"
-          />
-          {article.images[0].caption && (
-            <p className="text-xs text-muted-foreground mt-2">{article.images[0].caption}</p>
-          )}
-        </div>
-      )}
+      {(() => {
+        const featuredUrl = getFirstImageUrl(article.images);
+        if (!featuredUrl) return null;
+        return (
+          <div className="mb-8 rounded-xl overflow-hidden">
+            <img
+              src={featuredUrl}
+              alt={article.title}
+              className="w-full max-h-[480px] object-cover"
+            />
+          </div>
+        );
+      })()}
 
       {/* Divider */}
       <hr className="border-border mb-8" />

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import Link from "next/link";
 import { createServiceClient } from "@/lib/supabase";
-import { CATEGORY_COLORS, CATEGORY_FALLBACK_IMAGES, formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_COLORS, CATEGORY_FALLBACK_IMAGES, formatRelativeTime, getFirstImageUrl } from "@/lib/constants";
 import { SearchInput } from "./SearchInput";
 
 export const metadata: Metadata = {
@@ -63,7 +63,7 @@ export default async function SearchPage({
               CATEGORY_COLORS[article.category ?? ""] ??
               "bg-muted text-muted-foreground border border-border rounded-lg";
             const thumbnail =
-              article.images?.[0]?.url ||
+              getFirstImageUrl(article.images) ||
               CATEGORY_FALLBACK_IMAGES[article.category ?? ""] ||
               "/images/category-general.jpg";
 

--- a/src/components/public/HeroSection.tsx
+++ b/src/components/public/HeroSection.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CATEGORY_FALLBACK_IMAGES, formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_FALLBACK_IMAGES, formatRelativeTime, getFirstImageUrl } from "@/lib/constants";
 
 interface HeroArticle {
   id: string;
@@ -23,7 +23,7 @@ export function HeroSection({
   hero: HeroArticle;
   subHeroes: HeroArticle[];
 }) {
-  const heroImage = hero.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[hero.category ?? ""] || "/images/hero-sports-bg.jpg";
+  const heroImage = getFirstImageUrl(hero.images) || CATEGORY_FALLBACK_IMAGES[hero.category ?? ""] || "/images/hero-sports-bg.jpg";
 
   return (
     <section className="mb-8">
@@ -62,7 +62,7 @@ export function HeroSection({
         {/* Sub heroes - stacked vertically */}
         <div className="flex flex-col gap-4">
           {subHeroes.map((article) => {
-            const thumb = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
+            const thumb = getFirstImageUrl(article.images) || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
             return (
               <Link key={article.id} href={getHref(article)} className="block group flex-1">
                 <article className="relative rounded-xl bg-slate-800 text-white overflow-hidden h-full min-h-[150px] flex items-end active:scale-[0.99] transition-transform duration-150">
@@ -122,7 +122,7 @@ export function HeroSection({
 
         <div className="grid grid-cols-2 gap-3">
           {subHeroes.map((article) => {
-            const thumb = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
+            const thumb = getFirstImageUrl(article.images) || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
             return (
               <Link key={article.id} href={getHref(article)} className="block group">
                 <article className="relative rounded-xl bg-slate-800 text-white overflow-hidden min-h-[120px] flex items-end active:scale-[0.99] transition-transform duration-150">

--- a/src/components/public/PersonalizedArticleGrid.tsx
+++ b/src/components/public/PersonalizedArticleGrid.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { CATEGORY_COLORS, CATEGORY_FALLBACK_IMAGES, formatRelativeTime } from "@/lib/constants";
+import { CATEGORY_COLORS, CATEGORY_FALLBACK_IMAGES, formatRelativeTime, getFirstImageUrl } from "@/lib/constants";
 import { Star } from "lucide-react";
 
 interface FavoriteTeam {
@@ -71,7 +71,7 @@ export function PersonalizedArticleGrid({
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-5">
       {sortedArticles.map((article, index) => {
         const colorClass = CATEGORY_COLORS[article.category ?? ""] ?? "bg-muted text-muted-foreground rounded-md";
-        const thumbnail = article.images?.[0]?.url || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
+        const thumbnail = getFirstImageUrl(article.images) || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
         const isFavorite = favoriteNames.some((name) => article.title.includes(name));
 
         return (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -132,6 +132,17 @@ export const CATEGORY_COLORS: Record<string, string> = {
   綜合: "bg-violet-600 text-white rounded-md",
 };
 
+/** 從 images 欄位取第一張圖片 URL（相容 string[] 和 { url: string }[] 兩種格式） */
+export function getFirstImageUrl(images: unknown): string | null {
+  if (!Array.isArray(images) || images.length === 0) return null;
+  const first = images[0];
+  if (typeof first === "string") return first;
+  if (first && typeof first === "object" && "url" in first && typeof (first as { url: string }).url === "string") {
+    return (first as { url: string }).url;
+  }
+  return null;
+}
+
 /** 分類名稱 → 分類底圖 fallback（無文章配圖時使用） */
 export const CATEGORY_FALLBACK_IMAGES: Record<string, string> = {
   NBA: "/images/category-nba.jpg",


### PR DESCRIPTION
## Summary
- DB 的 `images` 欄位是 `string[]`（如 `["url1"]`），前台期望 `{ url: string }[]`
- 對字串做 `.url` 得到 `undefined`，永遠 fallback 到分類代圖
- 新增 `getFirstImageUrl()` helper 兼容兩種格式
- 更新 6 個前台檔案的取值邏輯

## Test plan
- [x] TypeScript 零錯誤
- [x] Vitest 245/245 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)