### PR TITLE
fix: 規劃列表未清除已發布文章 (#89)

### DIFF
--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -387,10 +387,25 @@ async function produceFromPlans(planIds: string[]) {
     }
   }
 
-  // 刪除已產出的規劃項目
+  // 刪除已產出的規劃項目（含 retry）
   if (producedPlanIds.length > 0) {
-    await supabase.from("rewrite_plans").delete().in("id", producedPlanIds);
-    console.log(`\n已移除 ${producedPlanIds.length} 個已產出的規劃項目`);
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      const { error: deleteError } = await supabase
+        .from("rewrite_plans")
+        .delete()
+        .in("id", producedPlanIds);
+
+      if (!deleteError) {
+        console.log(`\n已移除 ${producedPlanIds.length} 個已產出的規劃項目`);
+        break;
+      }
+
+      console.error(`刪除規劃項目失敗 (attempt ${attempt}):`, deleteError.message);
+      if (attempt < 2) {
+        console.log("等待 1 秒後重試...");
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
   }
 
   console.log(`\n=== 結果: 成功 ${success}, 失敗 ${failed} ===`);

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -86,7 +86,7 @@ export default function ArticlesPage() {
       invalidateArticles();
     },
     onProducePollComplete: () => {
-      planManager.fetchPlans();
+      planManager.cleanupProducedPlans();
       invalidateArticles();
     },
   });

--- a/src/hooks/usePlanManager.ts
+++ b/src/hooks/usePlanManager.ts
@@ -7,12 +7,14 @@ import type { PlanItem, RawArticleInfo } from "@/components/admin/PlansTable";
 
 interface UsePlanManagerOptions {
   onProduceSuccess?: (ids: string[]) => void;
+  onProduceComplete?: () => void;
 }
 
 export function usePlanManager(options: UsePlanManagerOptions = {}) {
   const queryClient = useQueryClient();
   const [selectedPlanIds, setSelectedPlanIds] = useState<Set<string>>(new Set());
   const [pendingDeleteIds, setPendingDeleteIds] = useState<string[] | null>(null);
+  const [lastProducedIds, setLastProducedIds] = useState<string[]>([]);
 
   const { data: planData, isLoading: planLoading } = useQuery<{
     plans: PlanItem[];
@@ -34,6 +36,22 @@ export function usePlanManager(options: UsePlanManagerOptions = {}) {
   const fetchPlans = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["rewrite-plans"] });
   }, [queryClient]);
+
+  // 產出完成後，明確呼叫 DELETE API 清除已產的 plans（防止 backend 刪除失敗）
+  const cleanupProducedPlans = useCallback(async () => {
+    if (lastProducedIds.length === 0) return;
+    try {
+      await fetch("/api/rewrite/plan", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: lastProducedIds }),
+      });
+    } catch {
+      // 清理失敗不阻塞流程
+    }
+    setLastProducedIds([]);
+    queryClient.invalidateQueries({ queryKey: ["rewrite-plans"] });
+  }, [lastProducedIds, queryClient]);
 
   const clearPlans = useCallback(() => {
     queryClient.setQueryData(["rewrite-plans"], {
@@ -65,6 +83,7 @@ export function usePlanManager(options: UsePlanManagerOptions = {}) {
         };
       });
       setSelectedPlanIds(new Set());
+      setLastProducedIds(ids);
     },
     onError: (err) => {
       toast.error(err.message);
@@ -146,6 +165,7 @@ export function usePlanManager(options: UsePlanManagerOptions = {}) {
     pendingDeleteIds,
     fetchPlans,
     clearPlans,
+    cleanupProducedPlans,
     handlePlanProduce,
     handlePlanDelete,
     confirmPlanDelete,


### PR DESCRIPTION
## Summary
- Backend: `produceFromPlans()` 的 plan 刪除加 error handling + 1 次 retry
- Frontend: produce polling 完成後，明確呼叫 DELETE API 清除已產出的 plan IDs（防止 backend 刪除失敗時 plans 殘留）

## Changes
- `scripts/local-rewriter.ts` — plan 刪除加 error handling + retry
- `src/hooks/usePlanManager.ts` — 新增 `cleanupProducedPlans()` 方法
- `src/app/admin/articles/page.tsx` — `onProducePollComplete` 改用 cleanup

## Test
- vitest 323/323 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)