### PR TITLE
feat(routes): add team slug & absolute URL helpers (#110)

### DIFF
--- a/src/__tests__/lib/routes-extended.test.ts
+++ b/src/__tests__/lib/routes-extended.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  teamSlugUrl,
+  absoluteTeamUrl,
+  absolutePlayerUrl,
+  absoluteGameUrl,
+} from "@/lib/routes";
+
+describe("extended route helpers", () => {
+  it("teamSlugUrl generates /team/:sport/:slug", () => {
+    expect(teamSlugUrl("nba", "lakers")).toBe("/team/nba/lakers");
+  });
+
+  it("teamSlugUrl handles different sports", () => {
+    expect(teamSlugUrl("mlb", "yankees")).toBe("/team/mlb/yankees");
+  });
+
+  it("absoluteTeamUrl generates full team URL", () => {
+    expect(absoluteTeamUrl("https://example.com", "nba", "13")).toBe(
+      "https://example.com/team/nba/13"
+    );
+  });
+
+  it("absoluteTeamUrl strips trailing slash from baseUrl", () => {
+    expect(absoluteTeamUrl("https://example.com/", "nba", "13")).toBe(
+      "https://example.com/team/nba/13"
+    );
+  });
+
+  it("absolutePlayerUrl generates full player URL", () => {
+    expect(absolutePlayerUrl("https://example.com", "nba", "3112335")).toBe(
+      "https://example.com/player/nba/3112335"
+    );
+  });
+
+  it("absolutePlayerUrl strips trailing slash from baseUrl", () => {
+    expect(absolutePlayerUrl("https://example.com/", "nba", "3112335")).toBe(
+      "https://example.com/player/nba/3112335"
+    );
+  });
+
+  it("absoluteGameUrl generates full game URL", () => {
+    expect(absoluteGameUrl("https://example.com", "nba", "401584793")).toBe(
+      "https://example.com/game/nba/401584793"
+    );
+  });
+
+  it("absoluteGameUrl strips trailing slash from baseUrl", () => {
+    expect(absoluteGameUrl("https://example.com/", "nba", "401584793")).toBe(
+      "https://example.com/game/nba/401584793"
+    );
+  });
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -42,3 +42,35 @@ export function absoluteCategoryUrl(baseUrl: string, slug: string) {
 export function absoluteWriterUrl(baseUrl: string, writerId: string) {
   return `${baseUrl}/writer/${writerId}`;
 }
+
+/** SEO 友善的球隊 slug URL（如 /team/nba/lakers），會被 redirect 到 canonical /team/nba/:id */
+export function teamSlugUrl(sport: string, slug: string) {
+  return `/team/${sport}/${slug}`;
+}
+
+/** 產生完整球隊 URL（含 domain），用於 sitemap/SEO */
+export function absoluteTeamUrl(
+  baseUrl: string,
+  sport: string,
+  teamId: string
+) {
+  return `${baseUrl.replace(/\/$/, "")}/team/${sport}/${teamId}`;
+}
+
+/** 產生完整球員 URL（含 domain），用於 sitemap/SEO */
+export function absolutePlayerUrl(
+  baseUrl: string,
+  sport: string,
+  playerId: string
+) {
+  return `${baseUrl.replace(/\/$/, "")}/player/${sport}/${playerId}`;
+}
+
+/** 產生完整比賽 URL（含 domain），用於 sitemap/SEO */
+export function absoluteGameUrl(
+  baseUrl: string,
+  sport: string,
+  gameId: string
+) {
+  return `${baseUrl.replace(/\/$/, "")}/game/${sport}/${gameId}`;
+}


### PR DESCRIPTION
## Summary
- 擴充 `src/lib/routes.ts`，新增 4 個 route helper：`teamSlugUrl`、`absoluteTeamUrl`、`absolutePlayerUrl`、`absoluteGameUrl`
- 所有 absolute URL helper 處理 baseUrl 尾部斜線，避免產生雙斜線
- 附 8 個 Vitest 測試，全部通過（340/340 全站測試無回歸）
- QA 3/3 通過（vitest + smoke test + E2E）

## Test plan
- [x] 新增 `src/__tests__/lib/routes-extended.test.ts`（8 個測試案例）
- [x] `npx vitest run` 全部 340 測試通過
- [x] `./scripts/qa.sh` 3/3 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)