### PR TITLE
fix(crawlers): 提高 cron maxDuration + per-fetch timeout

### DIFF
--- a/src/app/api/cron/crawl/route.ts
+++ b/src/app/api/cron/crawl/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { runAllCrawlers } from "@/lib/crawlers";
 
-export const maxDuration = 60; // Vercel function timeout
+export const maxDuration = 300; // Vercel function timeout（5 分鐘，確保所有爬蟲來源都能完成）
 
 export async function GET(request: NextRequest) {
   // 驗證 cron secret

--- a/src/lib/crawlers/generic.ts
+++ b/src/lib/crawlers/generic.ts
@@ -4,6 +4,7 @@ import type { CrawledArticle } from "./types";
 
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+const FETCH_TIMEOUT_MS = 15000; // 單一 fetch 15 秒 timeout
 
 // 從文字中推測分類
 function detectCategory(url: string, title: string, content: string): string | null {
@@ -147,6 +148,7 @@ async function crawlArticle(
   try {
     const res = await fetch(url, {
       headers: { "User-Agent": USER_AGENT },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) return null;
@@ -243,6 +245,7 @@ export async function crawlGeneric(
   try {
     const res = await fetch(baseUrl, {
       headers: { "User-Agent": USER_AGENT },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- cron crawl maxDuration 從 60s 提高到 300s，避免 CBS Sports 等慢來源被 timeout 殺掉
- 每個 fetch 加上 15 秒 per-request timeout，防止單一慢站卡住整體

## Changes
- `src/app/api/cron/crawl/route.ts`: maxDuration 60 → 300
- `src/lib/crawlers/generic.ts`: 新增 FETCH_TIMEOUT_MS + AbortSignal.timeout

## Test
- 409 unit tests passed
- 安全掃描通過