### PR TITLE
fix: local-rewriter main() 加入 is_processed 過濾 (#100)

### DIFF
--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -459,6 +459,7 @@ async function main() {
   const { data: rawArticles } = await supabase
     .from("raw_articles")
     .select("*")
+    .eq("is_processed", false)
     .gte("crawled_at", since.toISOString())
     .order("crawled_at", { ascending: false });
 


### PR DESCRIPTION
## Summary
- main() 模式的 raw_articles 查詢加入 `.eq("is_processed", false)`，與 plan-generator 一致

## Test
- vitest 332/332 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)