### PR TITLE
feat(article): 文章內文自動連結球隊名稱

### DIFF
--- a/src/__tests__/lib/auto-link.test.tsx
+++ b/src/__tests__/lib/auto-link.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { autoLinkChildren } from "@/lib/auto-link";
+
+// Wrapper to render React nodes returned by autoLinkChildren
+function renderLinked(text: string, category: string | null = null) {
+  const result = autoLinkChildren(text, category);
+  render(<p data-testid="content">{result}</p>);
+  return screen.getByTestId("content");
+}
+
+describe("autoLinkChildren", () => {
+  it("links full NBA team names", () => {
+    const el = renderLinked("The Los Angeles Lakers won last night.", "NBA");
+    const link = el.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe("Los Angeles Lakers");
+    expect(link?.getAttribute("href")).toMatch(/\/team\/nba\/\d+/);
+  });
+
+  it("links short team names like Lakers", () => {
+    const el = renderLinked("Lakers beat the Celtics 120-110.", "NBA");
+    const links = el.querySelectorAll("a");
+    expect(links.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not match partial words (heated ≠ Heat)", () => {
+    const el = renderLinked("The heated debate continued all day.");
+    const links = el.querySelectorAll("a");
+    expect(links.length).toBe(0);
+  });
+
+  it("does not double-link already linked text", () => {
+    // When react-markdown encounters [Lakers](url), it renders via
+    // the `a` component, not `p`. So autoLinkChildren only sees the
+    // text node parts. Passing a React element should not be processed.
+    const children = ["Check out ", <a key="x" href="/test">Lakers</a>, " news"];
+    const result = autoLinkChildren(children, "NBA");
+    // The <a> element should pass through unchanged
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("returns plain string when no matches", () => {
+    const result = autoLinkChildren("No team names here.", null);
+    expect(result).toBe("No team names here.");
+  });
+
+  it("handles MLB team names", () => {
+    const el = renderLinked("The New York Yankees signed a new pitcher.", "MLB");
+    const link = el.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe("New York Yankees");
+    expect(link?.getAttribute("href")).toMatch(/\/team\/mlb\/\d+/);
+  });
+
+  it("prefers same-sport matches when category is set", () => {
+    // "Braves" exists in both NBA (Hawks city Atlanta) but as a team name
+    // it's MLB Atlanta Braves. With MLB category, should link to MLB.
+    const el = renderLinked("The Braves dominated today.", "MLB");
+    const link = el.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toMatch(/\/team\/mlb\/\d+/);
+  });
+
+  it("links multiple teams in same text", () => {
+    const el = renderLinked("Lakers vs Celtics was an amazing game.", "NBA");
+    const links = el.querySelectorAll("a");
+    expect(links.length).toBe(2);
+  });
+
+  it("handles multi-word short names like Red Sox", () => {
+    const el = renderLinked("The Red Sox won the series.", "MLB");
+    const link = el.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe("Red Sox");
+  });
+
+  it("handles null children gracefully", () => {
+    const result = autoLinkChildren(null, null);
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/(public)/news/[slug]/page.tsx
+++ b/src/app/(public)/news/[slug]/page.tsx
@@ -253,7 +253,7 @@ export default async function ArticlePage({
       )}
 
       {/* Content - react-markdown */}
-      <ArticleContent content={contentStr} />
+      <ArticleContent content={contentStr} category={article.category} />
 
       {/* Reactions */}
       <div className="mb-4">

--- a/src/components/public/ArticleContent.tsx
+++ b/src/components/public/ArticleContent.tsx
@@ -3,6 +3,7 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
+import { autoLinkChildren } from "@/lib/auto-link";
 
 function getYouTubeId(url: string): string | null {
   const match = url.match(
@@ -15,7 +16,10 @@ function isTwitterUrl(url: string): boolean {
   return /^https?:\/\/(twitter\.com|x\.com)\//.test(url);
 }
 
-const markdownComponents: Components = {
+function buildComponents(category: string | null): Components {
+  const link = (children: React.ReactNode) => autoLinkChildren(children, category);
+
+  return {
   h1: ({ children }) => (
     <h1
       id={String(children).toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "")}
@@ -46,7 +50,7 @@ const markdownComponents: Components = {
     </h4>
   ),
   p: ({ children }) => (
-    <p className="text-foreground/90 leading-relaxed mb-4">{children}</p>
+    <p className="text-foreground/90 leading-relaxed mb-4">{link(children)}</p>
   ),
   a: ({ href, children }) => {
     if (href) {
@@ -121,7 +125,7 @@ const markdownComponents: Components = {
       {children}
     </ol>
   ),
-  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  li: ({ children }) => <li className="leading-relaxed">{link(children)}</li>,
   table: ({ children }) => (
     <div className="overflow-x-auto my-6">
       <table className="w-full text-sm border-collapse border border-border">
@@ -164,14 +168,16 @@ const markdownComponents: Components = {
   ),
   hr: () => <hr className="border-border my-8" />,
   strong: ({ children }) => (
-    <strong className="font-semibold text-foreground">{children}</strong>
+    <strong className="font-semibold text-foreground">{link(children)}</strong>
   ),
-};
+  };
+}
 
-export function ArticleContent({ content }: { content: string }) {
+export function ArticleContent({ content, category }: { content: string; category?: string | null }) {
+  const components = buildComponents(category ?? null);
   return (
     <div className="prose prose-lg max-w-none mb-12">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {content}
       </ReactMarkdown>
     </div>

--- a/src/lib/auto-link.tsx
+++ b/src/lib/auto-link.tsx
@@ -1,0 +1,240 @@
+import React from "react";
+import Link from "next/link";
+import { TEAM_NAME_ZH, TEAM_SLUG_MAP } from "./constants";
+import { teamUrl } from "./routes";
+
+interface TeamLink {
+  name: string;
+  sport: string;
+  teamId: string;
+  regex: RegExp;
+}
+
+/**
+ * Build team link lookup from existing constants.
+ * Maps English team names to { sport, teamId } for auto-linking.
+ */
+function buildTeamLinks(): TeamLink[] {
+  const links: TeamLink[] = [];
+
+  // Iterate TEAM_SLUG_MAP to get sport + teamId
+  for (const [key, teamId] of Object.entries(TEAM_SLUG_MAP)) {
+    const colonIdx = key.indexOf(":");
+    const sport = key.slice(0, colonIdx);
+    const slug = key.slice(colonIdx + 1);
+
+    // Find matching display name in TEAM_NAME_ZH
+    for (const englishName of Object.keys(TEAM_NAME_ZH)) {
+      const nameSlug = englishName
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/\./g, "");
+
+      if (nameSlug === slug || slug === nameSlug.replace(/^(la|st)-/, "$1-")) {
+        links.push({
+          name: englishName,
+          sport,
+          teamId,
+          regex: new RegExp(
+            `\\b${englishName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`
+          ),
+        });
+        break;
+      }
+    }
+  }
+
+  // Add common short names (map to full name's sport+id)
+  const shortNameMap: Record<string, string> = {
+    Lakers: "Los Angeles Lakers",
+    Celtics: "Boston Celtics",
+    Warriors: "Golden State Warriors",
+    Nets: "Brooklyn Nets",
+    Knicks: "New York Knicks",
+    Bucks: "Milwaukee Bucks",
+    Heat: "Miami Heat",
+    Bulls: "Chicago Bulls",
+    Cavs: "Cleveland Cavaliers",
+    Nuggets: "Denver Nuggets",
+    Rockets: "Houston Rockets",
+    Clippers: "LA Clippers",
+    Suns: "Phoenix Suns",
+    Spurs: "San Antonio Spurs",
+    Thunder: "Oklahoma City Thunder",
+    Grizzlies: "Memphis Grizzlies",
+    Mavericks: "Dallas Mavericks",
+    Mavs: "Dallas Mavericks",
+    Timberwolves: "Minnesota Timberwolves",
+    Pelicans: "New Orleans Pelicans",
+    Pacers: "Indiana Pacers",
+    Pistons: "Detroit Pistons",
+    Hawks: "Atlanta Hawks",
+    Hornets: "Charlotte Hornets",
+    Magic: "Orlando Magic",
+    Raptors: "Toronto Raptors",
+    Kings: "Sacramento Kings",
+    Blazers: "Portland Trail Blazers",
+    Wizards: "Washington Wizards",
+    Jazz: "Utah Jazz",
+    Dodgers: "Los Angeles Dodgers",
+    Yankees: "New York Yankees",
+    "Red Sox": "Boston Red Sox",
+    Astros: "Houston Astros",
+    Braves: "Atlanta Braves",
+    Phillies: "Philadelphia Phillies",
+    Padres: "San Diego Padres",
+    Mets: "New York Mets",
+    Cubs: "Chicago Cubs",
+    Cardinals: "St. Louis Cardinals",
+    Brewers: "Milwaukee Brewers",
+    Orioles: "Baltimore Orioles",
+    Twins: "Minnesota Twins",
+    Guardians: "Cleveland Guardians",
+    Tigers: "Detroit Tigers",
+    Royals: "Kansas City Royals",
+    Rays: "Tampa Bay Rays",
+    Rangers: "Texas Rangers",
+    Mariners: "Seattle Mariners",
+    Angels: "Los Angeles Angels",
+    Reds: "Cincinnati Reds",
+    Pirates: "Pittsburgh Pirates",
+    Marlins: "Miami Marlins",
+    Rockies: "Colorado Rockies",
+    Nationals: "Washington Nationals",
+    Giants: "San Francisco Giants",
+    "White Sox": "Chicago White Sox",
+    "Blue Jays": "Toronto Blue Jays",
+    Diamondbacks: "Arizona Diamondbacks",
+  };
+
+  for (const [shortName, fullName] of Object.entries(shortNameMap)) {
+    const found = links.find((l) => l.name === fullName);
+    if (found) {
+      links.push({
+        name: shortName,
+        sport: found.sport,
+        teamId: found.teamId,
+        regex: new RegExp(
+          `\\b${shortName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`
+        ),
+      });
+    }
+  }
+
+  // Sort by name length (longest first) to match "Los Angeles Lakers" before "Lakers"
+  links.sort((a, b) => b.name.length - a.name.length);
+
+  return links;
+}
+
+const TEAM_LINKS = buildTeamLinks();
+
+/** Map category name to sport key for disambiguation */
+function categoryToSport(category: string | null): string | null {
+  if (!category) return null;
+  const map: Record<string, string> = {
+    NBA: "nba",
+    "籃球": "nba",
+    MLB: "mlb",
+    "棒球": "mlb",
+  };
+  return map[category] ?? null;
+}
+
+/**
+ * Process a text string and replace team names with Link components.
+ * Returns an array of strings and React elements.
+ */
+function linkifyText(
+  text: string,
+  preferredSport: string | null
+): (string | React.ReactElement)[] {
+  const result: (string | React.ReactElement)[] = [];
+  let remaining = text;
+  let keyCounter = 0;
+
+  while (remaining.length > 0) {
+    let earliestMatch: { index: number; length: number; link: TeamLink } | null =
+      null;
+
+    for (const link of TEAM_LINKS) {
+      // If we have a preferred sport, skip teams from other sports
+      // unless the name is unambiguous (only one sport has this name)
+      if (preferredSport && link.sport !== preferredSport) {
+        const sameNameInPreferred = TEAM_LINKS.find(
+          (l) => l.name === link.name && l.sport === preferredSport
+        );
+        if (sameNameInPreferred) continue;
+      }
+
+      const match = link.regex.exec(remaining);
+      if (match && (!earliestMatch || match.index < earliestMatch.index)) {
+        earliestMatch = {
+          index: match.index,
+          length: match[0].length,
+          link,
+        };
+      }
+    }
+
+    if (!earliestMatch) {
+      result.push(remaining);
+      break;
+    }
+
+    if (earliestMatch.index > 0) {
+      result.push(remaining.slice(0, earliestMatch.index));
+    }
+
+    const matchedText = remaining.slice(
+      earliestMatch.index,
+      earliestMatch.index + earliestMatch.length
+    );
+    result.push(
+      <Link
+        key={`team-${keyCounter++}`}
+        href={teamUrl(earliestMatch.link.sport, earliestMatch.link.teamId)}
+        className="text-blue-600 hover:text-blue-800 underline underline-offset-2 decoration-blue-300 transition-colors"
+      >
+        {matchedText}
+      </Link>
+    );
+
+    remaining = remaining.slice(earliestMatch.index + earliestMatch.length);
+  }
+
+  return result;
+}
+
+/**
+ * Process react-markdown children to auto-link team names.
+ * Handles mixed children (strings + React elements).
+ * Does NOT process children that are already inside <a> tags.
+ */
+export function autoLinkChildren(
+  children: React.ReactNode,
+  category: string | null
+): React.ReactNode {
+  const preferredSport = categoryToSport(category);
+
+  if (typeof children === "string") {
+    const linked = linkifyText(children, preferredSport);
+    return linked.length === 1 && typeof linked[0] === "string"
+      ? children
+      : linked;
+  }
+
+  if (Array.isArray(children)) {
+    return children.map((child, i) => {
+      if (typeof child === "string") {
+        const linked = linkifyText(child, preferredSport);
+        return linked.length === 1 && typeof linked[0] === "string"
+          ? child
+          : <React.Fragment key={`frag-${i}`}>{linked}</React.Fragment>;
+      }
+      return child;
+    });
+  }
+
+  return children;
+}


### PR DESCRIPTION
## Summary
文章內文 react-markdown 渲染時自動偵測球隊名稱（英文全名+簡稱），加入超連結到球隊頁面

## Changes
- 新建 `src/lib/auto-link.tsx`：autoLinkChildren() 處理 react-markdown children
- 修改 `ArticleContent.tsx`：p/li/strong 元件呼叫 autoLinkChildren
- 文章頁面傳入 category 供消歧義

## Features
- 支援 60+ 球隊（NBA 30 + MLB 30）全名和簡稱
- Word-boundary regex 防部分匹配（heated 不匹配 Heat）
- Category 消歧義（NBA 文章優先連結 NBA 球隊）
- 最長優先匹配（Los Angeles Lakers 先於 Lakers）

## Test
- Unit tests: 409/409（含 10 auto-link tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)