### PR TITLE
fix(tags): 修復文章標籤系統 — 產生、顯示、回填

### DIFF
--- a/.claude/execution-log.md
+++ b/.claude/execution-log.md
@@ -195,3 +195,26 @@
 
 - [x] Git-Ops 建立 branch feat/132-homepage-ui-redesign
 - [ ] FE 實作中...
+
+## Issue #127: fix: NEXT_PUBLIC_SITE_URL 環境變數仍指向 sportnews-ashen.vercel.app
+
+### 分級：S（純環境變數修改，無程式碼變更）
+
+### Phase 0: 評估 — 2026-03-21
+- [x] S 級別，純 Vercel 環境變數修復
+- [x] Phase 1-2 跳過（S 級別 + 無程式碼變更）
+
+### Phase 3: 工程（OPS）— 2026-03-21
+- [x] OPS 確認問題：robots.txt sitemap 指向 sportnews-ashen.vercel.app
+- [x] vercel env rm NEXT_PUBLIC_SITE_URL production
+- [x] printf 'https://howger-sport.com' | vercel env add NEXT_PUBLIC_SITE_URL production
+- [x] vercel redeploy 觸發重新部署
+
+### Phase 4: QA — 2026-03-21
+- [x] 部署後 QA 通過（391 unit + 54 E2E + smoke）
+- [x] robots.txt: Sitemap: https://howger-sport.com/sitemap.xml ✓
+- [x] sitemap.xml: 所有 URL 使用正確域名 ✓
+
+### Phase 5: 交付 — 2026-03-21
+- [x] Issue #127 closed
+- [x] Evolve: S 級別無新發現，跳過（無程式碼變更，無逃逸鏈可分析）

