### PR TITLE
fix: 圖片 URL 加入 SSRF 防護 (#102)

### DIFF
--- a/src/lib/publish-article.ts
+++ b/src/lib/publish-article.ts
@@ -187,5 +187,33 @@ function extractImageUrls(images: unknown): string[] {
       }
       return undefined;
     })
-    .filter((url): url is string => typeof url === "string" && url.startsWith("http"));
+    .filter((url): url is string => typeof url === "string" && url.startsWith("http") && isSafeImageUrl(url));
+}
+
+/** 排除指向內部網路的 URL（防 SSRF） */
+function isSafeImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname;
+    // 排除 localhost、RFC 1918、link-local
+    if (
+      hostname === "localhost" ||
+      hostname.startsWith("127.") ||
+      hostname.startsWith("10.") ||
+      hostname.startsWith("192.168.") ||
+      hostname.startsWith("169.254.") ||
+      hostname === "0.0.0.0" ||
+      hostname.endsWith(".local") ||
+      hostname.startsWith("172.") && (() => {
+        const second = parseInt(hostname.split(".")[1], 10);
+        return second >= 16 && second <= 31;
+      })()
+    ) {
+      return false;
+    }
+    // 只允許 https（生產環境圖片都應走 https）
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- 新增 `isSafeImageUrl()` 排除內部網路 URL（localhost, 10.x, 192.168.x, 169.254.x, 172.16-31.x）
- 要求所有圖片 URL 使用 HTTPS 協定
- 整合到 `extractImageUrls()` 過濾鏈

## Test
- vitest 332/332 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)