### PR TITLE
feat(dashboard): 後台儀錶板新增爬蟲狀態區塊

### DIFF
--- a/smoke-test.config.json
+++ b/smoke-test.config.json
@@ -19,7 +19,8 @@
     "/api/articles/generated?page=1&limit=1",
     "/api/articles/raw?page=1&limit=1",
     "/api/admin/visitors?period=7d",
-    "/api/settings/automation"
+    "/api/settings/automation",
+    "/api/dashboard/crawler-status"
   ],
 
   "public_apis": [

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -26,6 +26,34 @@ interface Stats {
   channels: Channel[];
 }
 
+interface CrawlerStatus {
+  source: string;
+  count: number;
+  lastCrawled: string;
+}
+
+function getRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const diff = now - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return "剛剛";
+  if (minutes < 60) return `${minutes} 分鐘前`;
+  if (hours < 24) return `${hours} 小時前`;
+  return `${days} 天前`;
+}
+
+function getStatusIndicator(dateStr: string): { color: string; label: string } {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const hours = diff / 3600000;
+
+  if (hours < 24) return { color: "bg-green-500", label: "正常" };
+  if (hours < 48) return { color: "bg-yellow-500", label: "注意" };
+  return { color: "bg-red-500", label: "異常" };
+}
+
 export default function AdminDashboard() {
   const { data: stats, isLoading, error } = useQuery<Stats>({
     queryKey: ["dashboard-stats"],
@@ -34,6 +62,17 @@ export default function AdminDashboard() {
       if (!res.ok) throw new Error("fetch failed");
       return res.json();
     },
+  });
+
+  const { data: crawlerStatus } = useQuery<CrawlerStatus[]>({
+    queryKey: ["crawler-status"],
+    queryFn: async () => {
+      const res = await fetch("/api/dashboard/crawler-status");
+      if (!res.ok) throw new Error("fetch failed");
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 
   if (isLoading) {
@@ -80,6 +119,54 @@ export default function AdminDashboard() {
           </Card>
         ))}
       </div>
+
+      {/* 爬蟲狀態 */}
+      {crawlerStatus && crawlerStatus.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <span>🕷️</span>
+              爬蟲狀態
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-gray-500">
+                    <th className="pb-2 font-medium">來源</th>
+                    <th className="pb-2 font-medium text-right">文章數</th>
+                    <th className="pb-2 font-medium text-right">最後爬取</th>
+                    <th className="pb-2 font-medium text-center w-10">狀態</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {crawlerStatus.map((crawler) => {
+                    const status = getStatusIndicator(crawler.lastCrawled);
+                    return (
+                      <tr key={crawler.source} className="border-b last:border-0">
+                        <td className="py-2.5 font-medium">{crawler.source}</td>
+                        <td className="py-2.5 text-right tabular-nums">
+                          {crawler.count.toLocaleString()}
+                        </td>
+                        <td className="py-2.5 text-right text-gray-500">
+                          {getRelativeTime(crawler.lastCrawled)}
+                        </td>
+                        <td className="py-2.5 text-center">
+                          <span
+                            className={`inline-block w-2.5 h-2.5 rounded-full ${status.color}`}
+                            title={status.label}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* 自動化設定 */}
       <AutomationPanel />

--- a/src/app/api/dashboard/crawler-status/route.ts
+++ b/src/app/api/dashboard/crawler-status/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+import { auth } from "@/auth";
+
+interface CrawlerStatus {
+  source: string;
+  count: number;
+  lastCrawled: string;
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("raw_articles")
+    .select("source, crawled_at");
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch crawler status" },
+      { status: 500 }
+    );
+  }
+
+  // Group by source in memory
+  const grouped = new Map<string, { count: number; lastCrawled: string }>();
+  for (const row of data || []) {
+    const existing = grouped.get(row.source);
+    if (!existing) {
+      grouped.set(row.source, {
+        count: 1,
+        lastCrawled: row.crawled_at,
+      });
+    } else {
+      existing.count++;
+      if (row.crawled_at > existing.lastCrawled) {
+        existing.lastCrawled = row.crawled_at;
+      }
+    }
+  }
+
+  const result: CrawlerStatus[] = Array.from(grouped.entries())
+    .map(([source, { count, lastCrawled }]) => ({
+      source,
+      count,
+      lastCrawled,
+    }))
+    .sort(
+      (a, b) =>
+        new Date(b.lastCrawled).getTime() - new Date(a.lastCrawled).getTime()
+    );
+
+  return NextResponse.json(result);
+}


### PR DESCRIPTION
## Summary
- 後台儀錶板新增爬蟲狀態 Card，顯示各來源最後爬取時間和文章數
- 狀態指示燈：🟢 <24h / 🟡 24-48h / 🔴 >48h

## Changes
- `src/app/api/dashboard/crawler-status/route.ts` — 新增 API
- `src/app/admin/page.tsx` — 新增爬蟲狀態 Card
- `smoke-test.config.json` — 新增 endpoint

## Test
- TypeScript 編譯通過 ✓
- 409 unit tests 全部通過 ✓