### PR TITLE
fix: 前台多項修正 — 中文化、百分比 bug、球隊連結、tab 狀態、勝率圖

### DIFF
--- a/e2e/game-detail.spec.ts
+++ b/e2e/game-detail.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * Game Detail E2E tests
+ * 測試比賽詳情頁的 tab 切換、球隊連結、專家預測百分比、URL 狀態保持
+ */
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Game Detail Page
+// ---------------------------------------------------------------------------
+test.describe("比賽詳情頁", () => {
+  test("從 Scoreboard API 取得 eventId 後載入頁面", async ({
+    page,
+    request,
+  }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    if (!resp.ok()) {
+      test.skip(true, "Scoreboard API unavailable");
+      return;
+    }
+    const json = await resp.json();
+    const game = json.games?.[0];
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    await page.goto(`/game/nba/${game.id}`);
+
+    // 頁面載入成功 — 應有返回比分連結
+    await expect(
+      page.getByRole("link", { name: /返回比分/ })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 應顯示 Tab 列
+    await expect(page.getByRole("tab", { name: "摘要" })).toBeVisible();
+  });
+
+  test("Tab 切換會更新 URL query parameter", async ({ page, request }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    const json = await resp.json();
+    const game = json.games?.[0];
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    await page.goto(`/game/nba/${game.id}`);
+    await expect(page.getByRole("tab", { name: "摘要" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 點擊「賠率」tab
+    await page.getByRole("tab", { name: "賠率" }).click();
+    await expect(page).toHaveURL(/[?&]tab=odds/);
+
+    // 點擊「傷兵」tab
+    await page.getByRole("tab", { name: "傷兵" }).click();
+    await expect(page).toHaveURL(/[?&]tab=injuries/);
+  });
+
+  test("切 tab → 離開 → 返回 → tab 狀態保持", async ({ page, request }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    const json = await resp.json();
+    const game = json.games?.[0];
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    // 進入 game detail 並切到賠率 tab
+    await page.goto(`/game/nba/${game.id}`);
+    await expect(page.getByRole("tab", { name: "摘要" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByRole("tab", { name: "賠率" }).click();
+    await expect(page).toHaveURL(/[?&]tab=odds/);
+
+    // 離開到首頁
+    await page.goto("/scores");
+    await expect(
+      page.getByRole("heading", { name: "即時比分" }).or(
+        page.getByText("即時比分功能即將上線")
+      )
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 返回（使用瀏覽器 back）
+    await page.goBack();
+
+    // URL 應仍有 tab=odds
+    await expect(page).toHaveURL(/[?&]tab=odds/);
+    // 賠率 tab 應為 active
+    const oddsTab = page.getByRole("tab", { name: "賠率" });
+    await expect(oddsTab).toBeVisible({ timeout: 15_000 });
+    await expect(oddsTab).toHaveAttribute("data-state", "active");
+  });
+
+  test("球隊連結使用數字 ID 而非 abbreviation", async ({
+    page,
+    request,
+  }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    const json = await resp.json();
+    const game = json.games?.[0];
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    await page.goto(`/game/nba/${game.id}`);
+    await expect(
+      page.getByRole("link", { name: /返回比分/ })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 找到球隊連結（header 中有 2 個球隊連結）
+    const teamLinks = page.locator(
+      'a[href^="/team/nba/"]'
+    );
+    const count = await teamLinks.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+
+    // 驗證連結 href 使用數字 ID（非 3 字母 abbreviation）
+    for (let i = 0; i < Math.min(count, 2); i++) {
+      const href = await teamLinks.nth(i).getAttribute("href");
+      expect(href).toBeTruthy();
+      const idPart = href!.split("/").pop();
+      // ESPN team IDs are numeric
+      expect(idPart).toMatch(/^\d+$/);
+    }
+  });
+
+  test("點擊球隊連結可成功載入球隊頁", async ({ page, request }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    const json = await resp.json();
+    const game = json.games?.[0];
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    await page.goto(`/game/nba/${game.id}`);
+    await expect(
+      page.getByRole("link", { name: /返回比分/ })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 記錄 dialog 錯誤
+    const dialogMessages: string[] = [];
+    page.on("dialog", async (dialog) => {
+      dialogMessages.push(dialog.message());
+      await dialog.dismiss();
+    });
+
+    // 點擊第一個球隊連結
+    const teamLink = page.locator('a[href^="/team/nba/"]').first();
+    await teamLink.click();
+
+    // 等待球隊頁載入 — 應出現球員名單相關文字
+    await expect(
+      page.getByText("球員名單", { exact: true }).or(page.getByText("近期賽程", { exact: true }))
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 不應有 alert 錯誤
+    expect(dialogMessages).toHaveLength(0);
+  });
+
+  test("專家預測百分比不超過 100%", async ({ page, request }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    const json = await resp.json();
+    const games = json.games ?? [];
+
+    // 找一場已結束或進行中的比賽（較可能有 pick center 資料）
+    const game =
+      games.find(
+        (g: { status: string }) =>
+          g.status === "final" || g.status === "in_progress"
+      ) ?? games[0];
+
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    await page.goto(`/game/nba/${game.id}`);
+    await expect(page.getByRole("tab", { name: "摘要" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 等待摘要 tab 內容載入
+    await page.waitForTimeout(2000);
+
+    // 檢查所有 pick center 百分比文字
+    const pctTexts = await page
+      .locator("text=/\\d+%/")
+      .allTextContents();
+
+    for (const text of pctTexts) {
+      const match = text.match(/(\d+)%/);
+      if (match) {
+        const pct = parseInt(match[1]);
+        expect(pct).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+
+  test("賠率術語包含中文註解", async ({ page, request }) => {
+    const resp = await request.get("/api/public/scoreboard?league=nba");
+    const json = await resp.json();
+    const game = json.games?.[0];
+    if (!game) {
+      test.skip(true, "No NBA games available");
+      return;
+    }
+
+    await page.goto(`/game/nba/${game.id}`);
+    await expect(page.getByRole("tab", { name: "摘要" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // 如果有賠率區塊，應該包含中文註解
+    const spreadLabel = page.getByText("Spread (讓分)");
+    const ouLabel = page.getByText("O/U (大小分)");
+
+    // 只有當頁面有賠率資料時才驗證
+    const hasOdds = await page.getByText("賽前賠率").isVisible().catch(() => false);
+    if (hasOdds) {
+      await expect(spreadLabel.first()).toBeVisible();
+      await expect(ouLabel.first()).toBeVisible();
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,6 +45,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
+    // Game detail tests — no auth required
+    {
+      name: "game-detail",
+      testMatch: /game-detail\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+
     // Auth flow tests — no stored state (we're testing the flow itself)
     {
       name: "auth",

--- a/src/__tests__/lib/play-by-play-extended.test.ts
+++ b/src/__tests__/lib/play-by-play-extended.test.ts
@@ -98,7 +98,7 @@ describe("fetchSeasonSeries", () => {
 // ─── fetchPickCenter ──────────────────────────────────────────────────────────
 
 describe("fetchPickCenter", () => {
-  it("正確解析 pickcenter 資料，並由 moneyLine 計算 homeWinPct / awayWinPct", async () => {
+  it("正確解析 pickcenter 資料，並由 moneyLine 計算 homeWinPct / awayWinPct（0-1 區間）", async () => {
     mockEspnFetch.mockResolvedValueOnce({
       pickcenter: [
         {
@@ -115,10 +115,13 @@ describe("fetchPickCenter", () => {
     expect(result[0].provider).toBe("Draft Kings");
     expect(result[0].details).toBe("CHA -5.5");
     // moneyLine -205 → rawHome = 205/305 ≈ 0.672；moneyLine 170 → rawAway = 100/270 ≈ 0.370
-    // homeWinPct = round(0.672 / (0.672 + 0.370) * 100) = 65
+    // 回傳值必須在 0-1 區間（API 契約）
     expect(result[0].homeWinPct).toBeGreaterThan(0);
+    expect(result[0].homeWinPct).toBeLessThanOrEqual(1);
     expect(result[0].awayWinPct).toBeGreaterThan(0);
-    expect(result[0].homeWinPct + result[0].awayWinPct).toBe(100);
+    expect(result[0].awayWinPct).toBeLessThanOrEqual(1);
+    // 加總應約等於 1
+    expect(result[0].homeWinPct + result[0].awayWinPct).toBeCloseTo(1, 2);
   });
 
   it("pickcenter 為空陣列時回傳空陣列", async () => {
@@ -135,21 +138,21 @@ describe("fetchPickCenter", () => {
     expect(result).toEqual([]);
   });
 
-  it("winPercentage 已存在時直接使用，不從 moneyLine 計算", async () => {
+  it("winPercentage 已存在時直接使用（0-1 區間），不從 moneyLine 計算", async () => {
     mockEspnFetch.mockResolvedValueOnce({
       pickcenter: [
         {
           provider: { name: "ESPN BET" },
           details: "BOS -3",
-          homeTeamOdds: { moneyLine: -150, winPercentage: 60 },
-          awayTeamOdds: { moneyLine: 130, winPercentage: 40 },
+          homeTeamOdds: { moneyLine: -150, winPercentage: 0.6 },
+          awayTeamOdds: { moneyLine: 130, winPercentage: 0.4 },
         },
       ],
     });
 
     const result = await fetchPickCenter("nba", "401234567");
-    expect(result[0].homeWinPct).toBe(60);
-    expect(result[0].awayWinPct).toBe(40);
+    expect(result[0].homeWinPct).toBe(0.6);
+    expect(result[0].awayWinPct).toBe(0.4);
   });
 
   it("espnFetch 拋出例外時回傳空陣列", async () => {

--- a/src/__tests__/lib/scoreboard.test.ts
+++ b/src/__tests__/lib/scoreboard.test.ts
@@ -33,6 +33,7 @@ const MOCK_ESPN_RESPONSE = {
               score: "104",
               records: [{ summary: "30-42" }],
               team: {
+                id: "20",
                 displayName: "Philadelphia 76ers",
                 abbreviation: "PHI",
                 logo: "https://a.espncdn.com/phi.png",
@@ -43,6 +44,7 @@ const MOCK_ESPN_RESPONSE = {
               score: "97",
               records: [{ summary: "25-47" }],
               team: {
+                id: "17",
                 displayName: "Brooklyn Nets",
                 abbreviation: "BKN",
                 logo: "https://a.espncdn.com/bkn.png",
@@ -69,6 +71,7 @@ const MOCK_ESPN_RESPONSE = {
               score: "0",
               records: [{ summary: "50-22" }],
               team: {
+                id: "2",
                 displayName: "Boston Celtics",
                 abbreviation: "BOS",
                 logo: "https://a.espncdn.com/bos.png",
@@ -79,6 +82,7 @@ const MOCK_ESPN_RESPONSE = {
               score: "0",
               records: [{ summary: "45-27" }],
               team: {
+                id: "8",
                 displayName: "Milwaukee Bucks",
                 abbreviation: "MIL",
                 logo: "https://a.espncdn.com/mil.png",
@@ -105,10 +109,12 @@ describe("fetchScoreboard", () => {
     expect(game1.id).toBe("401633205");
     expect(game1.status).toBe("in_progress");
     expect(game1.statusDetail).toBe("Q3 5:23");
+    expect(game1.homeTeam.id).toBe("20");
     expect(game1.homeTeam.name).toBe("費城乘者");
     expect(game1.homeTeam.abbreviation).toBe("PHI");
     expect(game1.homeTeam.score).toBe("104");
     expect(game1.homeTeam.record).toBe("30-42");
+    expect(game1.awayTeam.id).toBe("17");
     expect(game1.awayTeam.name).toBe("布魯克林籃網");
     expect(game1.awayTeam.abbreviation).toBe("BKN");
     expect(game1.awayTeam.score).toBe("97");

--- a/src/app/admin/analytics/AnalyticsClient.tsx
+++ b/src/app/admin/analytics/AnalyticsClient.tsx
@@ -69,7 +69,7 @@ const DEVICE_ICONS: Record<string, typeof Monitor> = {
 
 export default function AnalyticsClient() {
   const [period, setPeriod] = useQueryState("period", parseAsString.withDefault("7d"));
-  const [tab, setTab] = useState<"visitor" | "content">("visitor");
+  const [tab, setTab] = useQueryState("tab", parseAsString.withDefault("visitor"));
   const [expandedSession, setExpandedSession] = useState<string | null>(null);
 
   const { data: content, isLoading: contentLoading } = useQuery<ContentData>({

--- a/src/app/api/public/team/route.ts
+++ b/src/app/api/public/team/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSportPath } from "@/lib/espn/client";
 import { fetchTeamATS } from "@/lib/espn/team";
+import { getTeamNameZh } from "@/lib/constants";
 
 const ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports";
 
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       team: {
         id: t.id ?? "",
-        name: t.displayName ?? "",
+        name: getTeamNameZh(t.displayName ?? ""),
         abbreviation: t.abbreviation ?? "",
         logo: t.logos?.[0]?.href ?? "",
         color: t.color ?? "",

--- a/src/components/game/GameDetailClient.tsx
+++ b/src/components/game/GameDetailClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useQueryState, parseAsString } from "nuqs";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -43,6 +43,7 @@ interface GameOdds {
 }
 
 interface TeamInfo {
+  id: string;
   name: string;
   abbreviation: string;
   logo: string;
@@ -152,7 +153,7 @@ export function GameDetailClient({
   eventId: string;
 }) {
   const { data: session } = useSession();
-  const [tab, setTab] = useState("summary");
+  const [tab, setTab] = useQueryState("tab", parseAsString.withDefault("summary"));
 
   const isMember = !!session?.user;
   const apiBase = getGameApiBase(isMember);
@@ -302,7 +303,7 @@ export function GameDetailClient({
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center justify-center gap-6">
-            <Link href={`/team/${sport}/${game.awayTeam.abbreviation}`} className="text-center hover:opacity-80">
+            <Link href={`/team/${sport}/${game.awayTeam.id}`} className="text-center hover:opacity-80">
               {game.awayTeam.logo && (
                 <img src={game.awayTeam.logo} alt="" className="w-14 h-14 mx-auto" />
               )}
@@ -325,7 +326,7 @@ export function GameDetailClient({
                 {game.statusDetail}
               </Badge>
             </div>
-            <Link href={`/team/${sport}/${game.homeTeam.abbreviation}`} className="text-center hover:opacity-80">
+            <Link href={`/team/${sport}/${game.homeTeam.id}`} className="text-center hover:opacity-80">
               {game.homeTeam.logo && (
                 <img src={game.homeTeam.logo} alt="" className="w-14 h-14 mx-auto" />
               )}
@@ -381,11 +382,20 @@ export function GameDetailClient({
                   <CardTitle className="text-base">勝率走勢</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className="text-xs text-muted-foreground mb-2">
-                    主隊（{game.homeTeam.name}）勝率
-                  </p>
+                  <div className="flex justify-between text-xs text-muted-foreground mb-2">
+                    <span className="text-blue-600 font-medium">{game.homeTeam.name}（主）</span>
+                    <span className="text-red-500 font-medium">{game.awayTeam.name}（客）</span>
+                  </div>
                   <ResponsiveContainer width="100%" height={220}>
                     <AreaChart data={chartData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                      <defs>
+                        <linearGradient id="homeWinGrad" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                          <stop offset="50%" stopColor="#3b82f6" stopOpacity={0.05} />
+                          <stop offset="50%" stopColor="#ef4444" stopOpacity={0.05} />
+                          <stop offset="100%" stopColor="#ef4444" stopOpacity={0.3} />
+                        </linearGradient>
+                      </defs>
                       <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
                       <XAxis
                         dataKey="elapsed"
@@ -403,23 +413,31 @@ export function GameDetailClient({
                       />
                       <YAxis
                         domain={[0, 100]}
+                        ticks={[0, 25, 50, 75, 100]}
                         tick={{ fontSize: 11 }}
-                        tickFormatter={(val: number) => `${val}%`}
+                        tickFormatter={(val: number) => {
+                          if (val === 0) return "客隊";
+                          if (val === 100) return "主隊";
+                          return `${val}%`;
+                        }}
                         className="text-muted-foreground"
                       />
                       <Tooltip
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        formatter={(value: any) => [`${Number(value).toFixed(1)}%`, "主隊勝率"]}
+                        formatter={(value: any) => {
+                          const homeVal = Number(value).toFixed(1);
+                          const awayVal = (100 - Number(value)).toFixed(1);
+                          return [`主隊 ${homeVal}% / 客隊 ${awayVal}%`, "勝率"];
+                        }}
                         labelFormatter={() => ""}
                         contentStyle={{ fontSize: 12 }}
                       />
-                      <ReferenceLine y={50} stroke="hsl(var(--muted-foreground))" strokeDasharray="4 4" />
+                      <ReferenceLine y={50} stroke="hsl(var(--muted-foreground))" strokeDasharray="4 4" label={{ value: "50%", fontSize: 10, fill: "hsl(var(--muted-foreground))" }} />
                       <Area
                         type="monotone"
                         dataKey="homeWinPct"
-                        stroke="hsl(var(--primary))"
-                        fill="hsl(var(--primary))"
-                        fillOpacity={0.15}
+                        stroke="#3b82f6"
+                        fill="url(#homeWinGrad)"
                         strokeWidth={2}
                       />
                     </AreaChart>
@@ -500,7 +518,6 @@ export function GameDetailClient({
                     {pickCenter.map((p, idx) => (
                       <div key={idx} className="text-sm">
                         <div className="flex items-center justify-between mb-1">
-                          <span className="text-muted-foreground">{p.provider || "ESPN"}</span>
                           <span className="text-xs text-muted-foreground">{p.details}</span>
                         </div>
                         <div className="flex h-5 rounded-full overflow-hidden bg-muted">
@@ -537,25 +554,22 @@ export function GameDetailClient({
                 <CardContent>
                   <div className="grid grid-cols-3 gap-4 text-center text-sm">
                     <div>
-                      <p className="font-medium text-muted-foreground">Spread</p>
+                      <p className="font-medium text-muted-foreground">Spread (讓分)</p>
                       <p className="text-lg tabular-nums">{game.odds.details || "-"}</p>
                     </div>
                     <div>
-                      <p className="font-medium text-muted-foreground">O/U</p>
+                      <p className="font-medium text-muted-foreground">O/U (大小分)</p>
                       <p className="text-lg tabular-nums">{game.odds.overUnder || "-"}</p>
                     </div>
                     <MemberGate message="登入查看 Money Line">
                       <div>
-                        <p className="font-medium text-muted-foreground">ML</p>
+                        <p className="font-medium text-muted-foreground">ML (勝負盤)</p>
                         <p className="text-lg tabular-nums">
                           {game.odds.awayMoneyLine} / {game.odds.homeMoneyLine}
                         </p>
                       </div>
                     </MemberGate>
                   </div>
-                  <p className="text-xs text-muted-foreground mt-2 text-center">
-                    來源：{game.odds.provider}
-                  </p>
                 </CardContent>
               </Card>
             )}
@@ -742,16 +756,12 @@ export function GameDetailClient({
                   </thead>
                   <tbody>
                     <tr className="border-b">
-                      <td className="py-2 px-3 text-muted-foreground">Spread</td>
+                      <td className="py-2 px-3 text-muted-foreground">Spread (讓分)</td>
                       <td className="text-center py-2 px-3 tabular-nums">{game.odds.details}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="py-2 px-3 text-muted-foreground">Over/Under</td>
+                      <td className="py-2 px-3 text-muted-foreground">O/U (大小分)</td>
                       <td className="text-center py-2 px-3 tabular-nums">{game.odds.overUnder}</td>
-                    </tr>
-                    <tr className="border-b">
-                      <td className="py-2 px-3 text-muted-foreground">來源</td>
-                      <td className="text-center py-2 px-3">{game.odds.provider}</td>
                     </tr>
                   </tbody>
                 </table>
@@ -759,7 +769,7 @@ export function GameDetailClient({
                   <table className="w-full text-sm mt-4">
                     <thead>
                       <tr className="border-b bg-muted">
-                        <th className="text-left py-2 px-3 text-muted-foreground">Money Line</th>
+                        <th className="text-left py-2 px-3 text-muted-foreground">ML (勝負盤)</th>
                         <th className="text-center py-2 px-3 text-muted-foreground">客隊</th>
                         <th className="text-center py-2 px-3 text-muted-foreground">主隊</th>
                       </tr>

--- a/src/components/odds/OddsClient.tsx
+++ b/src/components/odds/OddsClient.tsx
@@ -166,17 +166,15 @@ export function OddsClient() {
                           <table className="w-full text-sm">
                             <thead>
                               <tr className="text-xs text-muted-foreground border-b">
-                                <th className="text-left py-1">來源</th>
-                                <th className="text-center py-1">Spread</th>
-                                <th className="text-center py-1">O/U</th>
-                                <th className="text-center py-1">ML (客)</th>
-                                <th className="text-center py-1">ML (主)</th>
+                                <th className="text-center py-1">Spread (讓分)</th>
+                                <th className="text-center py-1">O/U (大小分)</th>
+                                <th className="text-center py-1">ML 客 (勝負盤)</th>
+                                <th className="text-center py-1">ML 主</th>
                               </tr>
                             </thead>
                             <tbody>
                               {gameMultiOdds.map((odds, idx) => (
                                 <tr key={idx} className="border-b last:border-0">
-                                  <td className="py-1.5 text-muted-foreground">{odds.provider}</td>
                                   <td className="text-center py-1.5 tabular-nums">{odds.details}</td>
                                   <td className="text-center py-1.5 tabular-nums">{odds.overUnder}</td>
                                   <td className="text-center py-1.5 tabular-nums text-xs">{odds.awayMoneyLine || "-"}</td>
@@ -192,15 +190,13 @@ export function OddsClient() {
                           <table className="w-full text-sm">
                             <thead>
                               <tr className="text-xs text-muted-foreground border-b">
-                                <th className="text-left py-1">來源</th>
-                                <th className="text-center py-1">Spread</th>
-                                <th className="text-center py-1">O/U</th>
-                                {isMember && <th className="text-center py-1">ML</th>}
+                                <th className="text-center py-1">Spread (讓分)</th>
+                                <th className="text-center py-1">O/U (大小分)</th>
+                                {isMember && <th className="text-center py-1">ML (勝負盤)</th>}
                               </tr>
                             </thead>
                             <tbody>
                               <tr className="border-b last:border-0">
-                                <td className="py-1.5 text-muted-foreground">{game.odds.provider}</td>
                                 <td className="text-center py-1.5 tabular-nums">{game.odds.details}</td>
                                 <td className="text-center py-1.5 tabular-nums">{game.odds.overUnder}</td>
                                 {isMember && (

--- a/src/components/public/QuickOdds.tsx
+++ b/src/components/public/QuickOdds.tsx
@@ -68,7 +68,7 @@ export function QuickOdds() {
                   )}
                   {game.odds && (
                     <span className="text-[10px] text-muted-foreground">
-                      O/U {game.odds.overUnder}
+                      O/U (大小分) {game.odds.overUnder}
                     </span>
                   )}
                 </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -118,6 +118,35 @@ export function getTeamNameZh(englishName: string): string {
   return TEAM_NAME_ZH[englishName] ?? englishName;
 }
 
+/** ESPN Conference/Division 英文 → 中文映射 */
+export const CONFERENCE_NAME_ZH: Record<string, string> = {
+  // NBA
+  "Eastern Conference": "東區",
+  "Western Conference": "西區",
+  "Atlantic": "大西洋組",
+  "Central": "中央組",
+  "Southeast": "東南組",
+  "Northwest": "西北組",
+  "Pacific": "太平洋組",
+  "Southwest": "西南組",
+  // MLB
+  "American League": "美國聯盟",
+  "National League": "國家聯盟",
+  "American League East": "美聯東區",
+  "American League Central": "美聯中區",
+  "American League West": "美聯西區",
+  "National League East": "國聯東區",
+  "National League Central": "國聯中區",
+  "National League West": "國聯西區",
+  // 足球
+  "English Premier League": "英超",
+};
+
+/** 將英文 Conference/Division 名稱轉為中文，找不到則回傳原文 */
+export function getConferenceNameZh(englishName: string): string {
+  return CONFERENCE_NAME_ZH[englishName] ?? englishName;
+}
+
 export const SITE_NAME = "超級運動資訊網";
 export const SITE_NAME_SHORT = "超級運動";
 export const SITE_DESCRIPTION = "最新體育新聞、NBA、MLB、足球賽事報導與深度分析";

--- a/src/lib/espn/play-by-play.ts
+++ b/src/lib/espn/play-by-play.ts
@@ -442,13 +442,13 @@ function parsePickCenter(data: any): PickCenterData[] {
     const awayMl = p.awayTeamOdds?.moneyLine ?? 0;
     let homeWinPct = p.homeTeamOdds?.winPercentage ?? 0;
     let awayWinPct = p.awayTeamOdds?.winPercentage ?? 0;
-    // If no winPercentage, derive from moneyLine
+    // If no winPercentage, derive from moneyLine (return 0-1 scale)
     if (homeWinPct === 0 && awayWinPct === 0 && (homeMl !== 0 || awayMl !== 0)) {
       const rawHome = moneyLineToProb(homeMl);
       const rawAway = moneyLineToProb(awayMl);
       const total = rawHome + rawAway;
-      homeWinPct = total > 0 ? Math.round((rawHome / total) * 100) : 50;
-      awayWinPct = total > 0 ? Math.round((rawAway / total) * 100) : 50;
+      homeWinPct = total > 0 ? rawHome / total : 0.5;
+      awayWinPct = total > 0 ? rawAway / total : 0.5;
     }
     return {
       provider: p.provider?.name ?? "",

--- a/src/lib/espn/scoreboard.ts
+++ b/src/lib/espn/scoreboard.ts
@@ -7,6 +7,7 @@ import { getTeamNameZh } from "@/lib/constants";
 // ---------- 前台使用的型別（保持與現有 scoreboard.ts 相容） ----------
 
 export interface TeamInfo {
+  id: string;
   name: string;
   abbreviation: string;
   logo: string;
@@ -90,6 +91,7 @@ function parseGames(data: ESPNScoreboardResponse): Game[] {
       statusDetail: event.status?.type?.shortDetail ?? "",
       broadcast,
       homeTeam: {
+        id: home?.team?.id ?? "",
         name: getTeamNameZh(home?.team?.displayName ?? ""),
         abbreviation: home?.team?.abbreviation ?? "",
         logo: home?.team?.logo ?? "",
@@ -101,6 +103,7 @@ function parseGames(data: ESPNScoreboardResponse): Game[] {
         })),
       },
       awayTeam: {
+        id: away?.team?.id ?? "",
         name: getTeamNameZh(away?.team?.displayName ?? ""),
         abbreviation: away?.team?.abbreviation ?? "",
         logo: away?.team?.logo ?? "",

--- a/src/lib/espn/standings.ts
+++ b/src/lib/espn/standings.ts
@@ -3,6 +3,7 @@
 
 import { CACHE_TTL, getSportPath } from "./client";
 import type { ESPNStandingsResponse } from "./types";
+import { getTeamNameZh, getConferenceNameZh } from "@/lib/constants";
 
 const ESPN_V2_BASE = "https://site.api.espn.com/apis/v2/sports";
 
@@ -30,7 +31,7 @@ const STAT_NAME_MAP: Record<string, string> = {
 
 function parseStandings(data: ESPNStandingsResponse): StandingsGroup[] {
   return (data.children ?? []).map((group) => ({
-    name: group.name,
+    name: getConferenceNameZh(group.name),
     entries: (group.standings?.entries ?? []).map((entry) => {
       const statsMap: Record<string, string> = {};
       (entry.stats ?? []).forEach((s) => {
@@ -39,7 +40,7 @@ function parseStandings(data: ESPNStandingsResponse): StandingsGroup[] {
       });
       return {
         teamId: entry.team?.id ?? "",
-        teamName: entry.team?.displayName ?? "",
+        teamName: getTeamNameZh(entry.team?.displayName ?? ""),
         abbreviation: entry.team?.abbreviation ?? "",
         logo: entry.team?.logos?.[0]?.href ?? "",
         stats: statsMap,

--- a/src/lib/scoreboard.ts
+++ b/src/lib/scoreboard.ts
@@ -7,6 +7,7 @@ const ESPN_BASE = "https://site.api.espn.com/apis/site/v2/sports";
 // ---------- Types ----------
 
 export interface TeamInfo {
+  id: string;
   name: string;
   abbreviation: string;
   logo: string;
@@ -86,6 +87,7 @@ function parseTeam(competitor: Record<string, unknown>): TeamInfo {
   const rawLinescores = Array.isArray(competitor.linescores) ? competitor.linescores : undefined;
 
   return {
+    id: String(team.id ?? ""),
     name: getTeamNameZh(String(team.displayName ?? team.name ?? "")),
     abbreviation: String(team.abbreviation ?? ""),
     logo: String(team.logo ?? ""),


### PR DESCRIPTION
## Summary

- Conference/球隊名稱中文化（排名頁、球隊頁 API）
- 賠率術語加中文註解（Spread→讓分、O/U→大小分、ML→勝負盤）
- 移除所有 provider 來源文字
- 修正專家預測百分比 bug（moneyLine 回傳統一為 0-1 區間，不再顯示 6500%）
- 球隊連結改用 ESPN 數字 ID（修正點擊後 404）
- Tab 狀態改用 useQueryState 保存至 URL（返回上一頁保持 tab）
- 勝率走勢圖改為雙色區域圖（主隊藍/客隊紅，Y 軸標隊名）
- 新增 game-detail E2E 測試（7 個 scenario）

Closes #61

## Test plan

- [x] `npx vitest run` — 270/270 通過
- [x] TypeScript 零錯誤
- [x] E2E game-detail 7 scenario 通過
- [x] Playwright 截圖驗證（PC 1440×900 + 手機 430×932）
- [ ] 部署後 smoke test + E2E 驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)