### PR TITLE
feat: 首頁快訊區塊 QuickNews (#115)

### DIFF
--- a/src/__tests__/components/QuickNews.test.tsx
+++ b/src/__tests__/components/QuickNews.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QuickNews } from "@/components/public/QuickNews";
+
+const mockArticles = [
+  {
+    id: "1",
+    title: "NBA 季後賽最新戰況更新",
+    slug: "nba-playoff-update",
+    published_at: "2026-03-21T10:00:00Z",
+  },
+  {
+    id: "2",
+    title: "湖人隊今日交易消息",
+    slug: "lakers-trade-news",
+    published_at: "2026-03-21T09:30:00Z",
+  },
+  {
+    id: "3",
+    title: "MLB 春訓最新動態報導",
+    slug: null,
+    published_at: "2026-03-21T09:00:00Z",
+  },
+];
+
+describe("QuickNews", () => {
+  it("renders section title with Zap icon", () => {
+    render(<QuickNews articles={mockArticles} />);
+    expect(screen.getByText("快訊")).toBeInTheDocument();
+  });
+
+  it("renders all article titles", () => {
+    render(<QuickNews articles={mockArticles} />);
+    expect(screen.getByText("NBA 季後賽最新戰況更新")).toBeInTheDocument();
+    expect(screen.getByText("湖人隊今日交易消息")).toBeInTheDocument();
+    expect(screen.getByText("MLB 春訓最新動態報導")).toBeInTheDocument();
+  });
+
+  it("renders nothing when articles array is empty", () => {
+    const { container } = render(<QuickNews articles={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("uses newsUrl route helper with slug for links", () => {
+    render(<QuickNews articles={mockArticles} />);
+    const link = screen.getByText("NBA 季後賽最新戰況更新").closest("a");
+    expect(link).toHaveAttribute("href", "/news/nba-playoff-update");
+  });
+
+  it("falls back to id when slug is null", () => {
+    render(<QuickNews articles={mockArticles} />);
+    const link = screen.getByText("MLB 春訓最新動態報導").closest("a");
+    expect(link).toHaveAttribute("href", "/news/3");
+  });
+
+  it("renders correct number of list items", () => {
+    render(<QuickNews articles={mockArticles} />);
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("displays relative time for each article", () => {
+    // Use a very recent date to test "剛剛"
+    const recentArticles = [
+      {
+        id: "10",
+        title: "剛發布的新聞",
+        slug: "just-now",
+        published_at: new Date().toISOString(),
+      },
+    ];
+    render(<QuickNews articles={recentArticles} />);
+    expect(screen.getByText("剛剛")).toBeInTheDocument();
+  });
+
+  it("renders as a list with proper semantic structure", () => {
+    render(<QuickNews articles={mockArticles} />);
+    const list = screen.getByRole("list");
+    expect(list).toBeInTheDocument();
+    expect(list.querySelectorAll("li")).toHaveLength(3);
+  });
+});

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { createServiceClient } from "@/lib/supabase";
 import { HeroSection } from "@/components/public/HeroSection";
 import { LiveScoreTicker } from "@/components/public/LiveScoreTicker";
+import { QuickNews } from "@/components/public/QuickNews";
 import { HomeArticleSection } from "@/components/public/HomeArticleSection";
 import { QuickStandings } from "@/components/public/QuickStandings";
 import { QuickOdds } from "@/components/public/QuickOdds";
@@ -57,7 +58,8 @@ export default async function HomePage() {
   const allArticles = (articlesResult.data || []) as unknown as ArticleWithWriter[];
   const hero = allArticles[0] || null;
   const subHeroes = allArticles.slice(1, 3);
-  const gridArticles = allArticles.slice(3, 33);
+  const quickNewsArticles = allArticles.slice(3, 13);
+  const gridArticles = allArticles.slice(13, 33);
 
   return (
     <div>
@@ -77,6 +79,16 @@ export default async function HomePage() {
           }))}
         />
       )}
+
+      {/* Quick News */}
+      <QuickNews
+        articles={quickNewsArticles.map((a) => ({
+          id: a.id,
+          title: a.title,
+          slug: a.slug,
+          published_at: a.published_at,
+        }))}
+      />
 
       {/* Main content + Sidebar */}
       <div className="flex flex-col lg:flex-row gap-6">

--- a/src/components/public/QuickNews.tsx
+++ b/src/components/public/QuickNews.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { Zap } from "lucide-react";
+import { formatRelativeTime } from "@/lib/constants";
+import { newsUrl } from "@/lib/routes";
+
+export interface QuickNewsArticle {
+  id: string;
+  title: string;
+  slug: string | null;
+  published_at: string | null;
+}
+
+export function QuickNews({ articles }: { articles: QuickNewsArticle[] }) {
+  if (articles.length === 0) return null;
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-center gap-2 mb-3">
+        <Zap className="h-5 w-5 text-brand fill-brand" />
+        <h2 className="text-lg font-bold text-foreground">快訊</h2>
+      </div>
+      <ul className="divide-y divide-border rounded-lg border bg-card">
+        {articles.map((article) => (
+          <li key={article.id}>
+            <Link
+              href={newsUrl(article.slug || article.id)}
+              className="flex items-baseline justify-between gap-3 px-4 py-2.5 hover:bg-muted/50 transition-colors"
+            >
+              <span className="text-sm font-medium text-foreground line-clamp-1 min-w-0">
+                {article.title}
+              </span>
+              <span className="text-xs text-muted-foreground whitespace-nowrap flex-shrink-0">
+                {formatRelativeTime(article.published_at)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- 在 Hero 區塊與文章列表之間新增「快訊」區塊，以純標題列表形式展示 10 則最新文章
- 首頁文章分配調整：hero(1) + subHeroes(2) + quickNews(10) + grid(剩餘)
- 空陣列時不渲染，Server Component 不需 "use client"

## Changes
- **New:** `src/components/public/QuickNews.tsx` — Zap icon + 標題列表，使用 newsUrl route helper
- **New:** `src/__tests__/components/QuickNews.test.tsx` — 8 tests covering rendering, routing, empty state
- **Modified:** `src/app/(public)/page.tsx` — 插入 QuickNews，調整文章分配邏輯

## Test plan
- [x] Vitest: 371 tests passed (含新增 8 tests)
- [x] Smoke test: 34/34 passed
- [x] E2E: 54 passed, 3 skipped (既有 skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)