### PR TITLE
fix: collectImages() 加入 isValidImageUrl 過濾 (#99)

### DIFF
--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -21,6 +21,7 @@ config({ path: resolve(__dirname, "..", ".env.local") });
 import { createClient } from "@supabase/supabase-js";
 import { matchesSpecialties, Specialties, RawArticleBase } from "./shared-matching";
 import { callClaude } from "./shared-claude";
+import { isValidImageUrl } from "../src/lib/constants";
 
 const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -138,7 +139,7 @@ function collectImages(articles: RawArticle[]): string[] {
   const images: string[] = [];
   for (const a of articles) {
     for (const url of a.images || []) {
-      if (url && !seen.has(url) && images.length < 5) {
+      if (url && isValidImageUrl(url) && !seen.has(url) && images.length < 5) {
         seen.add(url);
         images.push(url);
       }


### PR DESCRIPTION
## Summary
- `collectImages()` 加入 `isValidImageUrl()` 過濾 logo/tracking pixel/icon 等非內容圖片

## Changes
- `scripts/local-rewriter.ts` — import isValidImageUrl + 在 collectImages 過濾條件中使用

## Test
- vitest 332/332 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)