### PR TITLE
feat(seo): team slug → canonical ID 308 redirect

### DIFF
--- a/smoke-test.config.json
+++ b/smoke-test.config.json
@@ -78,6 +78,10 @@
     {
       "label": "批次發布 API endpoint 存在（POST /api/articles/generated/batch）",
       "command": "STATUS=$(curl -s -X POST -o /dev/null -w '%{http_code}' -H 'Content-Type: application/json' -d '{\"ids\":[],\"action\":\"publish\"}' '{{BASE_URL}}/api/articles/generated/batch' 2>/dev/null) && ([ \"$STATUS\" = \"401\" ] || [ \"$STATUS\" = \"200\" ]) && echo '✓ endpoint exists (auth required or success)' || echo \"✗ endpoint failed with $STATUS\""
+    },
+    {
+      "label": "球隊 slug URL 308 redirect 到 canonical ID URL",
+      "command": "STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-redirs 0 '{{BASE_URL}}/team/nba/los-angeles-lakers') && LOCATION=$(curl -s -o /dev/null -w '%{redirect_url}' --max-redirs 0 '{{BASE_URL}}/team/nba/los-angeles-lakers') && [ \"$STATUS\" = \"308\" ] && echo \"$LOCATION\" | grep -q '/team/nba/13'"
     }
   ]
 }

--- a/src/__tests__/pages/team-slug-redirect.test.tsx
+++ b/src/__tests__/pages/team-slug-redirect.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// vi.mock is hoisted — use vi.hoisted to create the mock fn
+const { mockPermanentRedirect } = vi.hoisted(() => ({
+  mockPermanentRedirect: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  permanentRedirect: mockPermanentRedirect,
+}));
+
+import TeamPage, {
+  generateMetadata,
+} from "@/app/(public)/team/[sport]/[id]/page";
+
+describe("TeamPage slug redirect", () => {
+  beforeEach(() => {
+    mockPermanentRedirect.mockReset();
+  });
+
+  describe("generateMetadata", () => {
+    it("returns noindex for slug URLs", async () => {
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ sport: "nba", id: "los-angeles-lakers" }),
+      });
+      expect(metadata).toEqual({ robots: { index: false } });
+    });
+
+    it("returns full metadata for numeric ID URLs", async () => {
+      const metadata = await generateMetadata({
+        params: Promise.resolve({ sport: "nba", id: "13" }),
+      });
+      expect(metadata).toHaveProperty("title");
+      expect(metadata.title).toContain("13");
+    });
+  });
+
+  describe("page component", () => {
+    it("calls permanentRedirect for known NBA slug", async () => {
+      mockPermanentRedirect.mockImplementation(() => {
+        throw new Error("NEXT_REDIRECT");
+      });
+
+      await expect(
+        TeamPage({
+          params: Promise.resolve({ sport: "nba", id: "los-angeles-lakers" }),
+        })
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockPermanentRedirect).toHaveBeenCalledWith("/team/nba/13");
+    });
+
+    it("calls permanentRedirect for MLB slug", async () => {
+      mockPermanentRedirect.mockImplementation(() => {
+        throw new Error("NEXT_REDIRECT");
+      });
+
+      await expect(
+        TeamPage({
+          params: Promise.resolve({ sport: "mlb", id: "new-york-yankees" }),
+        })
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockPermanentRedirect).toHaveBeenCalledWith("/team/mlb/10");
+    });
+
+    it("does not redirect for numeric ID", async () => {
+      const result = await TeamPage({
+        params: Promise.resolve({ sport: "nba", id: "13" }),
+      });
+      expect(mockPermanentRedirect).not.toHaveBeenCalled();
+      expect(result).toBeTruthy();
+    });
+
+    it("does not redirect for unknown slug (falls through to normal render)", async () => {
+      const result = await TeamPage({
+        params: Promise.resolve({ sport: "nba", id: "nonexistent-team" }),
+      });
+      expect(mockPermanentRedirect).not.toHaveBeenCalled();
+      expect(result).toBeTruthy();
+    });
+  });
+});

--- a/src/app/(public)/team/[sport]/[id]/page.tsx
+++ b/src/app/(public)/team/[sport]/[id]/page.tsx
@@ -1,14 +1,27 @@
 import { Metadata } from "next";
+import { permanentRedirect } from "next/navigation";
 import { TeamDetailClient } from "@/components/team/TeamDetailClient";
-import { SPORT_KEY_LABELS, SITE_URL } from "@/lib/constants";
+import { SPORT_KEY_LABELS, SITE_URL, getTeamIdBySlug } from "@/lib/constants";
+import { teamUrl } from "@/lib/routes";
 import { TeamJsonLd } from "./TeamJsonLd";
 
 interface Props {
   params: Promise<{ sport: string; id: string }>;
 }
 
+/** id 參數是純數字就是 ESPN ID，否則視為 slug */
+function isNumericId(id: string): boolean {
+  return /^\d+$/.test(id);
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { sport, id } = await params;
+
+  // slug URL 不應被索引，canonical 是數字 ID 版本
+  if (!isNumericId(id)) {
+    return { robots: { index: false } };
+  }
+
   const sportLabel = SPORT_KEY_LABELS[sport] || sport.toUpperCase();
   const title = `${sportLabel} 球隊 #${id}`;
   const ogUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(title)}&subtitle=${encodeURIComponent(sportLabel)}&type=team`;
@@ -29,6 +42,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function TeamPage({ params }: Props) {
   const { sport, id } = await params;
+
+  // slug → 308 permanent redirect 到 canonical URL
+  if (!isNumericId(id)) {
+    const teamId = getTeamIdBySlug(sport, id);
+    if (teamId) {
+      permanentRedirect(teamUrl(sport, teamId));
+    }
+    // 未知 slug 會落入下方正常渲染，ESPN API 會回 404/empty
+  }
+
   return (
     <>
       <TeamJsonLd sport={sport} teamId={id} />


### PR DESCRIPTION
## Summary
- `/team/nba/los-angeles-lakers` → 308 permanent redirect → `/team/nba/13`
- `/team/nba/13` → 正常顯示（行為不變）
- Slug URL 的 `generateMetadata` 返回 `{ robots: { index: false } }`，避免重複索引
- Smoke test 新增 slug redirect 驗證

## Changes
- `src/app/(public)/team/[sport]/[id]/page.tsx` — 整合 `isNumericId()` 判斷 + `permanentRedirect` 到 canonical URL
- `src/__tests__/pages/team-slug-redirect.test.tsx` — 6 個 unit tests
- `smoke-test.config.json` — 新增球隊 slug redirect 檢查

## Test plan
- [x] 356 unit tests passed
- [x] TypeScript 編譯通過
- [x] Next.js build 成功
- [ ] 部署後 smoke test 驗證 308 redirect

Resolves #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)