### PR TITLE
fix: CBS Sports 爬蟲連結優先級 (#82)

### DIFF
--- a/src/__tests__/lib/generic-crawler.test.ts
+++ b/src/__tests__/lib/generic-crawler.test.ts
@@ -84,6 +84,109 @@ describe("isLikelyArticleUrl", () => {
   });
 });
 
+describe("crawlGeneric - base path priority (CBS Sports scenario)", () => {
+  it("prioritizes links matching baseUrl path prefix over other /news/ links", async () => {
+    const { crawlGeneric } = await import("@/lib/crawlers/generic");
+
+    // Simulate CBS /nba/news/ page with 16 links:
+    // First 15 are non-NBA /news/ links (navigation, other sports)
+    // Last 1 is the real /nba/news/ article
+    const otherLinks = Array.from(
+      { length: 15 },
+      (_, i) => `<a href="/nfl/news/free-agency-update-${i}-story">NFL ${i}</a>`
+    ).join("\n");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => `
+        <html><body>
+          ${otherLinks}
+          <a href="/nba/news/real-nba-article-slug">Real NBA Article</a>
+        </body></html>
+      `,
+    });
+
+    // Mock the real NBA article
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => `
+        <html><body>
+          <h1>Real NBA Article</h1>
+          <article>
+            <p>This is a long enough paragraph with more than twenty characters for the content check.</p>
+            <p>Second paragraph with enough content to pass validation checks in crawler module okay.</p>
+            <p>Third paragraph ensures total content exceeds one hundred characters requirement easily.</p>
+          </article>
+        </body></html>
+      `,
+    });
+
+    // Also mock NFL articles (they'll be at the end and crawled after NBA)
+    for (let i = 0; i < 14; i++) {
+      mockFetch.mockResolvedValueOnce({ ok: false });
+    }
+
+    const articles = await crawlGeneric(
+      "CBS Sports",
+      "https://www.cbssports.com/nba/news/"
+    );
+
+    // The real NBA article should be first (prioritized)
+    expect(articles.length).toBeGreaterThanOrEqual(1);
+    expect(articles[0].title).toBe("Real NBA Article");
+  });
+
+  it("does not change order when all links already match the base path", async () => {
+    const { crawlGeneric } = await import("@/lib/crawlers/generic");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => `
+        <html><body>
+          <a href="/nba/news/first-article-slug">First</a>
+          <a href="/nba/news/second-article-slug">Second</a>
+        </body></html>
+      `,
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => `
+        <html><body>
+          <h1>First Article</h1>
+          <article>
+            <p>Content of first article that is long enough to pass the validation check here.</p>
+            <p>More content in second paragraph to ensure total length exceeds one hundred characters.</p>
+            <p>Third paragraph for good measure to make the content sufficient for crawling purposes.</p>
+          </article>
+        </body></html>
+      `,
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => `
+        <html><body>
+          <h1>Second Article</h1>
+          <article>
+            <p>Content of second article that is long enough to pass the validation check here.</p>
+            <p>More content in second paragraph to ensure total length exceeds one hundred characters.</p>
+            <p>Third paragraph for good measure to make the content sufficient for crawling purposes.</p>
+          </article>
+        </body></html>
+      `,
+    });
+
+    const articles = await crawlGeneric(
+      "NBA",
+      "https://www.nba.com/nba/news/"
+    );
+    expect(articles.length).toBe(2);
+    expect(articles[0].title).toBe("First Article");
+    expect(articles[1].title).toBe("Second Article");
+  });
+});
+
 describe("crawlGeneric - article image extraction", () => {
   it("extracts images from article page", async () => {
     const { crawlGeneric } = await import("@/lib/crawlers/generic");

--- a/src/lib/crawlers/generic.ts
+++ b/src/lib/crawlers/generic.ts
@@ -70,6 +70,7 @@ function isLikelyArticleUrl(url: string): boolean {
 function extractArticleLinks($: cheerio.CheerioAPI, baseUrl: string): string[] {
   const links = new Set<string>();
   const baseDomain = new URL(baseUrl).origin;
+  const basePath = new URL(baseUrl).pathname; // 例如 "/nba/news/"
 
   // 嘗試各種常見文章連結模式
   const selectors = [
@@ -117,7 +118,25 @@ function extractArticleLinks($: cheerio.CheerioAPI, baseUrl: string): string[] {
     });
   }
 
-  return Array.from(links).slice(0, 15);
+  // 優先排序：匹配 baseUrl 路徑前綴的連結排在前面
+  // 例如 baseUrl = /nba/news/ 時，/nba/news/xxx 優先於 /nfl/news/xxx
+  const allLinks = Array.from(links);
+  const prioritized = allLinks.filter((link) => {
+    try {
+      return new URL(link).pathname.startsWith(basePath);
+    } catch {
+      return false;
+    }
+  });
+  const others = allLinks.filter((link) => {
+    try {
+      return !new URL(link).pathname.startsWith(basePath);
+    } catch {
+      return true;
+    }
+  });
+
+  return [...prioritized, ...others].slice(0, 15);
 }
 
 // 通用：從文章頁面提取內容


### PR DESCRIPTION
## Summary
修正 CBS Sports 爬蟲無法抓取 NBA 新聞的問題。

根因：extractArticleLinks 用 `.slice(0, 15)` 截斷連結，但 CBS /nba/news/ 頁面的導航列包含非 NBA 連結（NFL、MLB 等），排在真正的 NBA 文章前面。

**修復**：在 slice 前優先排序匹配 baseUrl 路徑前綴的連結，確保同域同路徑的文章優先被選取。

## Changes
- `src/lib/crawlers/generic.ts`: extractArticleLinks 新增優先級排序邏輯
- `src/__tests__/lib/generic-crawler.test.ts`: 新增 2 個優先級測試

## Test
- Vitest: 287/287 通過 ✓
- Smoke test: 30/31 通過（1 個既有問題）✓
- E2E: 全通過 ✓
- Code Review: 無阻擋性問題 ✓