### PR TITLE
feat: 自動/手動模式切換 (#76)

### DIFF
--- a/smoke-test.config.json
+++ b/smoke-test.config.json
@@ -18,7 +18,8 @@
     "/api/dashboard/stats",
     "/api/articles/generated?page=1&limit=1",
     "/api/articles/raw?page=1&limit=1",
-    "/api/admin/visitors?period=7d"
+    "/api/admin/visitors?period=7d",
+    "/api/settings/automation"
   ],
 
   "public_apis": [

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { CHANNEL_TYPE_LABELS } from "@/lib/constants";
+import { AutomationPanel } from "@/components/admin/AutomationPanel";
 
 interface Channel {
   id: number;
@@ -79,6 +80,9 @@ export default function AdminDashboard() {
           </Card>
         ))}
       </div>
+
+      {/* 自動化設定 */}
+      <AutomationPanel />
 
       <div className="grid md:grid-cols-2 gap-6">
         {/* 寫手列表 */}

--- a/src/app/api/cron/auto-pipeline/route.ts
+++ b/src/app/api/cron/auto-pipeline/route.ts
@@ -1,0 +1,257 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+import { publishArticle } from "@/lib/publish-article";
+
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+  // 驗證 cron secret
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createServiceClient();
+
+  try {
+    // 1. 讀取自動化設定
+    const { data: settings, error: settingsError } = await supabase
+      .from("automation_settings")
+      .select("*")
+      .eq("id", 1)
+      .single();
+
+    if (settingsError || !settings) {
+      return NextResponse.json({
+        skipped: true,
+        reason: "settings not found",
+      });
+    }
+
+    // 2. 自動模式未開啟 → 跳過
+    if (!settings.is_auto_mode) {
+      return NextResponse.json({ skipped: true, reason: "manual mode" });
+    }
+
+    const now = new Date();
+    const result: Record<string, unknown> = { timestamp: now.toISOString() };
+
+    // === Phase A: 檢查已完成的自動任務 → 自動發布 ===
+    const publishResult = await autoPublishCompleted(supabase);
+    if (publishResult) {
+      result.auto_publish = publishResult;
+    }
+
+    // === Phase B: 檢查是否該觸發新的產文 ===
+
+    // 3. 檢查間隔未到 → 跳過觸發（但 Phase A 的發布仍然執行）
+    if (settings.last_check_at) {
+      const lastCheck = new Date(settings.last_check_at);
+      const diffMinutes =
+        (now.getTime() - lastCheck.getTime()) / (1000 * 60);
+      if (diffMinutes < settings.check_interval_minutes) {
+        return NextResponse.json({
+          ...result,
+          trigger: {
+            skipped: true,
+            reason: "interval not reached",
+            next_check_in_minutes: Math.ceil(
+              settings.check_interval_minutes - diffMinutes
+            ),
+          },
+        });
+      }
+    }
+
+    // 4. 更新 last_check_at
+    await supabase
+      .from("automation_settings")
+      .update({ last_check_at: now.toISOString() })
+      .eq("id", 1);
+
+    // 5. 計算未處理素材數
+    const { count } = await supabase
+      .from("raw_articles")
+      .select("*", { count: "exact", head: true })
+      .eq("is_processed", false);
+
+    const pendingCount = count ?? 0;
+
+    // 6. 未達門檻 → 跳過
+    if (pendingCount < settings.article_threshold) {
+      return NextResponse.json({
+        ...result,
+        trigger: {
+          skipped: true,
+          reason: "threshold not reached",
+          pending: pendingCount,
+          threshold: settings.article_threshold,
+        },
+      });
+    }
+
+    // 7. 檢查是否有正在執行的任務（避免重複觸發）
+    const { data: runningTasks } = await supabase
+      .from("rewrite_tasks")
+      .select("id")
+      .in("status", ["pending", "running"])
+      .limit(1);
+
+    if (runningTasks && runningTasks.length > 0) {
+      return NextResponse.json({
+        ...result,
+        trigger: { skipped: true, reason: "task already running" },
+      });
+    }
+
+    // 8. 達門檻 → 建立 rewrite_task，metadata 標記 auto_publish
+    await supabase
+      .from("automation_settings")
+      .update({
+        last_run_at: now.toISOString(),
+        last_run_status: "running",
+        last_run_error: null,
+      })
+      .eq("id", 1);
+
+    const { error: insertError } = await supabase
+      .from("rewrite_tasks")
+      .insert({
+        status: "pending",
+        metadata: { auto_publish: true },
+      });
+
+    if (insertError) {
+      await supabase
+        .from("automation_settings")
+        .update({
+          last_run_status: "failed",
+          last_run_error: insertError.message,
+        })
+        .eq("id", 1);
+
+      return NextResponse.json(
+        { ...result, error: insertError.message },
+        { status: 500 }
+      );
+    }
+
+    console.log(
+      `[Auto-Pipeline] Triggered: ${pendingCount} pending articles (threshold: ${settings.article_threshold})`
+    );
+
+    return NextResponse.json({
+      ...result,
+      trigger: {
+        triggered: true,
+        pending: pendingCount,
+        threshold: settings.article_threshold,
+      },
+    });
+  } catch (error) {
+    console.error("[Auto-Pipeline] Error:", error);
+    return NextResponse.json(
+      { success: false, error: String(error) },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * 檢查是否有剛完成的自動產文任務（metadata.auto_publish = true）
+ * 若有 → 找出新產出的 draft 文章 → 呼叫 publishArticle 逐篇發布
+ */
+async function autoPublishCompleted(
+  supabase: ReturnType<typeof createServiceClient>
+): Promise<{ published: number; errors: string[] } | null> {
+  // 找已完成但尚未發布的自動任務
+  const { data: completedTasks } = await supabase
+    .from("rewrite_tasks")
+    .select("id, completed_at, metadata")
+    .eq("status", "completed")
+    .order("completed_at", { ascending: false })
+    .limit(5);
+
+  if (!completedTasks || completedTasks.length === 0) return null;
+
+  const autoTasks = completedTasks.filter(
+    (t) =>
+      t.metadata &&
+      typeof t.metadata === "object" &&
+      (t.metadata as Record<string, unknown>).auto_publish === true
+  );
+
+  if (autoTasks.length === 0) return null;
+
+  // 找出所有 draft 狀態的 generated_articles（產文完成但尚未發布的）
+  const { data: draftArticles } = await supabase
+    .from("generated_articles")
+    .select("id")
+    .eq("status", "draft")
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (!draftArticles || draftArticles.length === 0) {
+    // 沒有 draft 了 → 清除自動任務的 auto_publish 標記（避免重複檢查）
+    for (const task of autoTasks) {
+      await supabase
+        .from("rewrite_tasks")
+        .update({
+          metadata: {
+            ...((task.metadata as Record<string, unknown>) || {}),
+            auto_publish: false,
+            auto_published: true,
+          },
+        })
+        .eq("id", task.id);
+    }
+    return null;
+  }
+
+  // 逐篇發布
+  let published = 0;
+  const errors: string[] = [];
+
+  for (const article of draftArticles) {
+    const pubResult = await publishArticle(article.id);
+    if (pubResult.success) {
+      published++;
+      console.log(
+        `[Auto-Pipeline] Published: "${pubResult.title}" → ${pubResult.channels_published} channels`
+      );
+    } else {
+      errors.push(
+        `${article.id}: ${pubResult.errors.join(", ")}`
+      );
+    }
+  }
+
+  // 更新自動任務標記（避免下次重複發布）
+  for (const task of autoTasks) {
+    await supabase
+      .from("rewrite_tasks")
+      .update({
+        metadata: {
+          ...((task.metadata as Record<string, unknown>) || {}),
+          auto_publish: false,
+          auto_published: true,
+        },
+      })
+      .eq("id", task.id);
+  }
+
+  // 更新 automation_settings 的執行狀態
+  await supabase
+    .from("automation_settings")
+    .update({
+      last_run_status: errors.length === 0 ? "success" : "failed",
+      last_run_error:
+        errors.length > 0 ? errors.join("; ").substring(0, 500) : null,
+      last_run_articles_count: published,
+      last_run_at: new Date().toISOString(),
+    })
+    .eq("id", 1);
+
+  return { published, errors };
+}

--- a/src/app/api/settings/automation/route.ts
+++ b/src/app/api/settings/automation/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+import { auth } from "@/auth";
+
+// GET: 取得自動化設定 + 目前未處理素材數
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const supabase = createServiceClient();
+
+    const [settingsRes, countRes] = await Promise.all([
+      supabase.from("automation_settings").select("*").eq("id", 1).single(),
+      supabase
+        .from("raw_articles")
+        .select("*", { count: "exact", head: true })
+        .eq("is_processed", false),
+    ]);
+
+    if (settingsRes.error) {
+      return NextResponse.json(
+        { error: settingsRes.error.message },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      ...settingsRes.data,
+      pending_raw_count: countRes.count ?? 0,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Internal error: ${err}` },
+      { status: 500 }
+    );
+  }
+}
+
+// PUT: 更新自動化設定
+export async function PUT(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { is_auto_mode, article_threshold, check_interval_minutes } =
+      body as {
+        is_auto_mode?: boolean;
+        article_threshold?: number;
+        check_interval_minutes?: number;
+      };
+
+    const updates: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    if (typeof is_auto_mode === "boolean") {
+      updates.is_auto_mode = is_auto_mode;
+    }
+    if (typeof article_threshold === "number" && article_threshold >= 1) {
+      updates.article_threshold = article_threshold;
+    }
+    if (
+      typeof check_interval_minutes === "number" &&
+      check_interval_minutes >= 1
+    ) {
+      updates.check_interval_minutes = check_interval_minutes;
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("automation_settings")
+      .update(updates)
+      .eq("id", 1)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Internal error: ${err}` },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/AutomationPanel.tsx
+++ b/src/components/admin/AutomationPanel.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useState, useEffect } from "react";
+
+interface AutomationSettings {
+  id: number;
+  is_auto_mode: boolean;
+  article_threshold: number;
+  check_interval_minutes: number;
+  last_check_at: string | null;
+  last_run_at: string | null;
+  last_run_status: string | null;
+  last_run_error: string | null;
+  last_run_articles_count: number;
+  updated_at: string;
+  pending_raw_count: number;
+}
+
+export function AutomationPanel() {
+  const queryClient = useQueryClient();
+
+  const { data: settings, isLoading } = useQuery<AutomationSettings>({
+    queryKey: ["automation-settings"],
+    queryFn: async () => {
+      const res = await fetch("/api/settings/automation");
+      if (!res.ok) throw new Error("fetch failed");
+      return res.json();
+    },
+    refetchInterval: 30000, // 每 30 秒刷新
+  });
+
+  const [threshold, setThreshold] = useState(5);
+  const [interval, setInterval] = useState(30);
+
+  useEffect(() => {
+    if (settings) {
+      setThreshold(settings.article_threshold);
+      setInterval(settings.check_interval_minutes);
+    }
+  }, [settings]);
+
+  const mutation = useMutation({
+    mutationFn: async (updates: Partial<AutomationSettings>) => {
+      const res = await fetch("/api/settings/automation", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
+      });
+      if (!res.ok) throw new Error("update failed");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["automation-settings"] });
+    },
+  });
+
+  if (isLoading || !settings) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>自動化設定</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-sm text-gray-500">載入中...</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const statusBadge = () => {
+    if (!settings.last_run_status) return null;
+    const variants: Record<
+      string,
+      { label: string; variant: "default" | "secondary" | "destructive" }
+    > = {
+      success: { label: "成功", variant: "default" },
+      failed: { label: "失敗", variant: "destructive" },
+      running: { label: "執行中", variant: "secondary" },
+    };
+    const v = variants[settings.last_run_status] || {
+      label: settings.last_run_status,
+      variant: "secondary" as const,
+    };
+    return <Badge variant={v.variant}>{v.label}</Badge>;
+  };
+
+  const formatTime = (dateStr: string | null) => {
+    if (!dateStr) return "—";
+    return new Date(dateStr).toLocaleString("zh-TW");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between">
+          <span>自動化設定</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-normal text-gray-500">
+              {settings.is_auto_mode ? "自動模式" : "手動模式"}
+            </span>
+            <Switch
+              checked={settings.is_auto_mode}
+              onCheckedChange={(checked) =>
+                mutation.mutate({ is_auto_mode: checked })
+              }
+              disabled={mutation.isPending}
+            />
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* 設定區 */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="threshold" className="text-xs text-gray-500">
+              累積門檻（篇）
+            </Label>
+            <Input
+              id="threshold"
+              type="number"
+              min={1}
+              max={50}
+              value={threshold}
+              onChange={(e) => setThreshold(Number(e.target.value))}
+              onBlur={() => {
+                if (threshold !== settings.article_threshold && threshold >= 1) {
+                  mutation.mutate({ article_threshold: threshold });
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && threshold >= 1) {
+                  mutation.mutate({ article_threshold: threshold });
+                }
+              }}
+              className="h-8"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="interval" className="text-xs text-gray-500">
+              檢查間隔（分鐘）
+            </Label>
+            <Input
+              id="interval"
+              type="number"
+              min={1}
+              max={1440}
+              value={interval}
+              onChange={(e) => setInterval(Number(e.target.value))}
+              onBlur={() => {
+                if (
+                  interval !== settings.check_interval_minutes &&
+                  interval >= 1
+                ) {
+                  mutation.mutate({ check_interval_minutes: interval });
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && interval >= 1) {
+                  mutation.mutate({ check_interval_minutes: interval });
+                }
+              }}
+              className="h-8"
+            />
+          </div>
+        </div>
+
+        {/* 狀態區 */}
+        <div className="rounded-lg border p-3 space-y-2 text-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-gray-500">目前待處理素材</span>
+            <span className="font-medium">
+              {settings.pending_raw_count} 篇
+              {settings.pending_raw_count >= settings.article_threshold && (
+                <span className="text-green-600 ml-1">（已達門檻）</span>
+              )}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-gray-500">上次檢查</span>
+            <span>{formatTime(settings.last_check_at)}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-gray-500">上次自動執行</span>
+            <div className="flex items-center gap-2">
+              <span>{formatTime(settings.last_run_at)}</span>
+              {statusBadge()}
+            </div>
+          </div>
+          {settings.last_run_articles_count > 0 && (
+            <div className="flex items-center justify-between">
+              <span className="text-gray-500">上次產出</span>
+              <span>{settings.last_run_articles_count} 篇</span>
+            </div>
+          )}
+          {settings.last_run_error && (
+            <div className="text-xs text-red-500 mt-1">
+              {settings.last_run_error}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/supabase/migrations/019_automation_settings.sql
+++ b/supabase/migrations/019_automation_settings.sql
@@ -1,0 +1,32 @@
+-- 019: 自動/手動模式設定表（Issue #76）
+-- 單行設定模式，id = 1 固定
+
+CREATE TABLE IF NOT EXISTS automation_settings (
+  id INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  is_auto_mode BOOLEAN NOT NULL DEFAULT false,
+  article_threshold INT NOT NULL DEFAULT 5,
+  check_interval_minutes INT NOT NULL DEFAULT 30,
+  last_check_at TIMESTAMPTZ,
+  last_run_at TIMESTAMPTZ,
+  last_run_status TEXT CHECK (last_run_status IN ('success', 'failed', 'running')),
+  last_run_error TEXT,
+  last_run_articles_count INT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 插入預設行（手動模式）
+INSERT INTO automation_settings (id) VALUES (1)
+ON CONFLICT (id) DO NOTHING;
+
+-- RLS: 只有 authenticated 用戶可讀寫（後台用）
+ALTER TABLE automation_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Allow authenticated read" ON automation_settings
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY IF NOT EXISTS "Allow authenticated update" ON automation_settings
+  FOR UPDATE TO authenticated USING (true) WITH CHECK (true);
+
+-- service_role 完整存取（cron endpoint 用）
+CREATE POLICY IF NOT EXISTS "Allow service_role all" ON automation_settings
+  FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/vercel.json
+++ b/vercel.json
@@ -18,6 +18,10 @@
     {
       "path": "/api/cron/rewrite",
       "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/auto-pipeline",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- 新增 `automation_settings` DB 表，持久化自動模式設定（開關、累積門檻、檢查間隔）
- 新增 `/api/settings/automation` (GET/PUT) 後台設定 API
- 新增 `/api/cron/auto-pipeline` Vercel Cron 端點，每分鐘觸發，DB 控制實際間隔
  - 自動模式下：檢查累積素材 → 達門檻觸發產文 → 產文完成後自動發布
- 後台儀表板新增 `AutomationPanel` 元件：模式切換、參數設定、執行狀態顯示
- 更新 `vercel.json` crons 和 `smoke-test.config.json`

## Test plan
- [x] TypeScript 編譯通過
- [x] Vitest 285/285 通過
- [x] Migration 套用 + schema cache 重載
- [ ] 部署後 smoke test
- [ ] 部署後 E2E test
- [ ] 後台驗證自動化面板 UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)