### PR TITLE
feat(seo): add ExtendedReading component to article pages

### DIFF
--- a/.claude/execution-log.md
+++ b/.claude/execution-log.md
@@ -1,0 +1,172 @@
+# Execution Log
+
+## Issue #109: SEO 技術優化 — robots.ts AI bot 規則 + llms.txt
+
+### 分級：S（≤3 檔案、設定檔修改）
+- 跳過 Phase 1-2：S 級別 + 無 API/DB 變更
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Branch: feat/109-seo-ai-bot-rules-llms-txt
+- [x] 實作完成：robots.ts AI bot 規則 + llms.txt + smoke-test 更新
+- [x] Vitest: 332/332 通過，無回歸
+- [x] Review: S 級別，3 檔案純設定改動，無邏輯風險
+
+### Phase 4: QA — 2026-03-21
+
+- [x] QA 通過（332 unit + 54 E2E + smoke test）
+
+### Phase 5: 交付 — 2026-03-21
+
+- [x] Commit + Push — PR #119
+- [x] PR #119 rebase merge 到 main
+- [x] Deploy: main merge 到 release → Vercel 自動部署
+- [x] 部署後 QA: ./scripts/qa.sh https://howger-sport.com — 3/3 通過
+- [x] Issue #109 已關閉
+
+---
+
+## Issue #110: Route helper 擴充 — team slug / player / game absolute URL
+
+### 分級：S（2 檔案、純 utility 函式擴充、無 API/DB 變更）
+- 跳過 Phase 0-2：S 級別 + 純函式新增
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Branch: feat/110-route-helper-team-slug-absolute-url
+- [x] TDD Red: 8 個測試全部失敗（函式不存在）
+- [x] TDD Green: 實作 4 個 route helper，8 個測試通過
+- [x] 全站回歸: 340/340 通過
+- [x] Review（S 級別快速模式）: reviewer-bugs 95/100 + reviewer-compliance 95/100，無問題
+
+### Phase 4: QA — 2026-03-21
+
+- [x] QA 通過（340 unit + 54 E2E + smoke test）— 3/3
+
+### Phase 5: 交付 — 2026-03-21
+
+- [x] Commit + Push — PR #120
+- [x] PR #120 rebase merge 到 main
+- [x] Deploy: main merge 到 release → Vercel 自動部署
+- [x] 部署後 QA: ./scripts/qa.sh https://howger-sport.com — 3/3 通過
+- [x] Issue #110 已關閉
+- [x] Evolve: 無改進建議（純函式擴充，流程順暢）
+
+---
+
+## Issue #111: 球隊 slug 映射表 — TEAM_SLUG_MAP
+
+### 分級：S（2 檔案、純常數 + 純函式新增、無 API/DB/UI 變更）
+- 跳過 Phase 1-2：S 級別 + 純資料映射
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Branch: feat/111-team-slug-map
+- [x] ESPN API 驗證：NBA 30 隊 + MLB 30 隊 ID/slug 取得
+- [x] TDD Red: 10 個測試全部失敗（常數和函式不存在）
+- [x] TDD Green: 實作 TEAM_SLUG_MAP（60 筆）+ getTeamIdBySlug()，10 個測試通過
+- [x] 全站回歸: 350/350 通過
+- [x] Review（S 級別快速模式）: 純靜態資料 + 純函式，無邏輯風險
+
+### Phase 4: QA — 2026-03-21
+
+- [x] QA 通過（350 unit + 54 E2E + smoke test）— 3/3
+
+### Phase 5: 交付 — 2026-03-21
+
+- [x] Commit + Push — PR #121
+- [x] PR #121 rebase merge 到 main
+- [x] Deploy: main merge 到 release → Vercel 自動部署
+- [x] 部署後 QA: 等待中
+- [x] Issue #111 已關閉
+- [x] Evolve: 無改進建議（純資料映射，TDD 流程順暢，ESPN API 驗證確保資料正確性）
+
+---
+
+## Issue #112: 球隊 slug 路由整合 — permanentRedirect 到 canonical URL
+
+### 分級：M（修改既有頁面邏輯、新增 redirect 行為、依賴 #110 + #111）
+- 簡化 Phase 1-2：M 級別 + 需求明確 + 無 DB/UI 變更
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Branch: feat/112-team-slug-redirect（已存在，含 #110 #111 的 commits）
+- [x] FE 實作：page.tsx 整合 isNumericId() + permanentRedirect + getTeamIdBySlug
+  - slug URL → 308 permanent redirect 到 canonical /team/:sport/:id
+  - slug URL generateMetadata → { robots: { index: false } }
+  - 未知 slug fallthrough 到正常渲染（ESPN API 回空）
+- [x] 測試：6 個 unit tests（slug redirect、MLB slug、numeric ID 不 redirect、unknown slug fallthrough、metadata noindex）
+- [x] smoke-test.config.json 新增 slug redirect 驗證
+- [x] 全站回歸: 356/356 通過
+- [x] TypeScript 編譯通過
+- [x] Next.js build 成功
+- [x] Review：使用 route helper teamUrl()、permanentRedirect（308）、純 server 端邏輯無 client 影響
+
+### Phase 4: QA — 2026-03-21
+
+- [x] QA 通過（356 unit + 34 smoke + 54 E2E）— 3/3
+
+### Phase 5: 交付 — 2026-03-21
+
+- [x] Commit + Push — PR #122
+- [x] PR #122 rebase merge 到 main
+- [x] Deploy: main merge 到 release → Vercel 自動部署
+- [x] 部署後 QA: ./scripts/qa.sh https://howger-sport.com — 3/3 通過
+- [x] Production 驗證: curl /team/nba/los-angeles-lakers → 308 redirect 確認
+- [x] Issue #112 已關閉
+- [x] Evolve: vi.hoisted() 是 vitest mock hoisting 的正確解法，記住此模式避免未來重複試錯
+
+---
+
+## Issue #113: Sitemap 完整補全 — 補入球隊動態頁面
+
+### 分級：S（1 檔案、純程式碼新增、無 API/DB/UI 變更）
+- 跳過 Phase 1-2：S 級別 + 需求明確 + 依賴已 merge
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Branch: feat/113-sitemap-team-pages
+- [x] 實作完成：sitemap.ts 新增 60 筆球隊頁面（30 NBA + 30 MLB）
+  - 遍歷 TEAM_SLUG_MAP 取得 sport + teamId
+  - 使用 absoluteTeamUrl() 產生 canonical URL
+  - changeFrequency: weekly, priority: 0.6
+- [x] TypeScript 編譯通過
+- [x] Review（S 級別快速模式）：1 檔案純新增區塊，使用既有 helper 和常數，無邏輯風險
+
+### Phase 4: QA — 2026-03-21
+
+- [x] QA 通過（unit + smoke + E2E）— 3/3
+
+### Phase 5: 交付 — 2026-03-21
+
+- [x] Commit + Push — PR #123
+- [x] PR #123 rebase merge 到 main
+- [x] Deploy: main merge 到 release → Vercel 自動部署
+- [x] 部署後 QA: ./scripts/qa.sh https://howger-sport.com — 3/3 通過
+- [x] Issue #113 已關閉
+- [x] Evolve: 流程順暢，無改進建議。S 級別純新增區塊，依賴 #110 route helper + #111 TEAM_SLUG_MAP 均已就位，實作直接了當
+
+---
+
+## Issue #114: 文章延伸閱讀 — ExtendedReading 元件
+
+### 分級：M（新增元件 + 測試 + 修改既有頁面、無 DB schema 變更）
+- 簡化 Phase 1-2：已有完整 spec（Section 2.1）+ implementation plan（Task 6），需求明確
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Branch: feat/114-extended-reading（已存在）
+- [x] TDD Red: 7 個測試全部失敗（元件不存在）
+- [x] TDD Green: 實作 ExtendedReading 元件，7 個測試通過
+  - 純 server component（無 "use client"）
+  - 使用 newsUrl route helper
+  - 使用 CATEGORY_COLORS + formatRelativeTime
+  - 空陣列時 return null
+  - 分類 Badge + 標題 line-clamp-2 + 相對時間
+- [x] 頁面整合：news/[slug]/page.tsx 新增跨分類查詢 + ExtendedReading JSX
+- [x] 全站回歸: 363/363 通過
+- [x] Review: 純 server component，無副作用，使用既有 helper 和常數
+
+### Phase 4: QA — 2026-03-21
+
+- [x] QA 通過（363 unit + smoke + 54 E2E）— 3/3

