### PR TITLE
feat(pipeline): 新增寫手+總編輯 pipeline 重構產文流程

### DIFF
--- a/.claude/execution-log.md
+++ b/.claude/execution-log.md
@@ -5,3 +5,50 @@
 - [x] 需求分級：**S** — 單一檔案 bug fix，根因已分析
 - [x] 風險掃描：低風險，只影響圖片抓取邏輯
 - [x] Phase 1-2 跳過：S 級別 + 根因分析已完成
+
+### Phase 3: 工程 — 2026-03-21
+
+- [x] Git-Ops 建立 branch fix/140-espn-crawler-images — 23:10
+- [x] BE 完成修復（3 點修復）— 23:15
+  1. `<picture><source srcset>` 解析：img 無 src 時從 picture source 取 srcset
+  2. 放寬容器選擇器：增加 .story-body, .story, main
+  3. og:image 降級：與 generic.ts 對齊
+- [x] Review 完成（bugs + compliance）— 23:20
+  - bugs: 2 Medium — 段落重複(已修)、authorExclude 不完整(已修)
+  - compliance: CATEGORY_MAP 差異不適用，已統一 authorExclude regex
+- [x] test-crawl.ts 驗證：ESPN 19 篇文章含圖片 ✓
+
+### Phase 4: QA — 2026-03-21
+
+- [x] TypeScript 編譯通過
+- [x] 409 unit tests 全部通過
+- [x] QA 3/3 通過（vitest + smoke + E2E 54 passed）
+
+### Phase 5: 交付 — 2026-03-21
+
+- [x] Git push + PR #149 merged — 23:25
+- [x] Deploy（main → release）+ 部署後 QA 通過
+- [x] Issue #140 已關閉
+- [ ] Evolve: 待執行（autopilot 最後一個 PR 後統一執行）
+
+---
+
+## Issue #139: research: 研究總編輯 Skill 設計
+
+### Phase 0: 評估 — 2026-03-22
+
+- [x] 需求分級：研究類 Issue，無程式碼變更
+- [x] 分析：研究目標已被 Issue #141 的詳細規格完全覆蓋
+- [x] 決定：關閉 #139，實作統一在 #141 進行
+- [x] Issue #139 已關閉（reason: not planned, superseded by #141）
+
+---
+
+## Issue #141: feature: 新增寫手+總編輯 Skill，重構產文流程
+
+### Phase 0: 評估 — 2026-03-22
+
+- [x] 需求分級：**XL** — 跨模組架構變更（Skill 定義 + DB + Scripts + API + FE）
+- [x] 風險掃描：DB schema ⚠️ 高風險 + Pipeline 依賴 ⚠️ 高風險
+- [x] Pipeline 現況分析完成：理解 plan-generator → local-rewriter → auto-pipeline → publish 完整流程
+- [x] 拆分計畫：4 PR 交付（DB+Skill → Writer → Editor → Frontend）

