### PR TITLE
feat: 灰底白卡層次感 (#39)

### DIFF
--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -151,7 +151,7 @@ export default async function ArticlePage({
   });
 
   return (
-    <article className="max-w-3xl mx-auto">
+    <article className="max-w-3xl mx-auto bg-card rounded-xl p-6 sm:p-8 shadow-sm">
       {/* JSON-LD structured data for SEO - trusted server-generated content */}
       <script type="application/ld+json" suppressHydrationWarning>
         {jsonLdData}

--- a/src/app/(public)/search/page.tsx
+++ b/src/app/(public)/search/page.tsx
@@ -43,7 +43,7 @@ export default async function SearchPage({
   }
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <div className="max-w-3xl mx-auto bg-card rounded-xl p-6 sm:p-8 shadow-sm">
       <h1 className="text-2xl font-bold text-foreground mb-6">搜尋文章</h1>
 
       <SearchInput defaultValue={query} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,7 +62,7 @@
   --live: oklch(0.65 0.2 30);
   --live-muted: oklch(0.92 0.05 30);
 
-  --background: oklch(0.98 0.002 260);
+  --background: oklch(0.95 0.005 260);
   --foreground: oklch(0.15 0.01 260);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.15 0.01 260);

--- a/src/components/scoreboard/ScoreCard.tsx
+++ b/src/components/scoreboard/ScoreCard.tsx
@@ -26,7 +26,7 @@ function StatusBadge({ game }: { game: Game }) {
   }
   if (game.status === "final") {
     return (
-      <div className="text-sm font-medium text-slate-500">
+      <div className="text-sm font-medium text-muted-foreground">
         已結束
       </div>
     );
@@ -49,11 +49,11 @@ function TeamRow({ team, isWinner }: { team: TeamInfo; isWinner: boolean }) {
         className="w-6 h-6 object-contain"
         loading="lazy"
       />
-      <span className="text-sm font-medium text-slate-700 w-10">{team.abbreviation}</span>
-      <span className={`text-sm flex-1 min-w-0 truncate ${isWinner ? "font-semibold text-slate-900" : "text-slate-600"}`}>
+      <span className="text-sm font-medium text-foreground w-10">{team.abbreviation}</span>
+      <span className={`text-sm flex-1 min-w-0 truncate ${isWinner ? "font-semibold text-foreground" : "text-muted-foreground"}`}>
         {team.name}
       </span>
-      <span className={`text-lg tabular-nums ${isWinner ? "font-bold text-slate-900" : "text-slate-600"}`}>
+      <span className={`text-lg tabular-nums ${isWinner ? "font-bold text-foreground" : "text-muted-foreground"}`}>
         {team.score}
       </span>
     </div>
@@ -75,7 +75,7 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
         : "border-l-4 border-l-blue-400";
 
   const content = (
-    <div className={`bg-white border border-slate-200 rounded-xl shadow-sm overflow-hidden ${borderClass} ${league ? "hover:shadow-md transition-all duration-150 active:scale-[0.98] cursor-pointer" : ""}`}>
+    <div className={`bg-card border border-border rounded-xl shadow-sm overflow-hidden ${borderClass} ${league ? "hover:shadow-md transition-all duration-150 active:scale-[0.98] cursor-pointer" : ""}`}>
       {/* Status */}
       <div className="px-4 pt-3 pb-2 flex items-center justify-between">
         <StatusBadge game={game} />
@@ -89,7 +89,7 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
       {/* Teams */}
       <div className="px-4 pb-2">
         <TeamRow team={game.awayTeam} isWinner={awayWins} />
-        <div className="border-t border-slate-100" />
+        <div className="border-t border-border/50" />
         <TeamRow team={game.homeTeam} isWinner={homeWins} />
       </div>
 
@@ -98,30 +98,30 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
         <div className="px-4 pb-2">
           <table className="w-full text-xs tabular-nums">
             <thead>
-              <tr className="text-slate-400">
+              <tr className="text-muted-foreground">
                 <th className="text-left font-normal py-0.5 w-10"></th>
                 {game.homeTeam.linescores.map((ls) => (
                   <th key={ls.period} className="text-center font-normal py-0.5 w-7">
                     {ls.period}
                   </th>
                 ))}
-                <th className="text-center font-medium py-0.5 w-7 text-slate-600">T</th>
+                <th className="text-center font-medium py-0.5 w-7 text-muted-foreground">T</th>
               </tr>
             </thead>
             <tbody>
-              <tr className="text-slate-600">
+              <tr className="text-muted-foreground">
                 <td className="text-left font-medium py-0.5">{game.awayTeam.abbreviation}</td>
                 {game.awayTeam.linescores.map((ls) => (
                   <td key={ls.period} className="text-center py-0.5">{ls.value}</td>
                 ))}
-                <td className={`text-center py-0.5 font-medium ${awayWins ? "text-slate-900" : ""}`}>{game.awayTeam.score}</td>
+                <td className={`text-center py-0.5 font-medium ${awayWins ? "text-foreground" : ""}`}>{game.awayTeam.score}</td>
               </tr>
-              <tr className="text-slate-600">
+              <tr className="text-muted-foreground">
                 <td className="text-left font-medium py-0.5">{game.homeTeam.abbreviation}</td>
                 {game.homeTeam.linescores.map((ls) => (
                   <td key={ls.period} className="text-center py-0.5">{ls.value}</td>
                 ))}
-                <td className={`text-center py-0.5 font-medium ${homeWins ? "text-slate-900" : ""}`}>{game.homeTeam.score}</td>
+                <td className={`text-center py-0.5 font-medium ${homeWins ? "text-foreground" : ""}`}>{game.homeTeam.score}</td>
               </tr>
             </tbody>
           </table>

--- a/src/components/scoreboard/ScoreCardSkeleton.tsx
+++ b/src/components/scoreboard/ScoreCardSkeleton.tsx
@@ -2,27 +2,27 @@
 
 export default function ScoreCardSkeleton() {
   return (
-    <div className="bg-white border border-slate-200 rounded-xl shadow-sm overflow-hidden border-l-4 border-l-slate-200 animate-pulse">
+    <div className="bg-card border border-border rounded-xl shadow-sm overflow-hidden border-l-4 border-l-muted animate-pulse">
       <div className="px-4 pt-3 pb-2">
-        <div className="h-5 w-24 bg-slate-200 rounded" />
+        <div className="h-5 w-24 bg-muted rounded" />
       </div>
       <div className="px-4 pb-2 space-y-3">
         <div className="flex items-center gap-3">
-          <div className="w-6 h-6 rounded-full bg-slate-200" />
-          <div className="h-4 w-10 bg-slate-200 rounded" />
-          <div className="h-4 flex-1 bg-slate-200 rounded" />
-          <div className="h-5 w-8 bg-slate-200 rounded" />
+          <div className="w-6 h-6 rounded-full bg-muted" />
+          <div className="h-4 w-10 bg-muted rounded" />
+          <div className="h-4 flex-1 bg-muted rounded" />
+          <div className="h-5 w-8 bg-muted rounded" />
         </div>
-        <div className="border-t border-slate-100" />
+        <div className="border-t border-border" />
         <div className="flex items-center gap-3">
-          <div className="w-6 h-6 rounded-full bg-slate-200" />
-          <div className="h-4 w-10 bg-slate-200 rounded" />
-          <div className="h-4 flex-1 bg-slate-200 rounded" />
-          <div className="h-5 w-8 bg-slate-200 rounded" />
+          <div className="w-6 h-6 rounded-full bg-muted" />
+          <div className="h-4 w-10 bg-muted rounded" />
+          <div className="h-4 flex-1 bg-muted rounded" />
+          <div className="h-5 w-8 bg-muted rounded" />
         </div>
       </div>
       <div className="px-4 pb-3 flex justify-center">
-        <div className="h-3 w-32 bg-slate-200 rounded" />
+        <div className="h-3 w-32 bg-muted rounded" />
       </div>
     </div>
   );

--- a/src/components/team/TeamDetailClient.tsx
+++ b/src/components/team/TeamDetailClient.tsx
@@ -113,7 +113,7 @@ export function TeamDetailClient({
   if (!team) {
     return (
       <div className="text-center py-12">
-        <p className="text-slate-500">找不到此球隊</p>
+        <p className="text-muted-foreground">找不到此球隊</p>
         <Link href={`/standings/${sport}`} className="text-blue-600 text-sm mt-2 inline-block">
           返回排名頁
         </Link>
@@ -125,7 +125,7 @@ export function TeamDetailClient({
     <div className="space-y-6">
       <Link
         href={`/standings/${sport}`}
-        className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-blue-600"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-blue-600"
       >
         <ArrowLeft className="w-4 h-4" />
         返回排名
@@ -139,15 +139,15 @@ export function TeamDetailClient({
               <img src={team.logo} alt={team.name} className="w-16 h-16" />
             )}
             <div className="flex-1">
-              <h1 className="text-2xl font-bold text-slate-900">{team.name}</h1>
+              <h1 className="text-2xl font-bold text-foreground">{team.name}</h1>
               <div className="flex items-center gap-2 mt-1">
                 <Badge variant="secondary">{team.abbreviation}</Badge>
                 {team.record && (
-                  <span className="text-sm text-slate-500">{team.record}</span>
+                  <span className="text-sm text-muted-foreground">{team.record}</span>
                 )}
               </div>
               {team.standingSummary && (
-                <p className="text-sm text-slate-500 mt-1">
+                <p className="text-sm text-muted-foreground mt-1">
                   {team.standingSummary}
                 </p>
               )}
@@ -204,7 +204,7 @@ export function TeamDetailClient({
         </CardHeader>
         <CardContent className="p-0">
           {roster.length === 0 ? (
-            <p className="p-6 text-slate-400 text-center">暫無球員資料</p>
+            <p className="p-6 text-muted-foreground text-center">暫無球員資料</p>
           ) : (
             <MemberGate
               message="登入查看完整球員名單與數據"
@@ -212,7 +212,7 @@ export function TeamDetailClient({
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="border-b bg-slate-50">
+                      <tr className="border-b bg-muted/50">
                         <th className="text-left py-2 px-3">#</th>
                         <th className="text-left py-2 px-3">球員</th>
                         <th className="text-center py-2 px-3">位置</th>
@@ -222,7 +222,7 @@ export function TeamDetailClient({
                     <tbody>
                       {roster.slice(0, 5).map((p) => (
                         <tr key={p.id} className="border-b">
-                          <td className="py-2 px-3 text-slate-500">{p.jersey}</td>
+                          <td className="py-2 px-3 text-muted-foreground">{p.jersey}</td>
                           <td className="py-2 px-3 font-medium">{p.displayName}</td>
                           <td className="text-center py-2 px-3">{p.position}</td>
                           <td className="text-center py-2 px-3">{p.age}</td>
@@ -244,7 +244,7 @@ export function TeamDetailClient({
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b bg-slate-50">
+                    <tr className="border-b bg-muted/50">
                       <th className="text-left py-2 px-3">#</th>
                       <th className="text-left py-2 px-3">球員</th>
                       <th className="text-center py-2 px-3">位置</th>
@@ -256,7 +256,7 @@ export function TeamDetailClient({
                   <tbody>
                     {roster.map((p) => (
                       <tr key={p.id} className="border-b last:border-0">
-                        <td className="py-2 px-3 text-slate-500">{p.jersey}</td>
+                        <td className="py-2 px-3 text-muted-foreground">{p.jersey}</td>
                         <td className="py-2 px-3">
                           <Link
                             href={`/player/${sport}/${p.id}`}


### PR DESCRIPTION
## Summary
- 背景色 oklch(0.98) → oklch(0.95)，灰底白卡 ESPN 風格層次感
- 文章詳情頁、搜尋頁包裹 `bg-card` 白色容器
- ScoreCard 從 `bg-white` 改為 `bg-card`，支援深色模式
- 剩餘硬編碼 `slate-*` 色替換為語意化 token

## Test plan
- [x] TypeScript 零錯誤
- [x] Vitest 245/245 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)