### PR TITLE
feat: 訪客分析強化 — 路徑中文 + visitor_id + 雙重去重 (#55)

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -45,7 +45,7 @@ interface VisitorData {
     memberViews: number;
   };
   dailyTrend: { date: string; pv: number; uv: number }[];
-  topPages: { path: string; pv: number; uv: number }[];
+  topPages: { path: string; name: string; pv: number; uv: number }[];
   referrerSources: { source: string; count: number }[];
   devices: { device: string; count: number }[];
   recentSessions: {
@@ -55,7 +55,7 @@ interface VisitorData {
     firstSeen: string;
     lastPage: string;
     ua: string;
-    pages: { path: string; time: string }[];
+    pages: { path: string; name: string; time: string }[];
   }[];
 }
 
@@ -233,7 +233,7 @@ export default function AnalyticsPage() {
                   {visitor.topPages.map((p, i) => (
                     <div key={p.path} className="flex items-center gap-2 text-xs">
                       <span className="w-5 text-gray-400 text-right">{i + 1}</span>
-                      <span className="flex-1 truncate text-gray-700" title={p.path}>{p.path}</span>
+                      <span className="flex-1 truncate text-gray-700" title={p.path}>{p.name}</span>
                       <span className="text-gray-500 tabular-nums">{p.pv}</span>
                       <span className="text-gray-400 tabular-nums">{p.uv} UV</span>
                     </div>
@@ -317,7 +317,7 @@ export default function AnalyticsPage() {
                               {new Date(p.time).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", second: "2-digit" })}
                             </span>
                             {i < s.pages.length - 1 && <ArrowRight className="w-3 h-3 text-gray-300" />}
-                            <span className="text-gray-600">{p.path}</span>
+                            <span className="text-gray-600">{p.name}</span>
                           </div>
                         ))}
                       </div>

--- a/src/app/api/admin/visitors/route.ts
+++ b/src/app/api/admin/visitors/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase";
+import { getPageName } from "@/lib/constants";
+
+/** Get the best unique identifier for a visitor (priority: member > visitor+ip > visitor > ip) */
+function getVisitorKey(v: { member_id: string | null; visitor_id: string | null; ip_hash: string | null; session_id: string }): string {
+  if (v.member_id) return `m:${v.member_id}`;
+  if (v.visitor_id && v.ip_hash) return `v:${v.visitor_id}`;
+  if (v.visitor_id) return `v:${v.visitor_id}`;
+  if (v.ip_hash) return `ip:${v.ip_hash}`;
+  return `s:${v.session_id}`;
+}
 
 export async function GET(req: NextRequest) {
   const period = req.nextUrl.searchParams.get("period") || "7d";
@@ -7,18 +17,17 @@ export async function GET(req: NextRequest) {
 
   const since = new Date();
   since.setDate(since.getDate() - days);
-  const sinceStr = since.toISOString();
 
   const supabase = createServiceClient();
 
   const { data: views } = await supabase
     .from("page_views")
-    .select("session_id, member_id, page_path, referrer, user_agent, ip_hash, created_at")
-    .gte("created_at", sinceStr)
+    .select("session_id, visitor_id, member_id, page_path, referrer, user_agent, ip_hash, created_at")
+    .gte("created_at", since.toISOString())
     .order("created_at", { ascending: false })
     .limit(50000);
 
-  // Filter out bot traffic in query results (defense in depth)
+  // Filter bots (defense in depth)
   const allViews = (views ?? []).filter((v) => {
     const ua = (v.user_agent || "").toLowerCase();
     return !(/headlesschrome|playwright|puppeteer|selenium|bot|spider|crawl/i.test(ua));
@@ -26,17 +35,14 @@ export async function GET(req: NextRequest) {
 
   // --- Summary ---
   const totalPV = allViews.length;
-  // UV: use member_id if available, fallback to session_id
-  const uniqueVisitors = new Set(allViews.map((v) => v.member_id || v.session_id));
+  const uniqueVisitors = new Set(allViews.map(getVisitorKey));
   const totalUV = uniqueVisitors.size;
   const avgPagesPerVisitor = totalUV > 0 ? Math.round((totalPV / totalUV) * 10) / 10 : 0;
 
   const todayStr = new Date().toISOString().slice(0, 10);
   const todayViews = allViews.filter((v) => v.created_at?.startsWith(todayStr));
   const todayPV = todayViews.length;
-  const todayUV = new Set(todayViews.map((v) => v.member_id || v.session_id)).size;
-
-  // Count logged-in views
+  const todayUV = new Set(todayViews.map(getVisitorKey)).size;
   const memberViews = allViews.filter((v) => v.member_id).length;
 
   // --- Daily trend ---
@@ -46,22 +52,22 @@ export async function GET(req: NextRequest) {
     if (!dailyMap.has(day)) dailyMap.set(day, { pv: 0, visitors: new Set() });
     const d = dailyMap.get(day)!;
     d.pv++;
-    d.visitors.add(v.member_id || v.session_id);
+    d.visitors.add(getVisitorKey(v));
   }
   const dailyTrend = Array.from(dailyMap.entries())
     .map(([date, d]) => ({ date, pv: d.pv, uv: d.visitors.size }))
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  // --- Top pages ---
+  // --- Top pages (with Chinese names) ---
   const pageMap = new Map<string, { pv: number; visitors: Set<string> }>();
   for (const v of allViews) {
     if (!pageMap.has(v.page_path)) pageMap.set(v.page_path, { pv: 0, visitors: new Set() });
     const p = pageMap.get(v.page_path)!;
     p.pv++;
-    p.visitors.add(v.member_id || v.session_id);
+    p.visitors.add(getVisitorKey(v));
   }
   const topPages = Array.from(pageMap.entries())
-    .map(([path, p]) => ({ path, pv: p.pv, uv: p.visitors.size }))
+    .map(([path, p]) => ({ path, name: getPageName(path), pv: p.pv, uv: p.visitors.size }))
     .sort((a, b) => b.pv - a.pv)
     .slice(0, 20);
 
@@ -82,7 +88,7 @@ export async function GET(req: NextRequest) {
     .map(([source, count]) => ({ source, count }))
     .sort((a, b) => b.count - a.count);
 
-  // --- Device distribution ---
+  // --- Devices ---
   const deviceMap = new Map<string, number>();
   for (const v of allViews) {
     const ua = (v.user_agent || "").toLowerCase();
@@ -96,25 +102,40 @@ export async function GET(req: NextRequest) {
     .map(([device, count]) => ({ device, count }))
     .sort((a, b) => b.count - a.count);
 
-  // --- Recent sessions ---
-  const sessionMap = new Map<string, { pages: { path: string; time: string }[]; firstSeen: string; ua: string; memberId: string | null }>();
+  // --- Recent sessions (with Chinese page names) ---
+  const sessionMap = new Map<string, {
+    pages: { path: string; name: string; time: string }[];
+    firstSeen: string;
+    ua: string;
+    memberId: string | null;
+    visitorKey: string;
+  }>();
   for (const v of allViews) {
-    const key = v.member_id || v.session_id;
+    const key = getVisitorKey(v);
     if (!sessionMap.has(key)) {
-      sessionMap.set(key, { pages: [], firstSeen: v.created_at, ua: v.user_agent || "", memberId: v.member_id });
+      sessionMap.set(key, {
+        pages: [],
+        firstSeen: v.created_at,
+        ua: v.user_agent || "",
+        memberId: v.member_id,
+        visitorKey: key,
+      });
     }
     sessionMap.get(key)!.pages.push({
       path: v.page_path,
+      name: getPageName(v.page_path),
       time: v.created_at,
     });
   }
   const recentSessions = Array.from(sessionMap.entries())
-    .map(([id, s]) => ({
-      sessionId: s.memberId ? `會員 ${id.slice(0, 8)}...` : id.slice(0, 8) + "...",
+    .map(([, s]) => ({
+      sessionId: s.memberId
+        ? `會員 ${s.memberId.slice(0, 8)}...`
+        : s.visitorKey.slice(0, 12) + "...",
       isMember: !!s.memberId,
       pageCount: s.pages.length,
       firstSeen: s.firstSeen,
-      lastPage: s.pages[0]?.path ?? "",
+      lastPage: s.pages[0]?.name ?? s.pages[0]?.path ?? "",
       ua: s.ua.slice(0, 80),
       pages: s.pages.slice(0, 30).reverse(),
     }))

--- a/src/app/api/public/pageview/route.ts
+++ b/src/app/api/public/pageview/route.ts
@@ -3,28 +3,11 @@ import { createServiceClient } from "@/lib/supabase";
 import crypto from "crypto";
 
 const BOT_PATTERNS = [
-  /headlesschrome/i,
-  /playwright/i,
-  /puppeteer/i,
-  /selenium/i,
-  /googlebot/i,
-  /bingbot/i,
-  /slurp/i,
-  /duckduckbot/i,
-  /baiduspider/i,
-  /yandexbot/i,
-  /facebookexternalhit/i,
-  /twitterbot/i,
-  /linkedinbot/i,
-  /whatsapp/i,
-  /telegrambot/i,
-  /applebot/i,
-  /mj12bot/i,
-  /ahrefsbot/i,
-  /semrushbot/i,
-  /dotbot/i,
-  /petalbot/i,
-  /bytespider/i,
+  /headlesschrome/i, /playwright/i, /puppeteer/i, /selenium/i,
+  /googlebot/i, /bingbot/i, /slurp/i, /duckduckbot/i, /baiduspider/i,
+  /yandexbot/i, /facebookexternalhit/i, /twitterbot/i, /linkedinbot/i,
+  /whatsapp/i, /telegrambot/i, /applebot/i, /mj12bot/i, /ahrefsbot/i,
+  /semrushbot/i, /dotbot/i, /petalbot/i, /bytespider/i,
 ];
 
 function isBot(ua: string): boolean {
@@ -34,27 +17,25 @@ function isBot(ua: string): boolean {
 export async function POST(req: NextRequest) {
   try {
     const userAgent = req.headers.get("user-agent") || "";
-
-    // Filter out bots and automated test traffic
     if (isBot(userAgent)) {
       return NextResponse.json({ ok: true, filtered: "bot" });
     }
 
     const body = await req.json();
-    const { sessionId, path, referrer, memberId } = body;
+    const { visitorId, sessionId, path, referrer, memberId } = body;
 
-    if (!sessionId || !path) {
-      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    if (!path) {
+      return NextResponse.json({ error: "Missing path" }, { status: 400 });
     }
 
-    // Hash IP for privacy
     const forwarded = req.headers.get("x-forwarded-for");
     const ip = forwarded?.split(",")[0]?.trim() || "unknown";
     const ipHash = crypto.createHash("sha256").update(ip + "pageview-salt").digest("hex").slice(0, 16);
 
     const supabase = createServiceClient();
     await supabase.from("page_views").insert({
-      session_id: sessionId.slice(0, 64),
+      visitor_id: visitorId?.slice(0, 64) || null,
+      session_id: (sessionId || visitorId || "unknown").slice(0, 64),
       page_path: path.slice(0, 500),
       referrer: referrer?.slice(0, 1000) || null,
       user_agent: userAgent.slice(0, 500),

--- a/src/components/public/PageTracker.tsx
+++ b/src/components/public/PageTracker.tsx
@@ -4,10 +4,22 @@ import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 
+const VISITOR_KEY = "pv_visitor_id";
 const SESSION_KEY = "pv_session_id";
 const SESSION_EXPIRY_KEY = "pv_session_expiry";
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
+/** Persistent visitor ID — never expires unless user clears browser data */
+function getVisitorId(): string {
+  let visitorId = localStorage.getItem(VISITOR_KEY);
+  if (!visitorId) {
+    visitorId = crypto.randomUUID();
+    localStorage.setItem(VISITOR_KEY, visitorId);
+  }
+  return visitorId;
+}
+
+/** Session ID — expires after 30 min of inactivity, used for path tracking */
 function getSessionId(): string {
   const now = Date.now();
   const expiry = parseInt(localStorage.getItem(SESSION_EXPIRY_KEY) || "0", 10);
@@ -18,7 +30,6 @@ function getSessionId(): string {
     localStorage.setItem(SESSION_KEY, sessionId);
   }
 
-  // Extend expiry on every activity
   localStorage.setItem(SESSION_EXPIRY_KEY, String(now + SESSION_TTL_MS));
   return sessionId;
 }
@@ -33,11 +44,13 @@ export function PageTracker() {
     lastTracked.current = pathname;
 
     try {
+      const visitorId = getVisitorId();
       const sessionId = getSessionId();
       const referrer = document.referrer || "";
       const memberId = (session?.user as { id?: string } | undefined)?.id || null;
 
       const data = JSON.stringify({
+        visitorId,
         sessionId,
         path: pathname,
         referrer,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -127,6 +127,37 @@ export const SITE_URL =
 
 export const TELEGRAM_CHANNEL_URL = "https://t.me/howger_sport_news";
 
+/** 頁面路徑 → 中文名稱，用於後台分析顯示 */
+const PAGE_NAME_MAP: Record<string, string> = {
+  "/": "首頁",
+  "/scores": "即時比分",
+  "/odds": "賠率",
+  "/search": "搜尋",
+  "/install": "安裝 App",
+  "/settings": "設定",
+  "/privacy": "隱私權政策",
+  "/standings/nba": "NBA 排名",
+  "/standings/mlb": "MLB 排名",
+  "/category/nba": "NBA 新聞",
+  "/category/mlb": "MLB 新聞",
+  "/category/soccer": "足球新聞",
+  "/category/general": "綜合新聞",
+};
+
+export function getPageName(path: string): string {
+  // Exact match
+  if (PAGE_NAME_MAP[path]) return PAGE_NAME_MAP[path];
+  // Pattern match
+  if (path.startsWith("/news/")) return "文章";
+  if (path.startsWith("/game/")) return "比賽詳情";
+  if (path.startsWith("/team/")) return "球隊頁";
+  if (path.startsWith("/player/")) return "球員頁";
+  if (path.startsWith("/writer/")) return "作者頁";
+  if (path.startsWith("/standings/")) return "排名";
+  if (path.startsWith("/category/")) return "分類";
+  return path;
+}
+
 export const CATEGORY_COLORS: Record<string, string> = {
   NBA: "bg-orange-500 text-white rounded-md",
   籃球: "bg-orange-500 text-white rounded-md",

--- a/supabase/migrations/016_page_views_visitor_id.sql
+++ b/supabase/migrations/016_page_views_visitor_id.sql
@@ -1,0 +1,3 @@
+-- Add persistent visitor_id for more reliable UV tracking
+ALTER TABLE page_views ADD COLUMN IF NOT EXISTS visitor_id text;
+CREATE INDEX IF NOT EXISTS idx_page_views_visitor ON page_views(visitor_id);


### PR DESCRIPTION
## Summary
- 頁面路徑中文化（`getPageName()`：/ → 首頁、/scores → 即時比分）
- 持久 `visitor_id`（localStorage 永不過期，瀏覽器不清除就固定）
- UV 去重優先級：`member_id` > `visitor_id` > `ip_hash`
- `page_views` 加 `visitor_id` 欄位（migration 016）

## Test plan
- [x] TypeScript 零錯誤
- [x] Vitest 270/270 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)