### PR TITLE
fix: 修正間歇性 client-side exception — NuqsAdapter + error boundary

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { PublicHeader } from "@/components/public/PublicHeader";
 import { PullToRefresh } from "@/components/public/PullToRefresh";
 import { PageTracker } from "@/components/public/PageTracker";
@@ -28,7 +27,6 @@ export default function PublicLayout({
       <div id="scroll-container" className="flex-1 overflow-y-auto overscroll-contain">
         <PullToRefresh scrollContainerId="scroll-container" />
         <PageTracker />
-        <NuqsAdapter>
         {/* Main Content */}
         <main className="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8">
           {children}
@@ -74,7 +72,6 @@ export default function PublicLayout({
             </div>
           </div>
         </footer>
-        </NuqsAdapter>
       </div>
     </div>
   );

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
 import AdminLayoutClient from "./AdminLayoutClient";
 
 export const metadata: Metadata = {
@@ -14,10 +13,8 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <NuqsAdapter>
-      <AdminLayoutClient>
-        <Suspense>{children}</Suspense>
-      </AdminLayoutClient>
-    </NuqsAdapter>
+    <AdminLayoutClient>
+      <Suspense>{children}</Suspense>
+    </AdminLayoutClient>
   );
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[GlobalError]", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[50vh] gap-4 px-4">
+      <h2 className="text-lg font-semibold text-foreground">發生錯誤</h2>
+      <p className="text-sm text-muted-foreground text-center max-w-md">
+        頁面載入時發生問題，請重新整理頁面。
+      </p>
+      <button
+        onClick={reset}
+        className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:opacity-90 transition-opacity"
+      >
+        重新整理
+      </button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { ThemeProvider } from "next-themes";
 import { SessionProvider } from "@/components/auth/SessionProvider";
 import { QueryProvider } from "@/components/QueryProvider";
@@ -59,11 +60,13 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-          <QueryProvider>
-            <SessionProvider>{children}</SessionProvider>
-          </QueryProvider>
-        </ThemeProvider>
+        <NuqsAdapter>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+            <QueryProvider>
+              <SessionProvider>{children}</SessionProvider>
+            </QueryProvider>
+          </ThemeProvider>
+        </NuqsAdapter>
       </body>
     </html>
   );

--- a/src/components/admin/ArticlesTable.tsx
+++ b/src/components/admin/ArticlesTable.tsx
@@ -91,7 +91,7 @@ function ArticleActions({
                   type="datetime-local"
                   value={scheduleDateTime}
                   onChange={(e) => setScheduleDateTime(e.target.value)}
-                  min={new Date().toISOString().slice(0, 16)}
+                  min=""
                   className="text-sm"
                 />
                 <div className="flex gap-2">

--- a/src/components/admin/article-detail/PublishOptionsCard.tsx
+++ b/src/components/admin/article-detail/PublishOptionsCard.tsx
@@ -74,7 +74,7 @@ export function PublishOptionsCard({
               value={scheduledDateTime}
               onChange={(e) => onScheduledDateTimeChange(e.target.value)}
               className="w-full sm:w-auto"
-              min={new Date().toISOString().slice(0, 16)}
+              min=""
             />
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary

- NuqsAdapter 從子 layout 移到 root layout，修正 useQueryState 找不到 context 的間歇性 crash
- 新增全域 error.tsx 防止白畫面
- 移除 datetime-local input 的 `new Date()` hydration mismatch

Closes #63

## Test plan

- [x] `npx vitest run` — 270/270 通過
- [x] TypeScript 零錯誤
- [x] E2E 29/29 通過
- [ ] 部署後 smoke test + E2E 驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)