### PR TITLE
feat: add skeleton loading components (#116)

### DIFF
--- a/src/__tests__/components/ArticleCardSkeleton.test.tsx
+++ b/src/__tests__/components/ArticleCardSkeleton.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  ArticleCardSkeleton,
+  ArticleCardSkeletonGrid,
+  QuickNewsSkeleton,
+} from "@/components/public/ArticleCardSkeleton";
+
+describe("ArticleCardSkeleton", () => {
+  it("renders skeleton structure with card container", () => {
+    const { container } = render(<ArticleCardSkeleton />);
+    expect(container.querySelector(".rounded-lg")).toBeInTheDocument();
+  });
+
+  it("renders image skeleton placeholder", () => {
+    const { container } = render(<ArticleCardSkeleton />);
+    // Image skeleton: full width, fixed height
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(skeletons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders multiple skeleton lines for title and meta", () => {
+    const { container } = render(<ArticleCardSkeleton />);
+    const skeletons = container.querySelectorAll('[data-slot="skeleton"]');
+    // At least: image + category + title + title-line2 + 2 meta = 6
+    expect(skeletons.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("ArticleCardSkeletonGrid", () => {
+  it("renders specified number of skeletons", () => {
+    const { container } = render(<ArticleCardSkeletonGrid count={3} />);
+    const cards = container.querySelectorAll(".rounded-lg.border");
+    expect(cards.length).toBe(3);
+  });
+
+  it("defaults to 6 skeletons", () => {
+    const { container } = render(<ArticleCardSkeletonGrid />);
+    const cards = container.querySelectorAll(".rounded-lg.border");
+    expect(cards.length).toBe(6);
+  });
+
+  it("renders grid layout with responsive columns", () => {
+    const { container } = render(<ArticleCardSkeletonGrid />);
+    const grid = container.querySelector(".grid");
+    expect(grid).toBeInTheDocument();
+  });
+});
+
+describe("QuickNewsSkeleton", () => {
+  it("renders specified number of rows", () => {
+    const { container } = render(<QuickNewsSkeleton count={3} />);
+    const rows = container.querySelectorAll(".flex.items-center");
+    expect(rows.length).toBe(3);
+  });
+
+  it("defaults to 5 rows", () => {
+    const { container } = render(<QuickNewsSkeleton />);
+    const rows = container.querySelectorAll(".flex.items-center");
+    expect(rows.length).toBe(5);
+  });
+
+  it("renders container with card styling", () => {
+    const { container } = render(<QuickNewsSkeleton />);
+    expect(container.querySelector(".rounded-lg.border")).toBeInTheDocument();
+  });
+});

--- a/src/components/public/ArticleCardSkeleton.tsx
+++ b/src/components/public/ArticleCardSkeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function ArticleCardSkeleton() {
+  return (
+    <div className="rounded-lg border border-border bg-card overflow-hidden">
+      <Skeleton className="w-full h-40" />
+      <div className="p-4 space-y-2">
+        <Skeleton className="h-3 w-16" />
+        <Skeleton className="h-5 w-full" />
+        <Skeleton className="h-5 w-3/4" />
+        <div className="flex gap-2 pt-1">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ArticleCardSkeletonGrid({ count = 6 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <ArticleCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function QuickNewsSkeleton({ count = 5 }: { count?: number }) {
+  return (
+    <div className="rounded-lg border border-border bg-card divide-y divide-border">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-center justify-between px-4 py-2.5">
+          <Skeleton className="h-4 flex-1 mr-3" />
+          <Skeleton className="h-3 w-12" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Summary
- Add `ArticleCardSkeleton`, `ArticleCardSkeletonGrid`, `QuickNewsSkeleton` components using shadcn/ui Skeleton primitive
- Install shadcn/ui `skeleton` component (`src/components/ui/skeleton.tsx`)
- Add 9 Vitest tests covering structure, count defaults, and responsive grid layout
- Spec: `docs/superpowers/specs/2026-03-21-ux-visual-seo-optimization-design.md` Section 2.7
- Plan: `docs/superpowers/plans/2026-03-21-phase1-seo-content-discovery.md` Task 8

## Test plan
- [x] `npx vitest run` — 380 tests pass (9 new skeleton tests)
- [x] `./scripts/qa.sh` — 3/3 passed (unit + smoke + E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)