### PR TITLE
feat: add team pages to sitemap (#113)

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from "next";
 import { createServiceClient } from "@/lib/supabase";
-import { SITE_URL } from "@/lib/constants";
-import { absoluteCategoryUrl, absoluteNewsUrl, absoluteWriterUrl } from "@/lib/routes";
+import { SITE_URL, TEAM_SLUG_MAP } from "@/lib/constants";
+import { absoluteCategoryUrl, absoluteNewsUrl, absoluteTeamUrl, absoluteWriterUrl } from "@/lib/routes";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const supabase = createServiceClient();
@@ -82,6 +82,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         priority: 0.5,
       });
     }
+  }
+
+  // Team pages (canonical URL with ESPN ID, not slug)
+  for (const [key, teamId] of Object.entries(TEAM_SLUG_MAP)) {
+    const sport = key.split(":")[0]; // "nba" or "mlb"
+    entries.push({
+      url: absoluteTeamUrl(SITE_URL, sport, teamId),
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    });
   }
 
   return entries;


### PR DESCRIPTION
## Summary
- Sitemap 新增 60 筆球隊頁面（30 NBA + 30 MLB），使用 canonical URL（`/team/nba/:id`、`/team/mlb/:id`）
- changeFrequency: weekly, priority: 0.6
- 從 `TEAM_SLUG_MAP` 取得所有球隊 ID，使用 `absoluteTeamUrl()` 產生完整 URL
- 不加入 slug URL（因為會 redirect 到 canonical）

## Test plan
- [x] TypeScript 編譯通過
- [x] QA 全部通過（Unit + Smoke + E2E 3/3）
- [x] 確認使用 route helper 而非手動拼接 URL
- [x] 確認使用 constants 中的 TEAM_SLUG_MAP

🤖 Generated with [Claude Code](https://claude.com/claude-code)