--- a/src/__tests__/components/ExtendedReading.test.tsx
+++ b/src/__tests__/components/ExtendedReading.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ExtendedReading } from "@/components/public/ExtendedReading";
+
+const mockArticles = {
+  sameCategory: [
+    {
+      id: "1",
+      title: "NBA 季後賽分析",
+      slug: "nba-playoff",
+      category: "NBA",
+      published_at: "2026-03-20",
+    },
+    {
+      id: "2",
+      title: "湖人交易消息",
+      slug: "lakers-trade",
+      category: "NBA",
+      published_at: "2026-03-19",
+    },
+  ],
+  crossCategory: [
+    {
+      id: "3",
+      title: "MLB 開幕戰預測",
+      slug: "mlb-opening",
+      category: "棒球",
+      published_at: "2026-03-18",
+    },
+    {
+      id: "4",
+      title: "英超本週焦點",
+      slug: "epl-focus",
+      category: "足球",
+      published_at: "2026-03-17",
+    },
+  ],
+};
+
+describe("ExtendedReading", () => {
+  it("renders both same-category and cross-category articles", () => {
+    render(
+      <ExtendedReading
+        sameCategory={mockArticles.sameCategory}
+        crossCategory={mockArticles.crossCategory}
+      />
+    );
+    expect(screen.getByText("延伸閱讀")).toBeInTheDocument();
+    expect(screen.getByText("NBA 季後賽分析")).toBeInTheDocument();
+    expect(screen.getByText("MLB 開幕戰預測")).toBeInTheDocument();
+  });
+
+  it("renders nothing when both arrays are empty", () => {
+    const { container } = render(
+      <ExtendedReading sameCategory={[]} crossCategory={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("uses newsUrl route helper for links", () => {
+    render(
+      <ExtendedReading
+        sameCategory={mockArticles.sameCategory}
+        crossCategory={[]}
+      />
+    );
+    const link = screen.getByText("NBA 季後賽分析").closest("a");
+    expect(link).toHaveAttribute("href", "/news/nba-playoff");
+  });
+
+  it("falls back to id when slug is null", () => {
+    render(
+      <ExtendedReading
+        sameCategory={[
+          {
+            id: "99",
+            title: "No Slug",
+            slug: null,
+            category: "NBA",
+            published_at: null,
+          },
+        ]}
+        crossCategory={[]}
+      />
+    );
+    const link = screen.getByText("No Slug").closest("a");
+    expect(link).toHaveAttribute("href", "/news/99");
+  });
+
+  it("displays category badges", () => {
+    render(
+      <ExtendedReading
+        sameCategory={mockArticles.sameCategory}
+        crossCategory={mockArticles.crossCategory}
+      />
+    );
+    expect(screen.getAllByText("NBA")).toHaveLength(2);
+    expect(screen.getByText("棒球")).toBeInTheDocument();
+    expect(screen.getByText("足球")).toBeInTheDocument();
+  });
+
+  it("renders only same-category when cross-category is empty", () => {
+    render(
+      <ExtendedReading
+        sameCategory={mockArticles.sameCategory}
+        crossCategory={[]}
+      />
+    );
+    expect(screen.getByText("延伸閱讀")).toBeInTheDocument();
+    expect(screen.getByText("NBA 季後賽分析")).toBeInTheDocument();
+    expect(screen.getByText("湖人交易消息")).toBeInTheDocument();
+  });
+
+  it("renders only cross-category when same-category is empty", () => {
+    render(
+      <ExtendedReading
+        sameCategory={[]}
+        crossCategory={mockArticles.crossCategory}
+      />
+    );
+    expect(screen.getByText("延伸閱讀")).toBeInTheDocument();
+    expect(screen.getByText("MLB 開幕戰預測")).toBeInTheDocument();
+  });
+});

--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { extractHeadings } from "@/lib/markdown-utils";
 import { TableOfContents } from "@/components/public/TableOfContents";
 import { ShareButtons } from "@/components/public/ShareButtons";
 import { ReactionButtons } from "@/components/public/ReactionButtons";
+import { ExtendedReading } from "@/components/public/ExtendedReading";
 
 export const revalidate = 60;
 
@@ -122,6 +123,16 @@ export default async function ArticlePage({
     .neq("id", article.id)
     .order("published_at", { ascending: false })
     .limit(4);
+
+  // Fetch cross-category articles for extended reading
+  const { data: crossCategoryArticles } = await supabase
+    .from("generated_articles")
+    .select("id, title, slug, category, published_at")
+    .eq("status", "published")
+    .neq("category", article.category)
+    .neq("id", article.id)
+    .order("published_at", { ascending: false })
+    .limit(3);
 
   const colorClass =
     CATEGORY_COLORS[article.category ?? ""] ?? "bg-muted text-muted-foreground border border-border rounded-lg";
@@ -315,6 +326,24 @@ export default async function ArticlePage({
           </div>
         </section>
       )}
+
+      {/* Extended Reading — same category + cross category */}
+      <ExtendedReading
+        sameCategory={(relatedArticles ?? []).slice(0, 3).map((a) => ({
+          id: a.id,
+          title: a.title,
+          slug: a.slug ?? null,
+          category: a.category ?? null,
+          published_at: a.published_at ?? null,
+        }))}
+        crossCategory={(crossCategoryArticles ?? []).map((a) => ({
+          id: a.id,
+          title: a.title,
+          slug: a.slug ?? null,
+          category: a.category ?? null,
+          published_at: a.published_at ?? null,
+        }))}
+      />
     </article>
   );
 }

--- a/src/components/public/ExtendedReading.tsx
+++ b/src/components/public/ExtendedReading.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { newsUrl } from "@/lib/routes";
+import { formatRelativeTime, CATEGORY_COLORS } from "@/lib/constants";
+
+interface Article {
+  id: string;
+  title: string;
+  slug: string | null;
+  category: string | null;
+  published_at: string | null;
+}
+
+interface ExtendedReadingProps {
+  sameCategory: Article[];
+  crossCategory: Article[];
+}
+
+export function ExtendedReading({
+  sameCategory,
+  crossCategory,
+}: ExtendedReadingProps) {
+  const all = [...sameCategory, ...crossCategory];
+  if (all.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-bold text-foreground mb-5 border-l-4 border-emerald-600 pl-3">
+        延伸閱讀
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {all.map((article) => (
+          <Link
+            key={article.id}
+            href={newsUrl(article.slug || article.id)}
+            className="group block rounded-lg border border-border bg-card p-4 hover:shadow-md hover:border-emerald-300 transition-all"
+          >
+            {article.category && (
+              <span
+                className={`inline-block text-xs px-2 py-0.5 mb-2 ${CATEGORY_COLORS[article.category] ?? "bg-gray-500 text-white rounded-md"}`}
+              >
+                {article.category}
+              </span>
+            )}
+            <h3 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-emerald-600 transition-colors mb-2">
+              {article.title}
+            </h3>
+            <time className="text-xs text-muted-foreground">
+              {formatRelativeTime(article.published_at)}
+            </time>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- 新增 `ExtendedReading` 純 server component，在文章頁底部顯示同分類 3 篇 + 跨分類 3 篇延伸閱讀
- 每篇顯示分類 Badge、標題（line-clamp-2）、相對時間，點擊導向文章頁
- 空陣列時不渲染，使用 newsUrl route helper
- 新增 7 個 Vitest 測試覆蓋所有邊界情況

## Test plan

- [x] 7 個 ExtendedReading 單元測試通過
- [x] 全站 363 個測試通過，無回歸
- [x] QA 腳本 3/3 通過（unit + smoke + E2E）

Issue #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)