### PR TITLE
refactor(perf): 前端效能最佳化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,23 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  compress: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "a.espncdn.com",
+      },
+      {
+        protocol: "https",
+        hostname: "*.espncdn.com",
+      },
+      {
+        protocol: "https",
+        hostname: "fmakjkvkmbltqgyndijb.supabase.co",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/QueryProvider.tsx
+++ b/src/components/QueryProvider.tsx
@@ -9,9 +9,9 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 30 * 1000, // 30 seconds
+            staleTime: 10 * 60 * 1000, // 10 minutes
             retry: 1,
-            refetchOnWindowFocus: true,
+            refetchOnWindowFocus: false,
           },
         },
       })

--- a/src/components/public/QuickOdds.tsx
+++ b/src/components/public/QuickOdds.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import type { Game } from "@/lib/scoreboard";
 import { gameUrl } from "@/lib/routes";
+import { SCOREBOARD_POLLING_MS } from "@/lib/constants";
 
 export function QuickOdds() {
   const { data: games = [], isLoading } = useQuery({
@@ -16,6 +17,8 @@ export function QuickOdds() {
       const upcoming = allGames.filter((g) => g.status !== "final");
       return upcoming.length > 0 ? upcoming.slice(0, 3) : allGames.slice(0, 3);
     },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    refetchInterval: SCOREBOARD_POLLING_MS,
   });
 
   return (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,7 +2,7 @@
 
 export const POLLING_INTERVAL_MS = 3000;
 export const POLLING_TIMEOUT_MS = 600000;
-export const SCOREBOARD_POLLING_MS = 10_000;
+export const SCOREBOARD_POLLING_MS = 60_000;
 
 export const SPORT_KEY_LABELS: Record<string, string> = {
   basketball: "籃球",


### PR DESCRIPTION
## Summary
- React Query staleTime 30s → 10min，關閉 refetchOnWindowFocus
- 輪詢間隔 10s → 60s
- next.config.ts 啟用 compress + images remotePatterns
- QuickOdds 元件 staleTime 優化

## Changes
- `src/components/QueryProvider.tsx` — 全域 Query 設定
- `src/lib/constants.ts` — SCOREBOARD_POLLING_MS
- `next.config.ts` — 效能設定
- `src/components/public/QuickOdds.tsx` — staleTime + refetchInterval

## Test
- TypeScript 編譯通過 ✓
- 409 unit tests 全部通過 ✓