--- a/scripts/editor-in-chief.ts
+++ b/scripts/editor-in-chief.ts
@@ -1,0 +1,256 @@
+/**
+ * 總編輯審稿腳本
+ *
+ * 讀取 generated_articles 中 status='draft' AND review_status='pending' 的文章，
+ * 呼叫 Claude AI 進行 9 項審查，更新 review_status/review_result/reviewed_at。
+ *
+ * 使用方式：
+ *   npx tsx scripts/editor-in-chief.ts
+ *   npx tsx scripts/editor-in-chief.ts --article-ids id1,id2
+ */
+
+import { config } from "dotenv";
+import { resolve } from "path";
+config({ path: resolve(__dirname, "..", ".env.local") });
+
+import { createClient } from "@supabase/supabase-js";
+import { callClaude } from "./shared-claude";
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  "https://fmakjkvkmbltqgyndijb.supabase.co";
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+
+if (!SUPABASE_KEY) {
+  console.error("Missing SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+interface ReviewResult {
+  decision: "approved" | "rejected";
+  scores: {
+    title_quality: number;
+    content_quality: number;
+    fact_check: number;
+    brand_tone: number;
+    seo: number;
+    overall: number;
+  };
+  checks?: {
+    topic_unique: "pass" | "fail";
+    image_unique: "pass" | "fail";
+    has_image: "pass" | "fail";
+  };
+  reject_reasons: string[];
+  suggestions: string[];
+}
+
+function extractFirstJson(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}') depth--;
+    if (depth === 0) return text.substring(start, i + 1);
+  }
+  return null;
+}
+
+function parseReviewResult(output: string): ReviewResult {
+  if (!output.trim()) {
+    throw new Error("Claude returned empty response");
+  }
+  const cleaned = output.replace(/```json\n?/g, "").replace(/```\n?/g, "");
+  const jsonStr = extractFirstJson(cleaned);
+  if (!jsonStr || !jsonStr.includes('"decision"')) {
+    throw new Error(`Response is not valid JSON: ${output.substring(0, 300)}`);
+  }
+  return JSON.parse(jsonStr);
+}
+
+function buildReviewPrompt(
+  article: { title: string; content: string; images: unknown[] },
+  rawArticlesContent: string,
+  recentTitles: string[],
+  recentImages: string[]
+): string {
+  const imageList = Array.isArray(article.images)
+    ? article.images
+        .map((img) => (typeof img === "string" ? img : (img as { url?: string })?.url || ""))
+        .filter(Boolean)
+        .join("\n")
+    : "（無圖片）";
+
+  return `你是 Howger Sport 的總編輯。審查以下文章是否達到發布標準。
+
+審查項目：
+1. 標題品質（1-10）— 吸引人、準確、非標題黨
+2. 內容品質（1-10）— 流暢度、深度、可讀性、結構
+3. 事實查核（1-10）— 對照原始素材，無捏造或扭曲
+4. 品牌調性（1-10）— 符合 Howger Sport 定位（專業體育媒體、繁體中文、球員名保留英文）
+5. SEO 優化（1-10）— 關鍵字、結構、標題長度
+6. 整體品質（1-10）— 綜合評分
+7. 題材未重複（pass/fail）— 對比近期文章標題，主題不可重複
+8. 圖片未重複（pass/fail）— 對比近期文章圖片，封面圖不可重複
+9. 有圖片（pass/fail）— 至少一張圖片
+
+判斷標準：
+- 項目 1-6 平均 >= 6 分 且 無任何項 < 4 分
+- 項目 7-9 全部 pass
+- 符合以上 → approved，否則 → rejected
+
+待審文章：
+標題：${article.title}
+內容：${article.content}
+圖片：
+${imageList}
+
+原始素材：
+${rawArticlesContent}
+
+近 7 天已發布文章標題：
+${recentTitles.length > 0 ? recentTitles.map((t, i) => `${i + 1}. ${t}`).join("\n") : "（無近期文章）"}
+
+近 7 天已發布文章圖片：
+${recentImages.length > 0 ? recentImages.join("\n") : "（無近期圖片）"}
+
+只回覆 JSON，不要 markdown code block：
+{"decision": "approved|rejected", "scores": {"title_quality": N, "content_quality": N, "fact_check": N, "brand_tone": N, "seo": N, "overall": N}, "checks": {"topic_unique": "pass|fail", "image_unique": "pass|fail", "has_image": "pass|fail"}, "reject_reasons": ["原因"], "suggestions": ["建議"]}`;
+}
+
+async function main() {
+  console.log(`\n[${new Date().toLocaleString("zh-TW")}] === 總編輯審稿開始 ===`);
+
+  // 解析 CLI 參數
+  const articleIdsArg = process.argv.indexOf("--article-ids");
+  let articleIds: string[] | null = null;
+  if (articleIdsArg !== -1 && process.argv[articleIdsArg + 1]) {
+    articleIds = process.argv[articleIdsArg + 1].split(",").filter(Boolean);
+  }
+
+  // 查詢待審文章
+  let query = supabase
+    .from("generated_articles")
+    .select("id, title, content, images, raw_article_ids")
+    .eq("status", "draft")
+    .eq("review_status", "pending");
+
+  if (articleIds && articleIds.length > 0) {
+    query = query.in("id", articleIds);
+  }
+
+  const { data: pendingArticles, error: queryError } = await query
+    .order("created_at", { ascending: true })
+    .limit(20);
+
+  if (queryError) {
+    console.error(`查詢失敗: ${queryError.message}`);
+    process.exit(1);
+  }
+
+  if (!pendingArticles || pendingArticles.length === 0) {
+    console.log("沒有待審文章");
+    return;
+  }
+
+  console.log(`找到 ${pendingArticles.length} 篇待審文章`);
+
+  // 取得近 7 天已發布文章的標題和圖片（供去重比對）
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+  const { data: recentArticles } = await supabase
+    .from("generated_articles")
+    .select("title, images")
+    .eq("status", "published")
+    .gte("published_at", sevenDaysAgo.toISOString())
+    .order("published_at", { ascending: false })
+    .limit(100);
+
+  const recentTitles = (recentArticles || []).map((a) => a.title);
+  const recentImages: string[] = [];
+  for (const a of recentArticles || []) {
+    if (Array.isArray(a.images) && a.images.length > 0) {
+      const firstImg = a.images[0];
+      const url = typeof firstImg === "string" ? firstImg : (firstImg as { url?: string })?.url;
+      if (url) recentImages.push(url);
+    }
+  }
+
+  let approved = 0;
+  let rejected = 0;
+  let failed = 0;
+
+  for (const article of pendingArticles) {
+    console.log(`\n  審查: "${article.title}"`);
+
+    try {
+      // 取得原始素材內容
+      let rawArticlesContent = "（無原始素材）";
+      if (article.raw_article_ids && article.raw_article_ids.length > 0) {
+        const { data: rawArticles } = await supabase
+          .from("raw_articles")
+          .select("title, content, source")
+          .in("id", article.raw_article_ids);
+
+        if (rawArticles && rawArticles.length > 0) {
+          rawArticlesContent = rawArticles
+            .map((r, i) => `【素材 ${i + 1}】${r.source}: ${r.title}\n${r.content.substring(0, 800)}`)
+            .join("\n\n---\n\n");
+        }
+      }
+
+      const prompt = buildReviewPrompt(
+        article,
+        rawArticlesContent,
+        recentTitles,
+        recentImages
+      );
+
+      const output = callClaude(prompt);
+      const result = parseReviewResult(output);
+
+      // 更新審查結果
+      const { error: updateError } = await supabase
+        .from("generated_articles")
+        .update({
+          review_status: result.decision,
+          review_result: result,
+          reviewed_at: new Date().toISOString(),
+        })
+        .eq("id", article.id);
+
+      if (updateError) {
+        console.error(`    更新失敗: ${updateError.message}`);
+        failed++;
+        continue;
+      }
+
+      if (result.decision === "approved") {
+        console.log(`    通過 (平均分: ${(
+          (result.scores.title_quality +
+            result.scores.content_quality +
+            result.scores.fact_check +
+            result.scores.brand_tone +
+            result.scores.seo +
+            result.scores.overall) /
+          6
+        ).toFixed(1)})`);
+        approved++;
+      } else {
+        console.log(`    退回: ${result.reject_reasons.join(", ")}`);
+        rejected++;
+      }
+    } catch (err) {
+      console.error(`    審查失敗: ${err}`);
+      failed++;
+    }
+  }
+
+  console.log(`\n=== 審稿結果: 通過 ${approved}, 退回 ${rejected}, 失敗 ${failed} ===`);
+}
+
+main().catch(console.error);

