### PR TITLE
feat(category): 分類頁側邊欄 — 本週熱門 + 同隊新聞

### DIFF
--- a/src/app/(public)/category/[slug]/page.tsx
+++ b/src/app/(public)/category/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { createServiceClient } from "@/lib/supabase";
 import { CATEGORY_COLORS, CATEGORY_DB_MAP, CATEGORY_FALLBACK_IMAGES, CATEGORY_LABELS, formatRelativeTime, getFirstImageUrl, SITE_NAME } from "@/lib/constants";
 import { categoryUrl, newsUrl } from "@/lib/routes";
 import { getExcerpt } from "@/lib/utils";
+import { CategorySidebar } from "@/components/public/CategorySidebar";
 
 export const revalidate = 60;
 
@@ -213,56 +214,60 @@ export default async function CategoryPage({
         </div>
       </div>
 
-      {/* Articles */}
-      {!articles || articles.length === 0 ? (
-        <p className="text-muted-foreground py-12 text-center">
-          此分類目前沒有文章。
-        </p>
-      ) : (
-        <div className="space-y-4 mb-8">
-          {(articles as unknown as ArticleWithWriter[]).map((article) => {
-            const writerName = article.writer_personas?.name;
-            const thumbnail = getFirstImageUrl(article.images) || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
-            return (
-              <Link
-                key={article.id}
-                href={newsUrl(article.slug || article.id)}
-                className="group block rounded-xl border border-border bg-card p-5 hover:shadow-md hover:border-brand/30 transition-all duration-200"
-              >
-                <div className="flex items-start gap-4">
-                  <div className="flex-1 min-w-0">
-                    <h2 className="text-lg font-semibold text-foreground line-clamp-2 group-hover:text-brand transition-colors mb-2">
-                      {article.title}
-                    </h2>
-                    <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
-                      {getExcerpt(article.content)}
-                    </p>
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      {writerName && <span>{writerName}</span>}
-                      {writerName && <span>&middot;</span>}
-                      <span>{formatRelativeTime(article.published_at)}</span>
-                      {sortBy === "popular" && article.view_count != null && article.view_count > 0 && (
-                        <>
-                          <span>&middot;</span>
-                          <span>{article.view_count} 次瀏覽</span>
-                        </>
-                      )}
+      {/* Main content + Sidebar grid */}
+      <div className="lg:grid lg:grid-cols-[1fr_300px] lg:gap-8">
+        {/* Main content */}
+        <div>
+          {/* Articles */}
+          {!articles || articles.length === 0 ? (
+            <p className="text-muted-foreground py-12 text-center">
+              此分類目前沒有文章。
+            </p>
+          ) : (
+            <div className="space-y-4 mb-8">
+              {(articles as unknown as ArticleWithWriter[]).map((article) => {
+                const writerName = article.writer_personas?.name;
+                const thumbnail = getFirstImageUrl(article.images) || CATEGORY_FALLBACK_IMAGES[article.category ?? ""] || "/images/category-general.jpg";
+                return (
+                  <Link
+                    key={article.id}
+                    href={newsUrl(article.slug || article.id)}
+                    className="group block rounded-xl border border-border bg-card p-5 hover:shadow-md hover:border-brand/30 transition-all duration-200"
+                  >
+                    <div className="flex items-start gap-4">
+                      <div className="flex-1 min-w-0">
+                        <h2 className="text-lg font-semibold text-foreground line-clamp-2 group-hover:text-brand transition-colors mb-2">
+                          {article.title}
+                        </h2>
+                        <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+                          {getExcerpt(article.content)}
+                        </p>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                          {writerName && <span>{writerName}</span>}
+                          {writerName && <span>&middot;</span>}
+                          <span>{formatRelativeTime(article.published_at)}</span>
+                          {sortBy === "popular" && article.view_count != null && article.view_count > 0 && (
+                            <>
+                              <span>&middot;</span>
+                              <span>{article.view_count} 次瀏覽</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <img
+                        src={thumbnail}
+                        alt=""
+                        className="w-28 h-20 object-cover rounded-lg flex-shrink-0"
+                      />
                     </div>
-                  </div>
-                  <img
-                    src={thumbnail}
-                    alt=""
-                    className="w-28 h-20 object-cover rounded-lg flex-shrink-0"
-                  />
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      )}
+                  </Link>
+                );
+              })}
+            </div>
+          )}
 
-      {/* Pagination */}
-      {totalPages > 1 && (
+          {/* Pagination */}
+          {totalPages > 1 && (
         <nav className="flex items-center justify-center gap-2 mt-8">
           {currentPage > 1 && (
             <Link
@@ -317,6 +322,13 @@ export default async function CategoryPage({
           )}
         </nav>
       )}
+        </div>
+
+        {/* Sidebar — desktop only inline, mobile below */}
+        <aside className="mt-8 lg:mt-0">
+          <CategorySidebar category={categoryName} />
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/app/api/public/articles/trending/route.ts
+++ b/src/app/api/public/articles/trending/route.ts
@@ -1,18 +1,59 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase";
+import { z } from "zod";
 
 export const revalidate = 300; // 5 minutes
 
-export async function GET() {
+const QuerySchema = z.object({
+  category: z.string().optional(),
+  period: z.enum(["week", "month", "all"]).default("all"),
+  limit: z.coerce.number().int().min(1).max(20).default(5),
+});
+
+export async function GET(request: NextRequest) {
   try {
+    const { searchParams } = request.nextUrl;
+    const parsed = QuerySchema.safeParse({
+      category: searchParams.get("category") ?? undefined,
+      period: searchParams.get("period") ?? undefined,
+      limit: searchParams.get("limit") ?? undefined,
+    });
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid query params" },
+        { status: 400 }
+      );
+    }
+
+    const { category, period, limit } = parsed.data;
     const supabase = createServiceClient();
 
-    const { data: articles, error } = await supabase
+    let query = supabase
       .from("generated_articles")
       .select("id, title, slug, category, view_count, published_at")
       .eq("status", "published")
       .order("view_count", { ascending: false })
-      .limit(5);
+      .limit(limit);
+
+    // Filter by category
+    if (category) {
+      query = query.eq("category", category);
+    }
+
+    // Filter by time period
+    if (period !== "all") {
+      const now = new Date();
+      const since = new Date();
+      if (period === "week") {
+        since.setDate(now.getDate() - 7);
+      } else if (period === "month") {
+        since.setDate(now.getDate() - 30);
+      }
+      query = query.gte("published_at", since.toISOString());
+    }
+
+    const { data: articles, error } = await query;
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/components/public/CategorySidebar.tsx
+++ b/src/components/public/CategorySidebar.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { TrendingUp, Star } from "lucide-react";
+import { newsUrl } from "@/lib/routes";
+import { formatRelativeTime } from "@/lib/constants";
+
+interface TrendingArticle {
+  id: string;
+  title: string;
+  slug: string | null;
+  category: string | null;
+  view_count: number | null;
+  published_at: string | null;
+}
+
+interface FavoriteTeam {
+  sport: string;
+  teamId: string;
+  name: string;
+}
+
+const rankClass = (idx: number) => {
+  if (idx === 0) return "text-amber-500";
+  if (idx === 1) return "text-slate-400";
+  if (idx === 2) return "text-amber-700";
+  return "text-muted-foreground/40";
+};
+
+function WeeklyTrending({ category }: { category: string }) {
+  const { data: articles = [], isLoading } = useQuery({
+    queryKey: ["trending-articles", category, "week"],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/public/articles/trending?category=${encodeURIComponent(category)}&period=week&limit=5`
+      );
+      if (!res.ok) throw new Error("fetch failed");
+      const d = await res.json();
+      return (d.articles ?? []) as TrendingArticle[];
+    },
+    staleTime: 10 * 60 * 1000,
+  });
+
+  return (
+    <div className="bg-card border border-border rounded-xl overflow-hidden">
+      <div className="flex items-center px-4 py-3.5 border-b border-border">
+        <h3 className="font-serif text-[15px] font-bold text-foreground flex items-center gap-1.5">
+          <TrendingUp className="w-4 h-4 text-red-500" />
+          本週熱門
+        </h3>
+      </div>
+
+      {isLoading ? (
+        <div className="p-4 space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="animate-pulse flex gap-3">
+              <div className="w-6 h-6 bg-muted rounded" />
+              <div className="flex-1">
+                <div className="h-3.5 bg-muted rounded w-full mb-1.5" />
+                <div className="h-3 bg-muted rounded w-1/3" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : articles.length === 0 ? (
+        <p className="text-sm text-muted-foreground p-4">本週暫無熱門文章</p>
+      ) : (
+        <div>
+          {articles.map((article, idx) => (
+            <Link
+              key={article.id}
+              href={newsUrl(article.slug || article.id)}
+              className="group flex gap-3 px-4 py-3 border-b border-border last:border-0 hover:bg-muted/50 transition-colors"
+            >
+              <span className={`font-serif text-[22px] font-black leading-none min-w-[26px] ${rankClass(idx)}`}>
+                {idx + 1}
+              </span>
+              <div className="flex-1 min-w-0">
+                <h4 className="text-[13px] font-semibold text-foreground line-clamp-2 leading-snug group-hover:text-blue-600 transition-colors">
+                  {article.title}
+                </h4>
+                <span className="text-[11px] text-muted-foreground mt-1 block">
+                  {formatRelativeTime(article.published_at)}
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RelatedByTeam({ category }: { category: string }) {
+  const { data: session } = useSession();
+
+  const { data: favorites = [] } = useQuery({
+    queryKey: ["favorites"],
+    queryFn: async () => {
+      const res = await fetch("/api/member/favorites");
+      if (!res.ok) throw new Error("fetch failed");
+      const d = await res.json();
+      return (d.favorites ?? []) as FavoriteTeam[];
+    },
+    enabled: !!session?.user,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: articles = [], isLoading } = useQuery({
+    queryKey: ["related-by-team", category],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/public/articles/trending?category=${encodeURIComponent(category)}&period=month&limit=10`
+      );
+      if (!res.ok) throw new Error("fetch failed");
+      const d = await res.json();
+      return (d.articles ?? []) as TrendingArticle[];
+    },
+    staleTime: 10 * 60 * 1000,
+  });
+
+  // Filter articles that mention favorite team names
+  const favoriteNames = favorites.map((f) => f.name);
+  const related = favoriteNames.length > 0
+    ? articles.filter((a) => favoriteNames.some((name) => a.title.includes(name))).slice(0, 5)
+    : [];
+
+  if (!session?.user || related.length === 0) return null;
+
+  return (
+    <div className="bg-card border border-border rounded-xl overflow-hidden">
+      <div className="flex items-center px-4 py-3.5 border-b border-border">
+        <h3 className="font-serif text-[15px] font-bold text-foreground flex items-center gap-1.5">
+          <Star className="w-4 h-4 text-yellow-500" />
+          我的球隊新聞
+        </h3>
+      </div>
+
+      {isLoading ? (
+        <div className="p-4 space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="animate-pulse">
+              <div className="h-3.5 bg-muted rounded w-full mb-1.5" />
+              <div className="h-3 bg-muted rounded w-2/3" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div>
+          {related.map((article) => (
+            <Link
+              key={article.id}
+              href={newsUrl(article.slug || article.id)}
+              className="group block px-4 py-3 border-b border-border last:border-0 hover:bg-muted/50 transition-colors"
+            >
+              <h4 className="text-[13px] font-semibold text-foreground line-clamp-2 leading-snug group-hover:text-blue-600 transition-colors">
+                {article.title}
+              </h4>
+              <span className="text-[11px] text-muted-foreground mt-1 block">
+                {formatRelativeTime(article.published_at)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CategorySidebar({ category }: { category: string }) {
+  return (
+    <div className="space-y-6">
+      <WeeklyTrending category={category} />
+      <RelatedByTeam category={category} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
分類頁新增桌面版側邊欄，包含「本週熱門」和「我的球隊新聞」兩個 widget

## Changes
- 擴充 trending API：支援 `?category=NBA&period=week&limit=5` 篩選
- 新建 `CategorySidebar.tsx`（WeeklyTrending + RelatedByTeam）
- 分類頁佈局改為 `lg:grid lg:grid-cols-[1fr_300px]`，行動版堆疊

## Test
- Unit tests: 399/399 ✓
- Review: 進行中

🤖 Generated with [Claude Code](https://claude.com/claude-code)