### PR TITLE
feat: 規劃階段去重 — 合併類似主題 (#90)

### DIFF
--- a/scripts/plan-generator.ts
+++ b/scripts/plan-generator.ts
@@ -61,6 +61,34 @@ function parseAIPlan(output: string): PlanProposal[] {
   }
 }
 
+// --- 標題去重工具 ---
+
+/** 從標題中提取關鍵詞（英文人名/隊名 + 中文 bigram） */
+export function extractKeyTerms(title: string): Set<string> {
+  const terms = new Set<string>();
+  // 英文單詞（球員名、隊名等，≥3 字元才有意義）
+  const englishWords = title.match(/[A-Za-z]+/g) || [];
+  for (const w of englishWords) {
+    if (w.length >= 3) terms.add(w.toLowerCase());
+  }
+  // 中文 bigram
+  const chinese = title.replace(/[A-Za-z0-9\s\p{P}]/gu, "");
+  for (let i = 0; i < chinese.length - 1; i++) {
+    terms.add(chinese.substring(i, i + 2));
+  }
+  return terms;
+}
+
+/** 判斷兩個標題是否相似（overlap coefficient ≥ threshold） */
+export function isSimilarTitle(a: string, b: string, threshold = 0.5): boolean {
+  const ka = extractKeyTerms(a);
+  const kb = extractKeyTerms(b);
+  if (ka.size === 0 || kb.size === 0) return false;
+  const intersection = [...ka].filter((x) => kb.has(x)).length;
+  const overlap = intersection / Math.min(ka.size, kb.size);
+  return overlap >= threshold;
+}
+
 // --- Main ---
 export async function generatePlans() {
   console.log(`\n[${new Date().toLocaleString("zh-TW")}] === 開始產生規劃 ===`);
@@ -111,19 +139,19 @@ export async function generatePlans() {
     }
   }
 
-  // 取得近 7 天已發布/已審核的文章標題（供 AI 判斷主題是否已報導過）
-  const sevenDaysAgo = new Date();
-  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-  const { data: recentPublished } = await supabase
+  // 取得近 14 天已發布或待審的文章標題（供去重比對）
+  const fourteenDaysAgo = new Date();
+  fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14);
+  const { data: recentArticles } = await supabase
     .from("generated_articles")
     .select("title")
-    .in("status", ["published"])
-    .gte("created_at", sevenDaysAgo.toISOString())
+    .in("status", ["published", "draft"])
+    .gte("created_at", fourteenDaysAgo.toISOString())
     .order("created_at", { ascending: false })
-    .limit(50);
+    .limit(100);
 
-  const publishedTitles = (recentPublished || []).map((a) => a.title);
-  console.log(`近 7 天已發布/審核文章: ${publishedTitles.length} 篇`);
+  const publishedTitles = (recentArticles || []).map((a) => a.title);
+  console.log(`近 14 天已有文章: ${publishedTitles.length} 篇（含 draft）`);
 
   // 讀取各球種的標題風格提詞
   const { data: sportSettings } = await supabase
@@ -250,6 +278,20 @@ ${articleList}
         .some((i) => (freshArticles[i].images?.length ?? 0) > 0);
       if (!hasImages) {
         console.log(`  跳過「${proposal.title}」- 素材組合無任何圖片`);
+        continue;
+      }
+
+      // 標題去重：與歷史文章比對
+      const similarToPublished = publishedTitles.find((t) => isSimilarTitle(proposal.title, t));
+      if (similarToPublished) {
+        console.log(`  跳過「${proposal.title}」- 與已有文章相似：「${similarToPublished}」`);
+        continue;
+      }
+
+      // 標題去重：與同批次已通過的規劃比對
+      const similarInBatch = allPlans.find((p) => isSimilarTitle(proposal.title, p.title));
+      if (similarInBatch) {
+        console.log(`  跳過「${proposal.title}」- 與同批規劃相似：「${similarInBatch.title}」`);
         continue;
       }
 

--- a/src/__tests__/scripts/plan-generator.test.ts
+++ b/src/__tests__/scripts/plan-generator.test.ts
@@ -167,6 +167,86 @@ describe("圖片過濾邏輯 — 素材組合必須有圖才規劃", () => {
   });
 });
 