--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -158,20 +158,56 @@ function collectImages(articles: RawArticle[]): string[] {
   return images;
 }
 
-function parseResult(output: string): { title: string; content: string; category?: string; tags?: string[] } {
+interface CitedSource {
+  type: string;
+  url: string;
+  title: string;
+  snippet: string;
+}
+
+function extractFirstJson(text: string): string | null {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}') depth--;
+    if (depth === 0) return text.substring(start, i + 1);
+  }
+  return null;
+}
+
+function parseResult(output: string): { title: string; content: string; category?: string; tags?: string[]; writing_strategy?: string; cited_sources?: CitedSource[] } {
   if (!output.trim()) {
     throw new Error("Claude returned empty response");
   }
   const cleaned = output.replace(/```json\n?/g, "").replace(/```\n?/g, "");
-  const jsonMatch = cleaned.match(/\{[\s\S]*"title"[\s\S]*"content"[\s\S]*\}/);
-  if (!jsonMatch) {
+  const jsonStr = extractFirstJson(cleaned);
+  if (!jsonStr || !jsonStr.includes('"title"') || !jsonStr.includes('"content"')) {
     throw new Error(`Response is not valid JSON: ${output.substring(0, 300)}`);
   }
-  return JSON.parse(jsonMatch[0]);
+  return JSON.parse(jsonStr);
 }
 
 // extractTagsFromContent 從 shared-tags.ts 匯入
 import { extractTagsFromContent } from "./shared-tags";
+
+/** 從原始素材自動產生 cited_sources（AI 沒回傳時的 fallback） */
+function buildCitedSourcesFromRaw(articles: RawArticle[]): CitedSource[] {
+  return articles.map((a) => ({
+    type: "raw_article",
+    url: (a as unknown as Record<string, unknown>).url as string || "",
+    title: a.title,
+    snippet: a.content.substring(0, 200),
+  }));
+}
+
+/** 判斷 writing_strategy 的 fallback（根據素材數量） */
+function inferWritingStrategy(articles: RawArticle[]): string {
+  if (articles.length >= 3) return "multi_source";
+  if (articles.length === 1) return "enriched";
+  return "multi_source";
+}
 
 function buildColumnistPrompt(
   articles: RawArticle[],
@@ -208,13 +244,18 @@ ${persona.style_prompt}
 8. 球員、教練、球隊等名稱保留英文原文，不要翻譯成中文（例如用 LeBron James 而非乔布朗·詹姆斯）
 9. 只回覆 JSON，不要 markdown code block
 10. tags 欄位必須包含文章提及的聯盟、球隊、球員名（英文原文），用於分類和推薦
+11. writing_strategy 欄位：根據素材狀態判斷策略
+   - "multi_source"：綜合多個不同來源的素材
+   - "enriched"：以單一素材為主但加入自己的分析和觀點
+   - "popular_digest"：熱門話題的綜合整理
+12. cited_sources 欄位：列出所有引用的素材來源，格式為陣列，每項包含 type、url、title、snippet
 
 分類：${category}
 素材數量：${articles.length} 篇
 
 ${sourceSummaries}
 
-請以純 JSON 格式回覆：{"title": "標題", "content": "文章內容", "category": "${category}", "tags": ["聯盟名", "球隊名", "球員名"]}`;
+請以純 JSON 格式回覆：{"title": "標題", "content": "文章內容", "category": "${category}", "tags": ["聯盟名", "球隊名", "球員名"], "writing_strategy": "multi_source|enriched|popular_digest", "cited_sources": [{"type": "raw_article", "url": "來源URL", "title": "來源標題", "snippet": "引用片段"}]}`;
 }
 
 function buildOfficialRecapPrompt(
@@ -247,12 +288,17 @@ ${persona.style_prompt}
 9. 球員、教練、球隊等名稱保留英文原文，不要翻譯成中文（例如用 LeBron James 而非乔布朗·詹姆斯）
 10. 只回覆 JSON，不要 markdown code block
 11. tags 欄位必須包含文章提及的聯盟、球隊、球員名（英文原文），用於分類和推薦
+12. writing_strategy 欄位：根據素材狀態判斷策略
+   - "multi_source"：綜合多個不同來源的素材
+   - "enriched"：以單一素材為主但加入自己的分析和觀點
+   - "popular_digest"：熱門話題的綜合整理
+13. cited_sources 欄位：列出所有引用的素材來源，格式為陣列，每項包含 type、url、title、snippet
 
 素材數量：${articles.length} 篇
 
 ${sourceSummaries}
 
-請以純 JSON 格式回覆：{"title": "標題", "content": "文章內容", "category": "${league}", "tags": ["聯盟名", "球隊名", "球員名"]}`;
+請以純 JSON 格式回覆：{"title": "標題", "content": "文章內容", "category": "${league}", "tags": ["聯盟名", "球隊名", "球員名"], "writing_strategy": "multi_source|enriched|popular_digest", "cited_sources": [{"type": "raw_article", "url": "來源URL", "title": "來源標題", "snippet": "引用片段"}]}`;
 }
 
 interface PlanItem {
@@ -373,6 +419,12 @@ async function produceFromPlans(planIds: string[]) {
       const aiTags = Array.isArray(result.tags) ? result.tags : [];
       const finalTags = aiTags.length > 0 ? aiTags : extractTagsFromContent(result.title, result.content);
 
+      // writing_strategy 和 cited_sources fallback
+      const writingStrategy = result.writing_strategy || inferWritingStrategy(articles);
+      const citedSources = Array.isArray(result.cited_sources) && result.cited_sources.length > 0
+        ? result.cited_sources
+        : buildCitedSourcesFromRaw(articles);
+
       const { error: insertError } = await supabase
         .from("generated_articles")
         .insert({
@@ -384,6 +436,9 @@ async function produceFromPlans(planIds: string[]) {
           images: collectedImages,
           tags: finalTags,
           status: "draft",
+          review_status: "pending",
+          writing_strategy: writingStrategy,
+          cited_sources: citedSources,
         });
 
       if (insertError) {
@@ -564,6 +619,11 @@ async function main() {
           const aiTagsOfficial = Array.isArray(result.tags) ? result.tags : [];
           const finalTagsOfficial = aiTagsOfficial.length > 0 ? aiTagsOfficial : extractTagsFromContent(result.title, result.content);
 
+          const writingStrategyOfficial = result.writing_strategy || inferWritingStrategy(group);
+          const citedSourcesOfficial = Array.isArray(result.cited_sources) && result.cited_sources.length > 0
+            ? result.cited_sources
+            : buildCitedSourcesFromRaw(group);
+
           const { error: insertError } = await supabase
             .from("generated_articles")
             .insert({
@@ -575,6 +635,9 @@ async function main() {
               images: officialImages,
               tags: finalTagsOfficial,
               status: "draft",
+              review_status: "pending",
+              writing_strategy: writingStrategyOfficial,
+              cited_sources: citedSourcesOfficial,
             });
 
           if (insertError) {
@@ -637,6 +700,11 @@ async function main() {
         const aiTagsCol = Array.isArray(result.tags) ? result.tags : [];
         const finalTagsCol = aiTagsCol.length > 0 ? aiTagsCol : extractTagsFromContent(result.title, result.content);
 
+        const writingStrategyCol = result.writing_strategy || inferWritingStrategy(group);
+        const citedSourcesCol = Array.isArray(result.cited_sources) && result.cited_sources.length > 0
+          ? result.cited_sources
+          : buildCitedSourcesFromRaw(group);
+
         const { error: insertError } = await supabase
           .from("generated_articles")
           .insert({
@@ -648,6 +716,9 @@ async function main() {
             images: columnistImages,
             tags: finalTagsCol,
             status: "draft",
+            review_status: "pending",
+            writing_strategy: writingStrategyCol,
+            cited_sources: citedSourcesCol,
           });
 
         if (insertError) {

--- a/scripts/rewrite-listener.ts
+++ b/scripts/rewrite-listener.ts
@@ -28,14 +28,19 @@ if (!SUPABASE_KEY) {
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 const REWRITER_SCRIPT = resolve(__dirname, "local-rewriter.ts");
 const PLAN_GENERATOR_SCRIPT = resolve(__dirname, "plan-generator.ts");
+const EDITOR_IN_CHIEF_SCRIPT = resolve(__dirname, "editor-in-chief.ts");
 
 let isRunning = false;
 
-// 解析任務的模式：plan（產生規劃）或 produce（根據規劃產出文章）
-function parseTaskMode(metadata: Record<string, unknown> | null): { mode: string; planIds?: string[] } {
+// 解析任務的模式：plan（產生規劃）、produce（根據規劃產出文章）、review（總編輯審稿）
+function parseTaskMode(metadata: Record<string, unknown> | null): { mode: string; planIds?: string[]; articleIds?: string[] } {
   if (!metadata) return { mode: "plan" };
   if (metadata.mode === "produce" && Array.isArray(metadata.plan_ids)) {
     return { mode: "produce", planIds: metadata.plan_ids as string[] };
+  }
+  if (metadata.mode === "review") {
+    const articleIds = Array.isArray(metadata.article_ids) ? metadata.article_ids as string[] : undefined;
+    return { mode: "review", articleIds };
   }
   return { mode: "plan" };
 }
@@ -55,7 +60,7 @@ async function executeTask(taskId: string) {
     .eq("id", taskId)
     .single();
 
-  const { mode, planIds } = parseTaskMode(task?.metadata);
+  const { mode, planIds, articleIds } = parseTaskMode(task?.metadata);
   console.log(`[${ts()}] 開始執行任務: ${taskId} (模式: ${mode})`);
 
   // 更新狀態為 running
@@ -75,11 +80,20 @@ async function executeTask(taskId: string) {
     .limit(1);
   const beforeTimestamp = latestBefore?.[0]?.created_at || new Date().toISOString();
 
+  // 提升至 try 外，讓 finally 後的邏輯可以存取
+  let generated = 0;
+
   try {
     let script: string;
     let args: string[];
 
-    if (mode === "produce" && planIds) {
+    if (mode === "review") {
+      // 審稿模式：執行 editor-in-chief
+      script = EDITOR_IN_CHIEF_SCRIPT;
+      args = articleIds
+        ? ["npx", "tsx", script, "--article-ids", articleIds.join(",")]
+        : ["npx", "tsx", script];
+    } else if (mode === "produce" && planIds) {
       // 產出模式：執行 local-rewriter 並傳入 plan ids
       script = REWRITER_SCRIPT;
       args = ["npx", "tsx", script, "--plan-ids", planIds.join(",")];
@@ -107,7 +121,7 @@ async function executeTask(taskId: string) {
       .select("*", { count: "exact", head: true })
       .gt("created_at", beforeTimestamp);
 
-    const generated = articlesGenerated || 0;
+    generated = articlesGenerated || 0;
 
     if (result.status === 0) {
       await supabase
@@ -122,6 +136,7 @@ async function executeTask(taskId: string) {
       console.log(
         `[${ts()}] 任務完成 (${mode})，產出 ${generated} 篇文章`
       );
+
     } else {
       const errorMsg = result.stderr?.substring(0, 500) || "Process exited with non-zero code";
       await supabase
@@ -150,6 +165,22 @@ async function executeTask(taskId: string) {
     console.error(`[${ts()}] 任務異常: ${errorMsg}`);
   } finally {
     isRunning = false;
+  }
+
+  // produce 完成後自動觸發審稿
+  // 必須在 finally（isRunning = false）之後才 insert，
+  // 否則 Realtime callback 收到新任務時 isRunning 仍為 true 而被跳過
+  if (mode === "produce" && generated > 0) {
+    console.log(`[${ts()}] 產出完成，自動觸發總編輯審稿...`);
+    const { error: reviewTaskError } = await supabase
+      .from("rewrite_tasks")
+      .insert({
+        status: "pending",
+        metadata: { mode: "review" },
+      });
+    if (reviewTaskError) {
+      console.error(`[${ts()}] 建立審稿任務失敗: ${reviewTaskError.message}`);
+    }
   }
 }
 

--- a/src/__tests__/lib/publish-article.test.ts
+++ b/src/__tests__/lib/publish-article.test.ts
@@ -170,6 +170,7 @@ describe("publishArticle - publish with channels", () => {
       slug: "test-article",
       images: ["https://img.com/test.jpg"],
       publish_channel_ids: [42, 99],
+      review_status: "approved",
     };
 
     const channels = [
@@ -244,6 +245,7 @@ describe("publishArticle - publish with channels", () => {
       slug: "all-channels",
       images: ["https://img.com/art2.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const allChannels = [
@@ -311,6 +313,7 @@ describe("publishArticle - publish with channels", () => {
       slug: "published-article",
       images: ["https://img.com/art3.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const updateEqMock = vi.fn().mockResolvedValue({ error: null });
@@ -368,6 +371,7 @@ describe("publishArticle - publish with channels", () => {
       slug: "error-article",
       images: ["https://img.com/art4.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const channels = [
@@ -439,6 +443,7 @@ describe("extractImageUrls (via publishArticle images field)", () => {
       slug: "image-test",
       images,
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     let fromCallIndex = 0;
@@ -587,6 +592,7 @@ describe("publishArticle - cover image dedup integration", () => {
       slug: "dedup-article",
       images: ["https://img.com/dup.jpg", "https://img.com/unique.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const publishedArticles = [
@@ -660,6 +666,7 @@ describe("publishArticle - cover image dedup integration", () => {
       slug: "dedup-fail",
       images: ["https://img.com/dup.jpg", "https://img.com/alt.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const publishedArticles = [
@@ -738,6 +745,7 @@ describe("publishArticle - image validation", () => {
       slug: "no-img",
       images: [],
       publish_channel_ids: [],
+      review_status: "approved",
     });
     mockCreateServiceClient.mockReturnValue(supabase as never);
 
@@ -756,6 +764,7 @@ describe("publishArticle - image validation", () => {
       slug: "null-img",
       images: null,
       publish_channel_ids: [],
+      review_status: "approved",
     });
     mockCreateServiceClient.mockReturnValue(supabase as never);
 
@@ -910,6 +919,7 @@ describe("deduplicateCoverImage", () => {
       slug: "seq-article",
       images: ["https://img.com/cover.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const supabase = {
@@ -964,6 +974,7 @@ describe("deduplicateCoverImage", () => {
       slug: "first-pub",
       images: ["https://img.com/first-cover.jpg"],
       publish_channel_ids: [],
+      review_status: "approved",
     };
 
     const supabase = {

--- a/src/app/admin/articles/[id]/page.tsx
+++ b/src/app/admin/articles/[id]/page.tsx
@@ -8,6 +8,8 @@ import { PublishStatusCard } from "@/components/admin/article-detail/PublishStat
 import { PublishOptionsCard } from "@/components/admin/article-detail/PublishOptionsCard";
 import { ArticleContentCard } from "@/components/admin/article-detail/ArticleContentCard";
 import { RawArticlesCard } from "@/components/admin/article-detail/RawArticlesCard";
+import { CitedSourcesCard } from "@/components/admin/article-detail/CitedSourcesCard";
+import { ReviewStatusCard } from "@/components/admin/article-detail/ReviewStatusCard";
 import type {
   ArticleDetail,
   RawArticle,
@@ -178,6 +180,13 @@ export default function ArticleDetailPage({
         />
       )}
 
+      <ReviewStatusCard
+        reviewStatus={article.review_status}
+        reviewResult={article.review_result}
+        reviewedAt={article.reviewed_at}
+        writingStrategy={article.writing_strategy}
+      />
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <ArticleContentCard
           article={article}
@@ -189,7 +198,10 @@ export default function ArticleDetailPage({
           onRemoveImage={handleRemoveImage}
         />
 
-        <RawArticlesCard rawArticles={rawArticles} />
+        <div className="space-y-6">
+          <RawArticlesCard rawArticles={rawArticles} />
+          <CitedSourcesCard citedSources={article.cited_sources || []} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/admin/personas/page.tsx
+++ b/src/app/admin/personas/page.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { PersonaForm } from "@/components/admin/personas/PersonaForm";
 import { PersonaCard } from "@/components/admin/personas/PersonaCard";
+import { WritingRulesSection } from "@/components/admin/personas/WritingRulesSection";
 import { emptyForm, type Persona, type PersonaFormData } from "@/components/admin/personas/types";
 
 export default function PersonasPage() {
@@ -168,6 +169,9 @@ export default function PersonasPage() {
           />
         ))}
       </div>
+
+      {/* 系統規則區塊 */}
+      <WritingRulesSection />
 
       {/* 刪除確認 Dialog */}
       <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>

--- a/src/app/api/cron/auto-pipeline/route.ts
+++ b/src/app/api/cron/auto-pipeline/route.ts
@@ -184,11 +184,14 @@ async function autoPublishCompleted(
 
   if (autoTasks.length === 0) return null;
 
-  // 找出所有 draft 狀態的 generated_articles（產文完成但尚未發布的）
+  // 找出最近 24 小時內 draft + approved 狀態的 generated_articles（產文完成且審查通過但尚未發布的）
+  // 加時間過濾避免重複發布舊文章
   const { data: draftArticles } = await supabase
     .from("generated_articles")
     .select("id")
     .eq("status", "draft")
+    .eq("review_status", "approved")
+    .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString())
     .order("created_at", { ascending: false })
     .limit(20);
 

--- a/src/components/admin/article-detail/CitedSourcesCard.tsx
+++ b/src/components/admin/article-detail/CitedSourcesCard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ExternalLink } from "lucide-react";
+import type { CitedSource } from "./article-detail-types";
+
+const sourceTypeLabels: Record<string, string> = {
+  raw_article: "原始文章",
+  web_search: "網路搜尋",
+  social: "社群媒體",
+};
+
+interface CitedSourcesCardProps {
+  citedSources: CitedSource[];
+}
+
+export function CitedSourcesCard({ citedSources }: CitedSourcesCardProps) {
+  if (!citedSources || citedSources.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">引用來源</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {citedSources.map((source, i) => (
+            <div
+              key={i}
+              className="flex items-start gap-3 p-3 rounded-lg border bg-muted/30"
+            >
+              <Badge variant="outline" className="shrink-0 mt-0.5">
+                {sourceTypeLabels[source.type] || source.type}
+              </Badge>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium truncate">{source.title}</p>
+                {source.url && (
+                  <a
+                    href={source.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mt-1"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    <span className="truncate max-w-[300px]">{source.url}</span>
+                  </a>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/article-detail/ReviewStatusCard.tsx
+++ b/src/components/admin/article-detail/ReviewStatusCard.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { ReviewResult } from "./article-detail-types";
+
+const reviewStatusConfig: Record<
+  string,
+  { label: string; className: string }
+> = {
+  pending: {
+    label: "待審",
+    className: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  },
+  approved: {
+    label: "通過",
+    className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  },
+  rejected: {
+    label: "未通過",
+    className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  },
+};
+
+const writingStrategyLabels: Record<string, string> = {
+  multi_source: "多源綜合",
+  enriched: "內容增值",
+  popular_digest: "熱門綜合",
+};
+
+interface ReviewStatusCardProps {
+  reviewStatus: string | null;
+  reviewResult: ReviewResult | null;
+  reviewedAt: string | null;
+  writingStrategy: string | null;
+}
+
+export function ReviewStatusCard({
+  reviewStatus,
+  reviewResult,
+  reviewedAt,
+  writingStrategy,
+}: ReviewStatusCardProps) {
+  if (!reviewStatus && !writingStrategy) return null;
+
+  const statusConfig = reviewStatus
+    ? reviewStatusConfig[reviewStatus] || { label: reviewStatus, className: "bg-gray-100 text-gray-800" }
+    : null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">審稿與寫作資訊</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* 寫作策略 + 審稿狀態 */}
+        <div className="flex flex-wrap items-center gap-3">
+          {writingStrategy && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">寫作策略：</span>
+              <Badge variant="secondary">
+                {writingStrategyLabels[writingStrategy] || writingStrategy}
+              </Badge>
+            </div>
+          )}
+          {statusConfig && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">審稿狀態：</span>
+              <Badge className={statusConfig.className}>
+                {statusConfig.label}
+              </Badge>
+            </div>
+          )}
+          {reviewedAt && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">審查時間：</span>
+              <span className="text-sm">
+                {new Date(reviewedAt).toISOString().replace("T", " ").substring(0, 19)}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* 審稿結果詳情 */}
+        {reviewResult && (
+          <div className="space-y-3 pt-2 border-t">
+            {/* 評分項目 */}
+            {reviewResult.scores && Object.keys(reviewResult.scores).length > 0 && (
+              <div>
+                <p className="text-sm font-medium mb-2">評分項目</p>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {Object.entries(reviewResult.scores).map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="flex items-center justify-between p-2 rounded border bg-muted/20 text-sm"
+                    >
+                      <span className="text-muted-foreground truncate mr-2">{key}</span>
+                      <span
+                        className={`font-mono font-medium ${
+                          typeof value === "number" && value < 4
+                            ? "text-red-500"
+                            : typeof value === "number" && value >= 7
+                              ? "text-green-500"
+                              : ""
+                        }`}
+                      >
+                        {value}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                {reviewResult.average_score !== undefined && (
+                  <p className="text-sm text-muted-foreground mt-2">
+                    平均分數：<span className="font-medium text-foreground">{reviewResult.average_score}</span>
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Pass/Fail 項目 */}
+            {reviewResult.checks && Object.keys(reviewResult.checks).length > 0 && (
+              <div>
+                <p className="text-sm font-medium mb-2">通過/不通過項目</p>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(reviewResult.checks).map(([key, value]) => (
+                    <Badge
+                      key={key}
+                      className={
+                        value === "pass"
+                          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                          : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400"
+                      }
+                    >
+                      {key}: {value === "pass" ? "Pass" : "Fail"}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* 原因 */}
+            {reviewResult.reason && (
+              <div>
+                <p className="text-sm font-medium mb-1">審查意見</p>
+                <p className="text-sm text-muted-foreground whitespace-pre-wrap bg-muted/20 p-3 rounded">
+                  {reviewResult.reason}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/article-detail/article-detail-types.ts
+++ b/src/components/admin/article-detail/article-detail-types.ts
@@ -1,5 +1,19 @@
 // --- Article detail type definitions ---
 
+export interface CitedSource {
+  type: string;
+  title: string;
+  url: string;
+}
+
+export interface ReviewResult {
+  scores?: Record<string, number>;
+  checks?: Record<string, string>;
+  reason?: string;
+  average_score?: number;
+  [key: string]: unknown;
+}
+
 export interface ArticleDetail {
   id: string;
   title: string;
@@ -16,6 +30,11 @@ export interface ArticleDetail {
     name: string;
     description: string | null;
   } | null;
+  cited_sources: CitedSource[] | null;
+  review_status: "pending" | "approved" | "rejected" | null;
+  review_result: ReviewResult | null;
+  reviewed_at: string | null;
+  writing_strategy: "multi_source" | "enriched" | "popular_digest" | null;
 }
 
 export interface RawArticle {

--- a/src/components/admin/personas/WritingRulesSection.tsx
+++ b/src/components/admin/personas/WritingRulesSection.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+
+export function WritingRulesSection() {
+  return (
+    <div className="space-y-4 pt-6 border-t">
+      <div>
+        <h2 className="text-lg font-semibold">系統規則</h2>
+        <p className="text-xs text-muted-foreground mt-1">
+          系統規則，如需修改請聯繫開發團隊
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Card 1: 寫手撰寫規則 */}
+        <Card className="bg-muted/30 border-muted">
+          <CardHeader>
+            <CardTitle className="text-base">寫手撰寫規則</CardTitle>
+            <CardDescription>AI 寫手產文時遵循的規範</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <div>
+              <p className="font-medium text-foreground">策略 1：多源綜合報導</p>
+              <p>來自不同新聞網站的相似新聞超過一篇以上時，綜合重寫</p>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">策略 2：內容增值搜尋</p>
+              <p>確定要寫的文章才上網搜尋，豐富內容</p>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">策略 3：熱門素材綜合報導</p>
+              <p>超過 12 小時無重複素材時，挑選熱門新聞綜合撰寫</p>
+            </div>
+            <div className="pt-2 border-t border-muted">
+              <p className="font-medium text-foreground">來源標註</p>
+              <p>所有引用必須標註來源（raw_article / web_search / social）</p>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">基本要求</p>
+              <p>600-1200 字、完整結構、繁體中文、球員名保留英文</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Card 2: 總編輯審查規則 */}
+        <Card className="bg-muted/30 border-muted">
+          <CardHeader>
+            <CardTitle className="text-base">總編輯審查規則</CardTitle>
+            <CardDescription>AI 總編輯審稿時的標準</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <div>
+              <p className="font-medium text-foreground mb-1">9 項審查標準</p>
+              <ul className="list-disc list-inside space-y-0.5">
+                <li>標題品質</li>
+                <li>內容品質</li>
+                <li>事實查核</li>
+                <li>品牌調性</li>
+                <li>SEO 優化</li>
+                <li>整體品質</li>
+                <li>題材未重複（pass/fail）</li>
+                <li>圖片未重複（pass/fail）</li>
+                <li>有圖片（pass/fail）</li>
+              </ul>
+            </div>
+            <div className="pt-2 border-t border-muted">
+              <p className="font-medium text-foreground">通過條件</p>
+              <p>評分項平均 &ge; 6 分且無任何項 &lt; 4 分，pass/fail 項全部 pass</p>
+            </div>
+            <div>
+              <p className="font-medium text-foreground">二級制</p>
+              <p>通過 &rarr; approved &rarr; 發布；不通過 &rarr; rejected &rarr; 不發布</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Card 3: 產文邏輯流程 */}
+        <Card className="bg-muted/30 border-muted">
+          <CardHeader>
+            <CardTitle className="text-base">產文邏輯流程</CardTitle>
+            <CardDescription>從爬蟲到發布的完整流程</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-medium shrink-0">1</span>
+                <span>爬蟲收集原始新聞</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-medium shrink-0">2</span>
+                <span>規劃（AI）— 決定寫哪些文章</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-medium shrink-0">3</span>
+                <span>寫手（AI）— 撰寫文章</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-medium shrink-0">4</span>
+                <span>總編輯（AI）— 審查品質</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-medium shrink-0">5</span>
+                <span>發布至網站與頻道</span>
+              </div>
+            </div>
+            <div className="pt-2 border-t border-muted">
+              <p className="font-medium text-foreground">Prompt 優先級</p>
+              <p>後台 persona 設定 &gt; Writer Skill 預設規則</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/publish-article.ts
+++ b/src/lib/publish-article.ts
@@ -24,7 +24,7 @@ export async function publishArticle(articleId: string): Promise<PublishResult> 
   // 讀取文章
   const { data: article, error: articleError } = await supabase
     .from("generated_articles")
-    .select("id, title, content, slug, images, publish_channel_ids")
+    .select("id, title, content, slug, images, publish_channel_ids, review_status")
     .eq("id", articleId)
     .single();
 
@@ -36,6 +36,18 @@ export async function publishArticle(articleId: string): Promise<PublishResult> 
       channels_published: 0,
       channels_failed: 0,
       errors: [articleError?.message || "Article not found"],
+    };
+  }
+
+  // 發布前檢查：文章必須通過總編輯審查
+  if (article.review_status !== "approved") {
+    return {
+      success: false,
+      article_id: articleId,
+      title: article.title,
+      channels_published: 0,
+      channels_failed: 0,
+      errors: [`文章未通過審查（目前狀態: ${article.review_status || "pending"}），無法發布`],
     };
   }
 

--- a/supabase/migrations/021_writer_editor_fields.sql
+++ b/supabase/migrations/021_writer_editor_fields.sql
@@ -1,0 +1,28 @@
+-- Migration 021: 新增寫手+總編輯相關欄位 (Issue #141)
+-- 在 generated_articles 表新增：review_status, review_result, reviewed_at, writing_strategy, cited_sources
+
+ALTER TABLE generated_articles
+  ADD COLUMN IF NOT EXISTS review_status text NOT NULL DEFAULT 'pending'
+    CHECK (review_status IN ('pending', 'approved', 'rejected'));
+
+ALTER TABLE generated_articles
+  ADD COLUMN IF NOT EXISTS review_result jsonb DEFAULT NULL;
+
+ALTER TABLE generated_articles
+  ADD COLUMN IF NOT EXISTS reviewed_at timestamptz DEFAULT NULL;
+
+ALTER TABLE generated_articles
+  ADD COLUMN IF NOT EXISTS writing_strategy text DEFAULT NULL
+    CHECK (writing_strategy IS NULL OR writing_strategy IN ('multi_source', 'enriched', 'popular_digest'));
+
+ALTER TABLE generated_articles
+  ADD COLUMN IF NOT EXISTS cited_sources jsonb DEFAULT '[]'::jsonb;
+
+-- Index: 按 review_status 篩選（總編輯待審、已通過、已拒絕）
+CREATE INDEX IF NOT EXISTS idx_generated_articles_review_status
+  ON generated_articles(review_status);
+
+-- Index: 按 writing_strategy 統計分析
+CREATE INDEX IF NOT EXISTS idx_generated_articles_writing_strategy
+  ON generated_articles(writing_strategy)
+  WHERE writing_strategy IS NOT NULL;


### PR DESCRIPTION
## Summary
- 新增 Writer pipeline：3 種撰寫策略（多源綜合/內容增值/熱門綜合）+ 引用來源標註
- 新增 Editor-in-Chief 自動審稿：9 項審查（6 評分 + 3 pass/fail）
- Pipeline 流程：爬蟲 → 規劃 → 寫手 → 總編輯 → 發布
- 後台：文章詳情頁新增審稿結果 + 引用來源；寫手管理頁新增唯讀規則顯示

## Changes
- `scripts/local-rewriter.ts` — 新增 writing_strategy、cited_sources、review_status
- `scripts/editor-in-chief.ts` — 新增 9 項自動審稿腳本
- `scripts/rewrite-listener.ts` — 新增 review mode + 自動觸發審稿
- `src/app/api/cron/auto-pipeline/route.ts` — 只發布 approved 文章
- `src/lib/publish-article.ts` — 發布前 approved 檢查
- `supabase/migrations/021_writer_editor_fields.sql` — 5 新欄位 + 2 索引
- 前端：CitedSourcesCard、ReviewStatusCard、WritingRulesSection
- DB：新增 6 位寫手 persona

## Test
- TypeScript 編譯通過 ✓
- 409 unit tests 全部通過 ✓
- QA 3/3（vitest + smoke + E2E 54 passed）✓
- Review bugs+compliance 完成 ✓（5 bug 已修正）