### PR TITLE
feat(analytics): integrate GA4 tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "@next/third-parties": "^16.2.0",
         "@supabase/supabase-js": "^2.98.0",
         "@tanstack/react-query": "^5.91.0",
         "cheerio": "^1.2.0",
@@ -2620,6 +2621,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.0.tgz",
+      "integrity": "sha512-FhtIAOyX3n0akJStdRd7eKdqr6E90Mo3HE2Pcrzs43mjc3DXYegWtrZ+oPBq9Rlq/KGxxSZ1iKw001BUm0Vc5w==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -15121,6 +15135,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@next/third-parties": "^16.2.0",
     "@supabase/supabase-js": "^2.98.0",
     "@tanstack/react-query": "^5.91.0",
     "cheerio": "^1.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { ThemeProvider } from "next-themes";
 import { SessionProvider } from "@/components/auth/SessionProvider";
@@ -70,6 +71,7 @@ export default function RootLayout({
           </ThemeProvider>
         </NuqsAdapter>
       </body>
+      <GoogleAnalytics gaId="G-09TF9265JG" />
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- 整合 Google Analytics 4 追蹤碼（G-09TF9265JG）到所有公開頁面
- 使用 Next.js 官方 `@next/third-parties` 的 `GoogleAnalytics` 元件
- 不影響現有 PageTracker / ViewTracker 自建分析系統

## Changes
- 安裝 `@next/third-parties` 套件
- `src/app/layout.tsx` 加入 `<GoogleAnalytics gaId="G-09TF9265JG" />`

## Test
- TypeScript 編譯通過 ✓
- Vitest 285/285 ✓
- Smoke test 30/31（1 個既有問題）✓
- E2E public 19/19 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)