+// 從 plan-generator 抽取的標題去重邏輯
+function extractKeyTerms(title: string): Set<string> {
+  const terms = new Set<string>();
+  const englishWords = title.match(/[A-Za-z]+/g) || [];
+  for (const w of englishWords) {
+    if (w.length >= 3) terms.add(w.toLowerCase());
+  }
+  const chinese = title.replace(/[A-Za-z0-9\s\p{P}]/gu, "");
+  for (let i = 0; i < chinese.length - 1; i++) {
+    terms.add(chinese.substring(i, i + 2));
+  }
+  return terms;
+}
+
+function isSimilarTitle(a: string, b: string, threshold = 0.5): boolean {
+  const ka = extractKeyTerms(a);
+  const kb = extractKeyTerms(b);
+  if (ka.size === 0 || kb.size === 0) return false;
+  const intersection = [...ka].filter((x) => kb.has(x)).length;
+  const overlap = intersection / Math.min(ka.size, kb.size);
+  return overlap >= threshold;
+}
+
+describe("extractKeyTerms — 關鍵詞提取", () => {
+  it("提取英文球員名", () => {
+    const terms = extractKeyTerms("LeBron James 率湖人大勝勇士");
+    expect(terms.has("lebron")).toBe(true);
+    expect(terms.has("james")).toBe(true);
+  });
+
+  it("提取中文 bigram", () => {
+    const terms = extractKeyTerms("湖人擊敗勇士");
+    expect(terms.has("湖人")).toBe(true);
+    expect(terms.has("勇士")).toBe(true);
+  });
+
+  it("忽略短英文詞（< 3 字元）", () => {
+    const terms = extractKeyTerms("AI vs ML comparison");
+    expect(terms.has("ai")).toBe(false);
+    expect(terms.has("vs")).toBe(false);
+    expect(terms.has("comparison")).toBe(true);
+  });
+
+  it("空字串回傳空 Set", () => {
+    expect(extractKeyTerms("").size).toBe(0);
+  });
+});
+
+describe("isSimilarTitle — 標題相似度", () => {
+  it("高度相似的同主題文章", () => {
+    expect(isSimilarTitle(
+      "LeBron James 率湖人大勝勇士",
+      "湖人擊敗勇士，LeBron James 砍下35分"
+    )).toBe(true);
+  });
+
+  it("不同主題的文章", () => {
+    expect(isSimilarTitle(
+      "LeBron James 率湖人大勝勇士",
+      "大谷翔平連續三場全壘打創紀錄"
+    )).toBe(false);
+  });
+
+  it("同聯盟但不同球隊的文章", () => {
+    expect(isSimilarTitle(
+      "Celtics 連勝五場 Tatum 表現亮眼",
+      "Nuggets 擊敗 Suns Jokic 大三元"
+    )).toBe(false);
+  });
+
+  it("空標題不相似", () => {
+    expect(isSimilarTitle("", "任何標題")).toBe(false);
+    expect(isSimilarTitle("任何標題", "")).toBe(false);
+  });
+
+  it("完全相同的標題", () => {
+    expect(isSimilarTitle("NBA 今日焦點", "NBA 今日焦點")).toBe(true);
+  });
+});
+
 describe("is_processed 標記邏輯", () => {
   it("收集所有 allPlans 中的 raw_article_ids 並去重", () => {
     const allPlans = [


### PR DESCRIPTION
## Summary
- 新增 `extractKeyTerms()` 和 `isSimilarTitle()` 做程式化標題去重
- 擴大歷史比對：7→14 天、50→100 篇、含 draft 文章
- Post-AI 驗證：跳過與已有文章標題相似的 proposals
- 同批次去重：跳過與同批已通過 proposals 相似的項目

## Changes
- `scripts/plan-generator.ts` — 新增去重工具函式 + 整合進 proposal 驗證迴圈
- `src/__tests__/scripts/plan-generator.test.ts` — 新增 9 個標題去重測試

## Test
- vitest 332/332 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)