### PR TITLE
feat: 後台訪客分析 — page_views 追蹤 + Dashboard (#51)

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { PublicHeader } from "@/components/public/PublicHeader";
 import { PullToRefresh } from "@/components/public/PullToRefresh";
+import { PageTracker } from "@/components/public/PageTracker";
 
 const footerLinks = [
   { href: "/scores", label: "即時比分" },
@@ -25,6 +26,7 @@ export default function PublicLayout({
       {/* Scrollable content area */}
       <div id="scroll-container" className="flex-1 overflow-y-auto overscroll-contain">
         <PullToRefresh scrollContainerId="scroll-container" />
+        <PageTracker />
         {/* Main Content */}
         <main className="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8">
           {children}

--- a/src/app/admin/AdminLayoutClient.tsx
+++ b/src/app/admin/AdminLayoutClient.tsx
@@ -16,6 +16,7 @@ const navItems = [
   { href: "/admin/channels", label: "發布頻道" },
   { href: "/admin/scoreboard", label: "即時比分" },
   { href: "/admin/analytics", label: "成效分析" },
+  { href: "/admin/visitors", label: "訪客分析" },
 ];
 
 export default function AdminLayout({

--- a/src/app/admin/visitors/page.tsx
+++ b/src/app/admin/visitors/page.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BarChart3, Eye, Users, Monitor, Smartphone, Tablet, Globe, ArrowRight } from "lucide-react";
+
+interface VisitorData {
+  summary: {
+    totalPV: number;
+    totalUV: number;
+    avgPagesPerVisitor: number;
+    todayPV: number;
+    todayUV: number;
+  };
+  dailyTrend: { date: string; pv: number; uv: number }[];
+  topPages: { path: string; pv: number; uv: number }[];
+  referrerSources: { source: string; count: number }[];
+  devices: { device: string; count: number }[];
+  recentSessions: {
+    sessionId: string;
+    pageCount: number;
+    firstSeen: string;
+    lastPage: string;
+    ua: string;
+    pages: { path: string; time: string }[];
+  }[];
+}
+
+const DEVICE_ICONS: Record<string, typeof Monitor> = {
+  Desktop: Monitor,
+  Mobile: Smartphone,
+  Tablet: Tablet,
+};
+
+export default function VisitorsPage() {
+  const [data, setData] = useState<VisitorData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState("7d");
+  const [expandedSession, setExpandedSession] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/admin/visitors?period=${period}`)
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [period]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">訪客分析</h1>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-24 bg-gray-100 rounded-xl animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div>
+        <h1 className="text-2xl font-bold mb-4">訪客分析</h1>
+        <p className="text-gray-500">無法載入訪客資料</p>
+      </div>
+    );
+  }
+
+  const { summary, dailyTrend, topPages, referrerSources, devices, recentSessions } = data;
+  const maxDailyPV = Math.max(...dailyTrend.map((d) => d.pv), 1);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">訪客分析</h1>
+        <div className="flex items-center gap-1 bg-gray-100 rounded-lg p-1">
+          {["7d", "30d", "90d"].map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                period === p ? "bg-white text-gray-900 shadow-sm" : "text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {p === "7d" ? "7 天" : p === "30d" ? "30 天" : "90 天"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
+              <Eye className="w-4 h-4" />
+              今日 PV
+            </div>
+            <div className="text-2xl font-bold text-blue-600">{summary.todayPV}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
+              <Users className="w-4 h-4" />
+              今日 UV
+            </div>
+            <div className="text-2xl font-bold text-green-600">{summary.todayUV}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
+              <BarChart3 className="w-4 h-4" />
+              總 PV
+            </div>
+            <div className="text-2xl font-bold">{summary.totalPV.toLocaleString()}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
+              <Users className="w-4 h-4" />
+              總 UV
+            </div>
+            <div className="text-2xl font-bold">{summary.totalUV.toLocaleString()}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-1">
+              <Globe className="w-4 h-4" />
+              平均頁數/人
+            </div>
+            <div className="text-2xl font-bold">{summary.avgPagesPerVisitor}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Daily Trend - Simple bar chart */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">每日瀏覽趨勢</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {dailyTrend.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-8">尚無資料</p>
+          ) : (
+            <div className="space-y-1.5">
+              {dailyTrend.map((d) => (
+                <div key={d.date} className="flex items-center gap-3 text-xs">
+                  <span className="w-20 text-gray-500 tabular-nums flex-shrink-0">
+                    {new Date(d.date + "T00:00:00").toLocaleDateString("zh-TW", { month: "short", day: "numeric", weekday: "short" })}
+                  </span>
+                  <div className="flex-1 flex items-center gap-2">
+                    <div
+                      className="h-5 bg-blue-500 rounded-sm transition-all"
+                      style={{ width: `${Math.max((d.pv / maxDailyPV) * 100, 2)}%` }}
+                    />
+                    <span className="text-gray-600 tabular-nums">{d.pv} PV / {d.uv} UV</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Top Pages */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">熱門頁面 TOP 20</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {topPages.map((p, i) => (
+                <div key={p.path} className="flex items-center gap-2 text-xs">
+                  <span className="w-5 text-gray-400 text-right">{i + 1}</span>
+                  <span className="flex-1 truncate text-gray-700" title={p.path}>
+                    {p.path}
+                  </span>
+                  <span className="text-gray-500 tabular-nums">{p.pv} PV</span>
+                  <span className="text-gray-400 tabular-nums">{p.uv} UV</span>
+                </div>
+              ))}
+              {topPages.length === 0 && (
+                <p className="text-sm text-gray-400 text-center py-4">尚無資料</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-4">
+          {/* Referrer Sources */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">流量來源</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {referrerSources.map((r) => {
+                  const pct = summary.totalPV > 0 ? Math.round((r.count / summary.totalPV) * 100) : 0;
+                  return (
+                    <div key={r.source} className="flex items-center gap-2 text-xs">
+                      <span className="w-20 text-gray-700">{r.source}</span>
+                      <div className="flex-1 bg-gray-100 rounded-full h-4 overflow-hidden">
+                        <div
+                          className="h-full bg-blue-400 rounded-full"
+                          style={{ width: `${Math.max(pct, 2)}%` }}
+                        />
+                      </div>
+                      <span className="text-gray-500 tabular-nums w-16 text-right">{r.count} ({pct}%)</span>
+                    </div>
+                  );
+                })}
+                {referrerSources.length === 0 && (
+                  <p className="text-sm text-gray-400 text-center py-4">尚無資料</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Device Distribution */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">裝置分佈</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-6">
+                {devices.map((d) => {
+                  const Icon = DEVICE_ICONS[d.device] || Monitor;
+                  const pct = summary.totalPV > 0 ? Math.round((d.count / summary.totalPV) * 100) : 0;
+                  return (
+                    <div key={d.device} className="flex items-center gap-2">
+                      <Icon className="w-5 h-5 text-gray-400" />
+                      <div>
+                        <div className="text-sm font-medium">{d.device}</div>
+                        <div className="text-xs text-gray-500">{pct}% ({d.count})</div>
+                      </div>
+                    </div>
+                  );
+                })}
+                {devices.length === 0 && (
+                  <p className="text-sm text-gray-400">尚無資料</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Recent Sessions */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">最近訪客（20 筆）</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-1">
+            {recentSessions.map((s) => (
+              <div key={s.sessionId} className="border-b border-gray-100 last:border-0">
+                <button
+                  onClick={() => setExpandedSession(expandedSession === s.sessionId ? null : s.sessionId)}
+                  className="w-full flex items-center gap-3 py-2 text-xs hover:bg-gray-50 rounded transition-colors text-left"
+                >
+                  <span className="font-mono text-gray-400 w-16">{s.sessionId}</span>
+                  <span className="text-gray-600">{s.pageCount} 頁</span>
+                  <span className="flex-1 truncate text-gray-500">{s.lastPage}</span>
+                  <span className="text-gray-400 w-14 text-right">
+                    {new Date(s.firstSeen).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit" })}
+                  </span>
+                </button>
+                {expandedSession === s.sessionId && (
+                  <div className="pl-8 pb-2 space-y-0.5">
+                    {s.pages.map((p, i) => (
+                      <div key={i} className="flex items-center gap-2 text-xs text-gray-500">
+                        <span className="text-gray-300">
+                          {new Date(p.time).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
+                        </span>
+                        {i < s.pages.length - 1 && <ArrowRight className="w-3 h-3 text-gray-300" />}
+                        <span className="text-gray-600">{p.path}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+            {recentSessions.length === 0 && (
+              <p className="text-sm text-gray-400 text-center py-8">尚無訪客資料</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/api/admin/visitors/route.ts
+++ b/src/app/api/admin/visitors/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+
+export async function GET(req: NextRequest) {
+  const period = req.nextUrl.searchParams.get("period") || "7d";
+  const days = period === "30d" ? 30 : period === "90d" ? 90 : 7;
+
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+  const sinceStr = since.toISOString();
+
+  const supabase = createServiceClient();
+
+  // Fetch all page views in period
+  const { data: views } = await supabase
+    .from("page_views")
+    .select("session_id, page_path, referrer, user_agent, ip_hash, created_at")
+    .gte("created_at", sinceStr)
+    .order("created_at", { ascending: false })
+    .limit(50000);
+
+  const allViews = views ?? [];
+
+  // --- Summary ---
+  const totalPV = allViews.length;
+  const uniqueSessions = new Set(allViews.map((v) => v.session_id));
+  const totalUV = uniqueSessions.size;
+  const avgPagesPerVisitor = totalUV > 0 ? Math.round((totalPV / totalUV) * 10) / 10 : 0;
+
+  // Today stats
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const todayViews = allViews.filter((v) => v.created_at?.startsWith(todayStr));
+  const todayPV = todayViews.length;
+  const todayUV = new Set(todayViews.map((v) => v.session_id)).size;
+
+  // --- Daily trend ---
+  const dailyMap = new Map<string, { pv: number; sessions: Set<string> }>();
+  for (const v of allViews) {
+    const day = v.created_at?.slice(0, 10) ?? "";
+    if (!dailyMap.has(day)) dailyMap.set(day, { pv: 0, sessions: new Set() });
+    const d = dailyMap.get(day)!;
+    d.pv++;
+    d.sessions.add(v.session_id);
+  }
+  const dailyTrend = Array.from(dailyMap.entries())
+    .map(([date, d]) => ({ date, pv: d.pv, uv: d.sessions.size }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  // --- Top pages ---
+  const pageMap = new Map<string, { pv: number; sessions: Set<string> }>();
+  for (const v of allViews) {
+    if (!pageMap.has(v.page_path)) pageMap.set(v.page_path, { pv: 0, sessions: new Set() });
+    const p = pageMap.get(v.page_path)!;
+    p.pv++;
+    p.sessions.add(v.session_id);
+  }
+  const topPages = Array.from(pageMap.entries())
+    .map(([path, p]) => ({ path, pv: p.pv, uv: p.sessions.size }))
+    .sort((a, b) => b.pv - a.pv)
+    .slice(0, 20);
+
+  // --- Referrer sources ---
+  const refMap = new Map<string, number>();
+  for (const v of allViews) {
+    let source = "直接訪問";
+    const ref = v.referrer || "";
+    if (ref.includes("t.me") || ref.includes("telegram")) source = "Telegram";
+    else if (ref.includes("line.me") || ref.includes("line://")) source = "LINE";
+    else if (ref.includes("google")) source = "Google";
+    else if (ref.includes("facebook") || ref.includes("fb.com")) source = "Facebook";
+    else if (ref.includes("twitter") || ref.includes("x.com")) source = "X/Twitter";
+    else if (ref && ref !== "") source = "其他";
+    refMap.set(source, (refMap.get(source) || 0) + 1);
+  }
+  const referrerSources = Array.from(refMap.entries())
+    .map(([source, count]) => ({ source, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // --- Device distribution ---
+  const deviceMap = new Map<string, number>();
+  for (const v of allViews) {
+    const ua = (v.user_agent || "").toLowerCase();
+    let device = "Desktop";
+    if (/mobile|android|iphone|ipad|ipod/i.test(ua)) {
+      device = /ipad|tablet/i.test(ua) ? "Tablet" : "Mobile";
+    }
+    deviceMap.set(device, (deviceMap.get(device) || 0) + 1);
+  }
+  const devices = Array.from(deviceMap.entries())
+    .map(([device, count]) => ({ device, count }))
+    .sort((a, b) => b.count - a.count);
+
+  // --- Recent sessions (last 20 unique) ---
+  const sessionMap = new Map<string, { pages: { path: string; time: string }[]; firstSeen: string; ua: string }>();
+  for (const v of allViews) {
+    if (!sessionMap.has(v.session_id)) {
+      sessionMap.set(v.session_id, { pages: [], firstSeen: v.created_at, ua: v.user_agent || "" });
+    }
+    sessionMap.get(v.session_id)!.pages.push({
+      path: v.page_path,
+      time: v.created_at,
+    });
+  }
+  const recentSessions = Array.from(sessionMap.entries())
+    .map(([id, s]) => ({
+      sessionId: id.slice(0, 8) + "...",
+      pageCount: s.pages.length,
+      firstSeen: s.firstSeen,
+      lastPage: s.pages[0]?.path ?? "",
+      ua: s.ua.slice(0, 80),
+      pages: s.pages.slice(0, 20).reverse(),
+    }))
+    .sort((a, b) => b.firstSeen.localeCompare(a.firstSeen))
+    .slice(0, 20);
+
+  return NextResponse.json({
+    summary: { totalPV, totalUV, avgPagesPerVisitor, todayPV, todayUV },
+    dailyTrend,
+    topPages,
+    referrerSources,
+    devices,
+    recentSessions,
+  });
+}

--- a/src/app/api/cron/cleanup-pageviews/route.ts
+++ b/src/app/api/cron/cleanup-pageviews/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+
+/**
+ * Cron job: 清除 90 天前的 page_views 資料
+ * 建議每天跑一次
+ */
+export async function GET() {
+  try {
+    const supabase = createServiceClient();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 90);
+
+    const { error } = await supabase
+      .from("page_views")
+      .delete()
+      .lt("created_at", cutoff.toISOString());
+
+    if (error) throw error;
+
+    return NextResponse.json({
+      ok: true,
+      cutoff: cutoff.toISOString(),
+    });
+  } catch (err) {
+    console.error("[Cron] cleanup-pageviews error:", err);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/public/pageview/route.ts
+++ b/src/app/api/public/pageview/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+import crypto from "crypto";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { sessionId, path, referrer } = body;
+
+    if (!sessionId || !path) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    }
+
+    // Hash IP for privacy
+    const forwarded = req.headers.get("x-forwarded-for");
+    const ip = forwarded?.split(",")[0]?.trim() || "unknown";
+    const ipHash = crypto.createHash("sha256").update(ip + "pageview-salt").digest("hex").slice(0, 16);
+
+    const userAgent = req.headers.get("user-agent") || "";
+
+    const supabase = createServiceClient();
+    await supabase.from("page_views").insert({
+      session_id: sessionId.slice(0, 64),
+      page_path: path.slice(0, 500),
+      referrer: referrer?.slice(0, 1000) || null,
+      user_agent: userAgent.slice(0, 500),
+      ip_hash: ipHash,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/components/public/PageTracker.tsx
+++ b/src/components/public/PageTracker.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+const SESSION_KEY = "pv_session_id";
+const SESSION_EXPIRY_KEY = "pv_session_expiry";
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+function getSessionId(): string {
+  const now = Date.now();
+  const expiry = parseInt(localStorage.getItem(SESSION_EXPIRY_KEY) || "0", 10);
+  let sessionId = localStorage.getItem(SESSION_KEY);
+
+  if (!sessionId || now > expiry) {
+    sessionId = crypto.randomUUID();
+    localStorage.setItem(SESSION_KEY, sessionId);
+  }
+
+  // Extend expiry on every activity
+  localStorage.setItem(SESSION_EXPIRY_KEY, String(now + SESSION_TTL_MS));
+  return sessionId;
+}
+
+export function PageTracker() {
+  const pathname = usePathname();
+  const lastTracked = useRef<string>("");
+
+  useEffect(() => {
+    // Don't double-track the same path
+    if (pathname === lastTracked.current) return;
+    lastTracked.current = pathname;
+
+    try {
+      const sessionId = getSessionId();
+      const referrer = document.referrer || "";
+
+      // Use sendBeacon for fire-and-forget (doesn't block navigation)
+      const data = JSON.stringify({
+        sessionId,
+        path: pathname,
+        referrer,
+      });
+
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon("/api/public/pageview", new Blob([data], { type: "application/json" }));
+      } else {
+        fetch("/api/public/pageview", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: data,
+          keepalive: true,
+        }).catch(() => {});
+      }
+    } catch {
+      // Silent fail — analytics should never break the app
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/supabase/migrations/014_page_views.sql
+++ b/supabase/migrations/014_page_views.sql
@@ -1,0 +1,15 @@
+-- Page views tracking for visitor analytics
+CREATE TABLE IF NOT EXISTS page_views (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  session_id text NOT NULL,
+  page_path text NOT NULL,
+  referrer text,
+  user_agent text,
+  ip_hash text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_page_views_session ON page_views(session_id);
+CREATE INDEX IF NOT EXISTS idx_page_views_path ON page_views(page_path);
+CREATE INDEX IF NOT EXISTS idx_page_views_created ON page_views(created_at);
+CREATE INDEX IF NOT EXISTS idx_page_views_ip ON page_views(ip_hash);


### PR DESCRIPTION
## Summary
- 新增 `page_views` 表 + migration
- `PageTracker` 元件自動追蹤路由（sendBeacon）
- Session ID：localStorage + 30 分鐘過期
- 後台 `/admin/visitors`：PV/UV 趨勢、熱門頁面、流量來源、裝置分佈、訪客路徑展開
- Cron cleanup API 清除 90 天前資料

## Test plan
- [x] TypeScript 零錯誤
- [x] Vitest 270/270 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)