### PR TITLE
refactor: title_prompt 整合到寫手 style_prompt

### DIFF
--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -212,7 +212,6 @@ function inferWritingStrategy(articles: RawArticle[]): string {
 function buildColumnistPrompt(
   articles: RawArticle[],
   persona: WriterPersona,
-  titleStyleHint?: string
 ): string {
   const sourceSummaries = articles
     .map(
@@ -240,8 +239,7 @@ ${persona.style_prompt}
 4. 不可出現「根據報導」「據悉」「外媒指出」等轉述用語
 5. 以專業部落客的口吻撰寫，有自己的觀點和分析
 6. 文章長度 600-1200 字
-7. 標題要有創意、吸引眼球${titleStyleHint ? `\n${titleStyleHint}` : ""}
-8. 球員、教練、球隊等名稱保留英文原文，不要翻譯成中文（例如用 LeBron James 而非乔布朗·詹姆斯）
+7. 標題要有創意、吸引眼球8. 球員、教練、球隊等名稱保留英文原文，不要翻譯成中文（例如用 LeBron James 而非乔布朗·詹姆斯）
 9. 只回覆 JSON，不要 markdown code block
 10. tags 欄位必須包含文章提及的聯盟、球隊、球員名（英文原文），用於分類和推薦
 11. writing_strategy 欄位：根據素材狀態判斷策略
@@ -262,7 +260,6 @@ function buildOfficialRecapPrompt(
   league: string,
   articles: RawArticle[],
   persona: WriterPersona,
-  titleStyleHint?: string
 ): string {
   const sourceSummaries = articles
     .map(
@@ -284,8 +281,7 @@ ${persona.style_prompt}
 5. 每個重點賽事要有比分、關鍵球員表現、簡要分析
 6. 結尾可以展望接下來的賽程
 7. 文章長度 800-1500 字
-8. 標題必須包含「${league}」關鍵字，風格要專業且吸引眼球${titleStyleHint ? `\n${titleStyleHint}` : ""}
-9. 球員、教練、球隊等名稱保留英文原文，不要翻譯成中文（例如用 LeBron James 而非乔布朗·詹姆斯）
+8. 標題必須包含「${league}」關鍵字，風格要專業且吸引眼球9. 球員、教練、球隊等名稱保留英文原文，不要翻譯成中文（例如用 LeBron James 而非乔布朗·詹姆斯）
 10. 只回覆 JSON，不要 markdown code block
 11. tags 欄位必須包含文章提及的聯盟、球隊、球員名（英文原文），用於分類和推薦
 12. writing_strategy 欄位：根據素材狀態判斷策略
@@ -355,18 +351,6 @@ async function produceFromPlans(planIds: string[]) {
   const rawMap = Object.fromEntries(rawArticles.map((a) => [a.id, a as RawArticle]));
 
   // 讀取各球種的標題風格提詞
-  const { data: sportSettings } = await supabase
-    .from("sport_settings")
-    .select("sport_key, title_prompt")
-    .eq("enabled", true);
-
-  const titlePromptMap: Record<string, string> = {};
-  if (sportSettings) {
-    for (const s of sportSettings) {
-      if (s.title_prompt) titlePromptMap[s.sport_key] = s.title_prompt;
-    }
-  }
-
   let success = 0;
   let failed = 0;
   const producedPlanIds: string[] = [];
@@ -392,17 +376,11 @@ async function produceFromPlans(planIds: string[]) {
     console.log(`\n  [${plan.plan_type === "official" ? "官方戰報" : "專欄"}] ${persona.name} - "${plan.title}" (${articles.length} 篇素材)`);
 
     try {
-      // 組裝標題風格提詞
-      const titlePrompts = Object.values(titlePromptMap).filter(Boolean);
-      const titleStyleHint = titlePrompts.length > 0
-        ? `標題風格指引：\n${titlePrompts.join("\n")}`
-        : undefined;
-
       let prompt: string;
       if (plan.plan_type === "official" && plan.league) {
-        prompt = buildOfficialRecapPrompt(plan.league, articles, persona, titleStyleHint);
+        prompt = buildOfficialRecapPrompt(plan.league, articles, persona);
       } else {
-        prompt = buildColumnistPrompt(articles, persona, titleStyleHint);
+        prompt = buildColumnistPrompt(articles, persona);
       }
 
       const output = callClaude(prompt);
@@ -542,24 +520,6 @@ async function main() {
 
   console.log(`找到 ${rawArticles.length} 篇未處理文章`);
 
-  // 讀取各球種的標題風格提詞
-  const { data: sportSettings } = await supabase
-    .from("sport_settings")
-    .select("sport_key, title_prompt")
-    .eq("enabled", true);
-
-  const titlePromptMap: Record<string, string> = {};
-  if (sportSettings) {
-    for (const s of sportSettings) {
-      if (s.title_prompt) titlePromptMap[s.sport_key] = s.title_prompt;
-    }
-  }
-
-  const titlePrompts = Object.values(titlePromptMap).filter(Boolean);
-  const titleStyleHint = titlePrompts.length > 0
-    ? `標題風格指引：\n${titlePrompts.join("\n")}`
-    : undefined;
-
   let success = 0;
   let failed = 0;
 
@@ -605,7 +565,7 @@ async function main() {
         group.forEach((a) => console.log(`    - ${a.title}`));
 
         try {
-          const prompt = buildOfficialRecapPrompt(league, group, official, titleStyleHint);
+          const prompt = buildOfficialRecapPrompt(league, group, official);
           const output = callClaude(prompt);
           const result = parseResult(output);
 
@@ -686,7 +646,7 @@ async function main() {
       group.forEach((a) => console.log(`    - ${a.title}`));
 
       try {
-        const prompt = buildColumnistPrompt(group, columnist, titleStyleHint);
+        const prompt = buildColumnistPrompt(group, columnist);
         const output = callClaude(prompt);
         const result = parseResult(output);
 

--- a/scripts/plan-generator.ts
+++ b/scripts/plan-generator.ts
@@ -181,20 +181,7 @@ export async function generatePlans() {
   const publishedTitles = (recentArticles || []).map((a) => a.title);
   console.log(`近 14 天已有文章: ${publishedTitles.length} 篇（含 draft）`);
 
-  // 讀取各球種的標題風格提詞
-  const { data: sportSettings } = await supabase
-    .from("sport_settings")
-    .select("sport_key, title_prompt")
-    .eq("enabled", true);
-
-  const titlePromptMap: Record<string, string> = {};
-  if (sportSettings) {
-    for (const s of sportSettings) {
-      if (s.title_prompt) titlePromptMap[s.sport_key] = s.title_prompt;
-    }
-  }
-
-  const allPlans: { writer_persona_id: string; title: string; raw_article_ids: string[]; league: string | null; plan_type: string; }[] = [];
+const allPlans: { writer_persona_id: string; title: string; raw_article_ids: string[]; league: string | null; plan_type: string; }[] = [];
 
   for (const persona of personas as WriterPersona[]) {
     // 驗證 specialties 欄位是否有效（Supabase JSONB 可能返回序列化字符串）
@@ -234,16 +221,12 @@ export async function generatePlans() {
       ? `\n以下是近 7 天已發布的文章標題，請勿規劃與這些主題重複的內容：\n${publishedTitles.map((t) => `- ${t}`).join("\n")}\n`
       : "";
 
-    // 組裝標題風格提詞（合併所有啟用球種的提詞）
-    const titlePrompts = Object.values(titlePromptMap).filter(Boolean);
-    const titleStyleSection = titlePrompts.length > 0
-      ? `\n標題風格指引：\n${titlePrompts.join("\n")}\n`
-      : "";
+    // 標題風格已整合到各寫手的 style_prompt 中（Issue #160）
 
     const prompt = `你是體育新聞網站的內容規劃師。以下是從多個來源爬取的 ${freshArticles.length} 篇體育新聞素材。
 
 你的任務：分析這些素材，找出不重複的獨立主題，為「${persona.name}」（${writerTypeDesc}）規劃要產出的文章列表。
-${publishedSection}${titleStyleSection}
+${publishedSection}
 重要規則：
 1. 多篇來自不同來源但報導同一事件的素材，必須合併為一個規劃項目（例如：ESPN 和 ETtoday 都在報導同一場比賽）
 2. 同一事件的不同角度（例如：得分紀錄、賽後反應、女友見證）可以合併成一篇綜合報導，或拆成最多 2 篇（主報導 + 花絮）

--- a/src/app/admin/sports/page.tsx
+++ b/src/app/admin/sports/page.tsx
@@ -193,20 +193,6 @@ export default function SportsSettingsPage() {
     },
   });
 
-  const saveTitlePromptMutation = useMutation({
-    mutationFn: async ({ sportKey, title_prompt }: { sportKey: SportKey; title_prompt: string }) => {
-      const res = await fetch("/api/settings/sports", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sport_key: sportKey, title_prompt }),
-      });
-      const data = await res.json();
-      if (!data.success) throw new Error("save failed");
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sport-settings"] });
-    },
-  });
 
   async function toggleSport(sportKey: SportKey, enabled: boolean) {
     toggleSportMutation.mutate({ sportKey, enabled });
@@ -266,10 +252,6 @@ export default function SportsSettingsPage() {
   function saveEdit(id: number, oldName: string) {
     if (!editName.trim() || !editUrl.trim()) return;
     saveEditMutation.mutate({ id, oldName });
-  }
-
-  function saveTitlePrompt(sportKey: SportKey, title_prompt: string) {
-    saveTitlePromptMutation.mutate({ sportKey, title_prompt });
   }
 
   function handleStartEdit(source: CrawlSource) {
@@ -334,12 +316,10 @@ export default function SportsSettingsPage() {
                 isEnabled={isEnabled}
                 isUpdating={isUpdating}
                 selectedSources={selectedSources}
-                titlePrompt={settings[key]?.title_prompt || ""}
                 crawlSources={crawlSources}
                 updating={updating}
                 onToggleSport={toggleSport}
                 onToggleSource={toggleSource}
-                onSaveTitlePrompt={saveTitlePrompt}
               />
             );
           }

--- a/src/app/api/settings/sports/route.ts
+++ b/src/app/api/settings/sports/route.ts
@@ -14,7 +14,7 @@ export async function GET() {
     const supabase = createServiceClient();
     const { data, error } = await supabase
       .from("sport_settings")
-      .select("sport_key, enabled, sources, title_prompt, updated_at");
+      .select("sport_key, enabled, sources, updated_at");
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
@@ -22,11 +22,11 @@ export async function GET() {
 
     const settings: Record<
       string,
-      { enabled: boolean; sources: string[]; title_prompt: string; updated_at?: string }
+      { enabled: boolean; sources: string[]; updated_at?: string }
     > = {};
 
     for (const [key, config] of Object.entries(SPORTS)) {
-      settings[key] = { enabled: config.enabled, sources: [], title_prompt: "" };
+      settings[key] = { enabled: config.enabled, sources: [] };
     }
 
     if (data) {
@@ -35,7 +35,6 @@ export async function GET() {
           settings[row.sport_key] = {
             enabled: row.enabled,
             sources: row.sources || [],
-            title_prompt: row.title_prompt || "",
             updated_at: row.updated_at,
           };
         }
@@ -60,11 +59,10 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const { sport_key, enabled, sources, title_prompt } = body as {
+    const { sport_key, enabled, sources } = body as {
       sport_key: SportKey;
       enabled?: boolean;
       sources?: string[];
-      title_prompt?: string;
     };
 
     if (!sport_key || !(sport_key in SPORTS)) {
@@ -85,10 +83,6 @@ export async function POST(request: Request) {
 
     if (Array.isArray(sources)) {
       updateData.sources = sources;
-    }
-
-    if (typeof title_prompt === "string") {
-      updateData.title_prompt = title_prompt;
     }
 
     const supabase = createServiceClient();

--- a/src/components/admin/sports/SportCard.tsx
+++ b/src/components/admin/sports/SportCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import {
   Card,
   CardContent,
@@ -10,7 +9,6 @@ import {
 } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 import type { SportKey } from "@/lib/sport-config";
 import type { CrawlSource } from "./types";
 
@@ -21,12 +19,10 @@ interface SportCardProps {
   isEnabled: boolean;
   isUpdating: boolean;
   selectedSources: string[];
-  titlePrompt: string;
   crawlSources: CrawlSource[];
   updating: string | null;
   onToggleSport: (sportKey: SportKey, enabled: boolean) => void;
   onToggleSource: (sportKey: SportKey, sourceName: string, checked: boolean) => void;
-  onSaveTitlePrompt: (sportKey: SportKey, prompt: string) => void;
 }
 
 export function SportCard({
@@ -36,27 +32,11 @@ export function SportCard({
   isEnabled,
   isUpdating,
   selectedSources,
-  titlePrompt,
   crawlSources,
   updating,
   onToggleSport,
   onToggleSource,
-  onSaveTitlePrompt,
 }: SportCardProps) {
-  const [localPrompt, setLocalPrompt] = useState(titlePrompt);
-  const [saving, setSaving] = useState(false);
-  const isDirty = localPrompt !== titlePrompt;
-
-  useEffect(() => {
-    setLocalPrompt(titlePrompt);
-  }, [titlePrompt]);
-
-  async function handleSavePrompt() {
-    setSaving(true);
-    await onSaveTitlePrompt(sportKey, localPrompt);
-    setSaving(false);
-  }
-
   return (
     <Card className={!isEnabled ? "opacity-60" : ""}>
       <CardHeader>
@@ -94,73 +74,53 @@ export function SportCard({
         </span>
 
         {isEnabled && (
-          <>
-            <div className="pt-2 border-t">
-              <p className="text-xs text-gray-500 mb-2">
-                選擇爬蟲來源
-                {selectedSources.length > 0 && (
-                  <span className="ml-1 text-gray-400">
-                    （已選 {selectedSources.length} 個）
-                  </span>
-                )}
-              </p>
-              <div className="flex flex-col gap-2">
-                {crawlSources.map((source) => {
-                  const isChecked = selectedSources.includes(source.name);
-                  const isSourceUpdating =
-                    updating === `${sportKey}-${source.name}`;
-                  return (
-                    <label
-                      key={source.id}
-                      className="flex items-center gap-2 cursor-pointer"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={isChecked}
-                        onChange={(e) =>
-                          onToggleSource(sportKey, source.name, e.target.checked)
-                        }
-                        disabled={isSourceUpdating}
-                        className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                      />
-                      <span className="text-sm">{source.name}</span>
-                      <span className="text-xs text-gray-400 truncate">
-                        {source.base_url}
+          <div className="pt-2 border-t">
+            <p className="text-xs text-gray-500 mb-2">
+              選擇爬蟲來源
+              {selectedSources.length > 0 && (
+                <span className="ml-1 text-gray-400">
+                  （已選 {selectedSources.length} 個）
+                </span>
+              )}
+            </p>
+            <div className="flex flex-col gap-2">
+              {crawlSources.map((source) => {
+                const isChecked = selectedSources.includes(source.name);
+                const isSourceUpdating =
+                  updating === `${sportKey}-${source.name}`;
+                return (
+                  <label
+                    key={source.id}
+                    className="flex items-center gap-2 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isChecked}
+                      onChange={(e) =>
+                        onToggleSource(sportKey, source.name, e.target.checked)
+                      }
+                      disabled={isSourceUpdating}
+                      className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span className="text-sm">{source.name}</span>
+                    <span className="text-xs text-gray-400 truncate">
+                      {source.base_url}
+                    </span>
+                    {isSourceUpdating && (
+                      <span className="text-xs text-gray-400">
+                        更新中...
                       </span>
-                      {isSourceUpdating && (
-                        <span className="text-xs text-gray-400">
-                          更新中...
-                        </span>
-                      )}
-                    </label>
-                  );
-                })}
-                {crawlSources.length === 0 && (
-                  <p className="text-xs text-gray-400">
-                    尚無爬蟲來源，請先在上方新增
-                  </p>
-                )}
-              </div>
-            </div>
-
-            <div className="pt-2 border-t">
-              <p className="text-xs text-gray-500 mb-2">標題風格提詞</p>
-              <textarea
-                value={localPrompt}
-                onChange={(e) => setLocalPrompt(e.target.value)}
-                placeholder="輸入標題風格指引，AI 規劃文章時會參考此提詞產生標題..."
-                rows={3}
-                className="w-full text-sm border rounded-md p-2 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-              {isDirty && (
-                <div className="flex justify-end mt-1">
-                  <Button size="sm" onClick={handleSavePrompt} disabled={saving}>
-                    {saving ? "儲存中..." : "儲存"}
-                  </Button>
-                </div>
+                    )}
+                  </label>
+                );
+              })}
+              {crawlSources.length === 0 && (
+                <p className="text-xs text-gray-400">
+                  尚無爬蟲來源，請先在上方新增
+                </p>
               )}
             </div>
-          </>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/admin/sports/types.ts
+++ b/src/components/admin/sports/types.ts
@@ -10,7 +10,6 @@ export interface SportSettings {
   [key: string]: {
     enabled: boolean;
     sources: string[];
-    title_prompt: string;
     updated_at?: string;
   };
 }


### PR DESCRIPTION
## Summary
- 標題風格提詞從 sport_settings 搬到 writer_personas.style_prompt
- 移除 plan-generator/local-rewriter 的 titlePromptMap 邏輯
- 移除後台球種管理頁的標題風格編輯 UI

## Changes
- `scripts/plan-generator.ts`: 移除 titlePromptMap
- `scripts/local-rewriter.ts`: 移除 titlePromptMap（2 處）+ 函式參數
- `src/components/admin/sports/SportCard.tsx`: 移除 title_prompt UI
- `src/components/admin/sports/types.ts`: 移除 title_prompt 型別
- `src/app/admin/sports/page.tsx`: 移除 saveTitlePromptMutation
- `src/app/api/settings/sports/route.ts`: 移除 title_prompt 處理

## DB Changes (已執行)
- basketball title_prompt 內容已追加到 4 位籃球寫手的 style_prompt
- sport_settings.title_prompt 已清空

## Test
- 409 tests passed
- 安全掃描通過