--- a/scripts/backfill-tags.ts
+++ b/scripts/backfill-tags.ts
@@ -1,0 +1,76 @@
+/**
+ * 一次性回填腳本：為現有文章補上標籤
+ *
+ * 掃描所有 generated_articles 中 tags 為空陣列的文章，
+ * 根據標題和內容提取球隊名、聯盟名作為標籤。
+ *
+ * 使用方式：npx tsx scripts/backfill-tags.ts
+ */
+
+import { config } from "dotenv";
+import { resolve } from "path";
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+import { createClient } from "@supabase/supabase-js";
+import { extractTagsFromContent } from "./shared-tags";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+async function main() {
+  console.log("=== 文章標籤回填腳本 ===\n");
+
+  // 查詢所有 tags 為空的文章
+  const { data: articles, error } = await supabase
+    .from("generated_articles")
+    .select("id, title, content")
+    .or("tags.eq.{},tags.is.null")
+    .order("created_at");
+
+  if (error) {
+    console.error(`查詢失敗: ${error.message}`);
+    process.exit(1);
+  }
+
+  console.log(`找到 ${articles.length} 篇需要回填標籤的文章\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const article of articles) {
+    const tags = extractTagsFromContent(article.title, article.content || "");
+
+    if (tags.length === 0) {
+      console.log(`  跳過: ${article.title.substring(0, 50)}... (無法提取標籤)`);
+      skipped++;
+      continue;
+    }
+
+    const { error: updateError } = await supabase
+      .from("generated_articles")
+      .update({ tags })
+      .eq("id", article.id);
+
+    if (updateError) {
+      console.error(`  ✗ ${article.title.substring(0, 50)}... 更新失敗: ${updateError.message}`);
+      continue;
+    }
+
+    console.log(`  ✓ ${article.title.substring(0, 50)}... → [${tags.join(", ")}]`);
+    updated++;
+  }
+
+  console.log(`\n=== 完成 ===`);
+  console.log(`更新: ${updated} 篇`);
+  console.log(`跳過: ${skipped} 篇`);
+  console.log(`總計: ${articles.length} 篇`);
+}
+
+main().catch(console.error);

--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -160,6 +160,9 @@ function parseResult(output: string): { title: string; content: string; category
   return JSON.parse(jsonMatch[0]);
 }
 
+// extractTagsFromContent 從 shared-tags.ts 匯入
+import { extractTagsFromContent } from "./shared-tags";
+
 function buildColumnistPrompt(
   articles: RawArticle[],
   persona: WriterPersona,
@@ -356,6 +359,10 @@ async function produceFromPlans(planIds: string[]) {
         continue;
       }
 
+      // AI 不可靠地回傳 tags，用 extractTagsFromContent 作為 fallback
+      const aiTags = Array.isArray(result.tags) ? result.tags : [];
+      const finalTags = aiTags.length > 0 ? aiTags : extractTagsFromContent(result.title, result.content);
+
       const { error: insertError } = await supabase
         .from("generated_articles")
         .insert({
@@ -365,7 +372,7 @@ async function produceFromPlans(planIds: string[]) {
           content: result.content,
           category: result.category || plan.league || articles[0].category || "綜合",
           images: collectedImages,
-          tags: Array.isArray(result.tags) ? result.tags : [],
+          tags: finalTags,
           status: "draft",
         });
 
@@ -544,6 +551,9 @@ async function main() {
             continue;
           }
 
+          const aiTagsOfficial = Array.isArray(result.tags) ? result.tags : [];
+          const finalTagsOfficial = aiTagsOfficial.length > 0 ? aiTagsOfficial : extractTagsFromContent(result.title, result.content);
+
           const { error: insertError } = await supabase
             .from("generated_articles")
             .insert({
@@ -553,7 +563,7 @@ async function main() {
               content: result.content,
               category: result.category || league,
               images: officialImages,
-              tags: Array.isArray(result.tags) ? result.tags : [],
+              tags: finalTagsOfficial,
               status: "draft",
             });
 
@@ -614,6 +624,9 @@ async function main() {
           continue;
         }
 
+        const aiTagsCol = Array.isArray(result.tags) ? result.tags : [];
+        const finalTagsCol = aiTagsCol.length > 0 ? aiTagsCol : extractTagsFromContent(result.title, result.content);
+
         const { error: insertError } = await supabase
           .from("generated_articles")
           .insert({
@@ -623,7 +636,7 @@ async function main() {
             content: result.content,
             category: result.category || group[0].category || "綜合",
             images: columnistImages,
-            tags: Array.isArray(result.tags) ? result.tags : [],
+            tags: finalTagsCol,
             status: "draft",
           });
 

--- a/scripts/shared-tags.ts
+++ b/scripts/shared-tags.ts
@@ -1,0 +1,52 @@
+/**
+ * 共用標籤提取邏輯 — 從文章標題和內容中提取球隊名、聯盟名
+ *
+ * 供 local-rewriter.ts 和 backfill-tags.ts 使用
+ */
+
+/** 從文章標題和內容中提取標籤（球隊名、聯盟名） */
+export function extractTagsFromContent(title: string, content: string): string[] {
+  const text = `${title} ${content}`;
+  const tags = new Set<string>();
+
+  // 聯盟名稱
+  const leagues = ["NBA", "MLB", "NFL", "NHL", "Premier League", "La Liga", "Serie A", "Bundesliga", "Ligue 1"];
+  for (const league of leagues) {
+    if (text.includes(league)) tags.add(league);
+  }
+
+  // 球隊簡短名稱 → 全名
+  const teamShortNames: Record<string, string> = {
+    // NBA
+    "Hawks": "Atlanta Hawks", "Celtics": "Boston Celtics", "Nets": "Brooklyn Nets",
+    "Hornets": "Charlotte Hornets", "Bulls": "Chicago Bulls", "Cavaliers": "Cleveland Cavaliers",
+    "Cavs": "Cleveland Cavaliers", "Mavericks": "Dallas Mavericks", "Mavs": "Dallas Mavericks",
+    "Nuggets": "Denver Nuggets", "Pistons": "Detroit Pistons", "Warriors": "Golden State Warriors",
+    "Rockets": "Houston Rockets", "Pacers": "Indiana Pacers", "Clippers": "LA Clippers",
+    "Lakers": "Los Angeles Lakers", "Grizzlies": "Memphis Grizzlies", "Heat": "Miami Heat",
+    "Bucks": "Milwaukee Bucks", "Timberwolves": "Minnesota Timberwolves", "Wolves": "Minnesota Timberwolves",
+    "Pelicans": "New Orleans Pelicans", "Knicks": "New York Knicks", "Thunder": "Oklahoma City Thunder",
+    "Magic": "Orlando Magic", "76ers": "Philadelphia 76ers", "Sixers": "Philadelphia 76ers",
+    "Suns": "Phoenix Suns", "Trail Blazers": "Portland Trail Blazers", "Blazers": "Portland Trail Blazers",
+    "Kings": "Sacramento Kings", "Spurs": "San Antonio Spurs", "Raptors": "Toronto Raptors",
+    "Jazz": "Utah Jazz", "Wizards": "Washington Wizards",
+    // MLB
+    "Diamondbacks": "Arizona Diamondbacks", "Braves": "Atlanta Braves", "Orioles": "Baltimore Orioles",
+    "Red Sox": "Boston Red Sox", "Cubs": "Chicago Cubs", "White Sox": "Chicago White Sox",
+    "Reds": "Cincinnati Reds", "Guardians": "Cleveland Guardians", "Rockies": "Colorado Rockies",
+    "Tigers": "Detroit Tigers", "Astros": "Houston Astros", "Royals": "Kansas City Royals",
+    "Angels": "Los Angeles Angels", "Dodgers": "Los Angeles Dodgers", "Marlins": "Miami Marlins",
+    "Brewers": "Milwaukee Brewers", "Twins": "Minnesota Twins", "Mets": "New York Mets",
+    "Yankees": "New York Yankees", "Athletics": "Oakland Athletics", "Phillies": "Philadelphia Phillies",
+    "Pirates": "Pittsburgh Pirates", "Padres": "San Diego Padres", "Giants": "San Francisco Giants",
+    "Mariners": "Seattle Mariners", "Cardinals": "St. Louis Cardinals", "Rays": "Tampa Bay Rays",
+    "Rangers": "Texas Rangers", "Blue Jays": "Toronto Blue Jays", "Nationals": "Washington Nationals",
+  };
+
+  for (const [shortName, fullName] of Object.entries(teamShortNames)) {
+    const regex = new RegExp(`\\b${shortName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
+    if (regex.test(text)) tags.add(fullName);
+  }
+
+  return Array.from(tags);
+}

--- a/src/__tests__/scripts/extract-tags.test.ts
+++ b/src/__tests__/scripts/extract-tags.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { extractTagsFromContent } from "../../../scripts/shared-tags";
+
+describe("extractTagsFromContent", () => {
+  it("extracts NBA league and team names", () => {
+    const tags = extractTagsFromContent(
+      "LeBron James 30 分力克火箭",
+      "NBA 賽季中 Lakers 以 120-110 擊敗 Rockets"
+    );
+    expect(tags).toContain("NBA");
+    expect(tags).toContain("Los Angeles Lakers");
+    expect(tags).toContain("Houston Rockets");
+  });
+
+  it("extracts MLB teams", () => {
+    const tags = extractTagsFromContent(
+      "MLB 春訓最新",
+      "Dodgers 與 Yankees 春訓對決"
+    );
+    expect(tags).toContain("MLB");
+    expect(tags).toContain("Los Angeles Dodgers");
+    expect(tags).toContain("New York Yankees");
+  });
+
+  it("handles short team names like Cavs, Mavs, Wolves", () => {
+    const tags = extractTagsFromContent(
+      "Cavs vs Wolves",
+      "The Cavs defeated the Wolves in overtime"
+    );
+    expect(tags).toContain("Cleveland Cavaliers");
+    expect(tags).toContain("Minnesota Timberwolves");
+  });
+
+  it("does not match partial words (e.g., 'heated' should not match 'Heat')", () => {
+    const tags = extractTagsFromContent(
+      "heated debate",
+      "The heated argument continued all day"
+    );
+    expect(tags).not.toContain("Miami Heat");
+  });
+
+  it("returns empty array for unrecognized content", () => {
+    const tags = extractTagsFromContent(
+      "天氣預報",
+      "今天天氣晴朗，適合出門"
+    );
+    expect(tags).toHaveLength(0);
+  });
+
+  it("deduplicates when both short and long names appear", () => {
+    const tags = extractTagsFromContent(
+      "Lakers game",
+      "Los Angeles Lakers played well. The Lakers dominated."
+    );
+    const lakerCount = tags.filter(t => t === "Los Angeles Lakers").length;
+    expect(lakerCount).toBe(1);
+  });
+
+  it("extracts from title even if content is empty", () => {
+    const tags = extractTagsFromContent("NBA Celtics 大勝", "");
+    expect(tags).toContain("NBA");
+    expect(tags).toContain("Boston Celtics");
+  });
+
+  it("handles 76ers / Sixers aliases", () => {
+    const tags1 = extractTagsFromContent("76ers win", "");
+    const tags2 = extractTagsFromContent("Sixers win", "");
+    expect(tags1).toContain("Philadelphia 76ers");
+    expect(tags2).toContain("Philadelphia 76ers");
+  });
+});

--- a/src/components/admin/article-detail/ArticleHeader.tsx
+++ b/src/components/admin/article-detail/ArticleHeader.tsx
@@ -32,9 +32,18 @@ export function ArticleHeader({
         </Button>
         <Badge variant="secondary">{ARTICLE_STATUS_LABELS[article.status]}</Badge>
         {article.writer_personas && (
-          <span className="text-sm text-gray-500">
+          <span className="text-sm text-muted-foreground">
             寫手：{article.writer_personas.name}
           </span>
+        )}
+        {article.tags?.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {article.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
         )}
       </div>
       <div className="flex gap-2">

--- a/src/components/admin/article-detail/article-detail-types.ts
+++ b/src/components/admin/article-detail/article-detail-types.ts
@@ -11,6 +11,7 @@ export interface ArticleDetail {
   scheduled_at: string | null;
   publish_channel_ids: number[];
   images: string[];
+  tags: string[];
   writer_personas: {
     name: string;
     description: string | null;


### PR DESCRIPTION
## Summary
修復文章標籤系統：AI 不可靠回傳 tags → 添加 extractTagsFromContent fallback → 回填 83/84 篇文章 → 後台顯示標籤

## Changes
- 新增 `scripts/shared-tags.ts`：共用標籤提取邏輯（球隊名 word-boundary 匹配）
- 修復 `scripts/local-rewriter.ts`：3 處 insert 邏輯添加 extractTagsFromContent fallback
- 重寫 `scripts/backfill-tags.ts`：改用 Supabase JS client（消除 SQL injection）
- 新增 `ArticleDetail.tags` 型別 + 後台 Badge 顯示
- 修復 `text-gray-500` → `text-muted-foreground`

## Test
- Unit tests: 399/399 ✓（含 8 個 extractTagsFromContent 測試）
- Review: 5 agent 審查，3 項修復 ✓
- Backfill: 83/84 篇文章已補上標籤 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)