### PR TITLE
feat(seo): add TEAM_SLUG_MAP for SEO-friendly team URLs

### DIFF
--- a/src/__tests__/lib/team-slugs.test.ts
+++ b/src/__tests__/lib/team-slugs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { TEAM_SLUG_MAP, getTeamIdBySlug } from "@/lib/constants";
+
+describe("TEAM_SLUG_MAP", () => {
+  it("contains NBA teams with correct ESPN IDs", () => {
+    // Verified from ESPN API: https://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams
+    expect(TEAM_SLUG_MAP["nba:los-angeles-lakers"]).toBe("13");
+    expect(TEAM_SLUG_MAP["nba:boston-celtics"]).toBe("2");
+    expect(TEAM_SLUG_MAP["nba:golden-state-warriors"]).toBe("9");
+    expect(TEAM_SLUG_MAP["nba:brooklyn-nets"]).toBe("17");
+    expect(TEAM_SLUG_MAP["nba:oklahoma-city-thunder"]).toBe("25");
+  });
+
+  it("contains MLB teams with correct ESPN IDs", () => {
+    // Verified from ESPN API: https://site.api.espn.com/apis/site/v2/sports/baseball/mlb/teams
+    expect(TEAM_SLUG_MAP["mlb:new-york-yankees"]).toBe("10");
+    expect(TEAM_SLUG_MAP["mlb:los-angeles-dodgers"]).toBe("19");
+    expect(TEAM_SLUG_MAP["mlb:boston-red-sox"]).toBe("2");
+    expect(TEAM_SLUG_MAP["mlb:chicago-cubs"]).toBe("16");
+    expect(TEAM_SLUG_MAP["mlb:athletics"]).toBe("11");
+  });
+
+  it("has 30 NBA teams", () => {
+    const nbaCount = Object.keys(TEAM_SLUG_MAP).filter((k) =>
+      k.startsWith("nba:")
+    ).length;
+    expect(nbaCount).toBe(30);
+  });
+
+  it("has 30 MLB teams", () => {
+    const mlbCount = Object.keys(TEAM_SLUG_MAP).filter((k) =>
+      k.startsWith("mlb:")
+    ).length;
+    expect(mlbCount).toBe(30);
+  });
+
+  it("all values are non-empty strings", () => {
+    for (const [key, value] of Object.entries(TEAM_SLUG_MAP)) {
+      expect(value, `${key} should have a non-empty value`).toBeTruthy();
+      expect(typeof value).toBe("string");
+    }
+  });
+});
+
+describe("getTeamIdBySlug", () => {
+  it("returns ESPN ID for valid NBA slug", () => {
+    expect(getTeamIdBySlug("nba", "los-angeles-lakers")).toBe("13");
+  });
+
+  it("returns ESPN ID for valid MLB slug", () => {
+    expect(getTeamIdBySlug("mlb", "new-york-yankees")).toBe("10");
+  });
+
+  it("returns null for invalid slug", () => {
+    expect(getTeamIdBySlug("nba", "nonexistent-team")).toBeNull();
+  });
+
+  it("returns null for invalid sport", () => {
+    expect(getTeamIdBySlug("cricket", "los-angeles-lakers")).toBeNull();
+  });
+
+  it("returns null for empty slug", () => {
+    expect(getTeamIdBySlug("nba", "")).toBeNull();
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -368,3 +368,79 @@ export function parsePagination(searchParams: URLSearchParams, defaultLimit = 20
   const offset = (page - 1) * limit;
   return { page, limit, offset };
 }
+
+/**
+ * 球隊 slug → ESPN team ID 映射表
+ * 格式: "sport:slug" → "espn_id"
+ * 用於 SEO 友善的 URL（如 /team/nba/los-angeles-lakers）解析為 ESPN ID
+ * ID 來源：ESPN site API /apis/site/v2/sports/{sport}/{league}/teams
+ */
+export const TEAM_SLUG_MAP: Record<string, string> = {
+  // NBA — 30 teams (verified from ESPN API 2026-03-21)
+  "nba:atlanta-hawks": "1",
+  "nba:boston-celtics": "2",
+  "nba:brooklyn-nets": "17",
+  "nba:charlotte-hornets": "30",
+  "nba:chicago-bulls": "4",
+  "nba:cleveland-cavaliers": "5",
+  "nba:dallas-mavericks": "6",
+  "nba:denver-nuggets": "7",
+  "nba:detroit-pistons": "8",
+  "nba:golden-state-warriors": "9",
+  "nba:houston-rockets": "10",
+  "nba:indiana-pacers": "11",
+  "nba:la-clippers": "12",
+  "nba:los-angeles-lakers": "13",
+  "nba:memphis-grizzlies": "29",
+  "nba:miami-heat": "14",
+  "nba:milwaukee-bucks": "15",
+  "nba:minnesota-timberwolves": "16",
+  "nba:new-orleans-pelicans": "3",
+  "nba:new-york-knicks": "18",
+  "nba:oklahoma-city-thunder": "25",
+  "nba:orlando-magic": "19",
+  "nba:philadelphia-76ers": "20",
+  "nba:phoenix-suns": "21",
+  "nba:portland-trail-blazers": "22",
+  "nba:sacramento-kings": "23",
+  "nba:san-antonio-spurs": "24",
+  "nba:toronto-raptors": "28",
+  "nba:utah-jazz": "26",
+  "nba:washington-wizards": "27",
+  // MLB — 30 teams (verified from ESPN API 2026-03-21)
+  "mlb:arizona-diamondbacks": "29",
+  "mlb:athletics": "11",
+  "mlb:atlanta-braves": "15",
+  "mlb:baltimore-orioles": "1",
+  "mlb:boston-red-sox": "2",
+  "mlb:chicago-cubs": "16",
+  "mlb:chicago-white-sox": "4",
+  "mlb:cincinnati-reds": "17",
+  "mlb:cleveland-guardians": "5",
+  "mlb:colorado-rockies": "27",
+  "mlb:detroit-tigers": "6",
+  "mlb:houston-astros": "18",
+  "mlb:kansas-city-royals": "7",
+  "mlb:los-angeles-angels": "3",
+  "mlb:los-angeles-dodgers": "19",
+  "mlb:miami-marlins": "28",
+  "mlb:milwaukee-brewers": "8",
+  "mlb:minnesota-twins": "9",
+  "mlb:new-york-mets": "21",
+  "mlb:new-york-yankees": "10",
+  "mlb:philadelphia-phillies": "22",
+  "mlb:pittsburgh-pirates": "23",
+  "mlb:san-diego-padres": "25",
+  "mlb:san-francisco-giants": "26",
+  "mlb:seattle-mariners": "12",
+  "mlb:st-louis-cardinals": "24",
+  "mlb:tampa-bay-rays": "30",
+  "mlb:texas-rangers": "13",
+  "mlb:toronto-blue-jays": "14",
+  "mlb:washington-nationals": "20",
+};
+
+/** 根據 sport + slug 取得 ESPN team ID，找不到回傳 null */
+export function getTeamIdBySlug(sport: string, slug: string): string | null {
+  return TEAM_SLUG_MAP[`${sport}:${slug}`] ?? null;
+}


### PR DESCRIPTION
## Summary
- Add `TEAM_SLUG_MAP` (60 teams: 30 NBA + 30 MLB) mapping SEO-friendly slugs to ESPN team IDs
- Add `getTeamIdBySlug(sport, slug)` helper function
- All ESPN IDs verified from ESPN site API, not hardcoded guesses
- 10 new Vitest tests covering value correctness, count validation, and edge cases

## Test plan
- [x] Vitest: 350/350 passed (10 new + 340 existing)
- [x] Smoke test: passed
- [x] E2E: 54/54 passed
- [x] QA script: 3/3 passed

Resolves #111

Generated with [Claude Code](https://claude.com/claude-code)