### PR TITLE
feat(admin): 後台導航重構 — 側邊欄分組 + 儀表板精簡

### DIFF
--- a/src/app/admin/AdminLayoutClient.tsx
+++ b/src/app/admin/AdminLayoutClient.tsx
@@ -1,22 +1,44 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { cn } from "@/lib/utils";
 
-const navItems = [
-  { href: "/admin", label: "儀表板" },
-  { href: "/admin/articles", label: "文章管理" },
-  { href: "/admin/raw", label: "原始新聞" },
-  { href: "/admin/personas", label: "寫手管理" },
-  { href: "/admin/sports", label: "球種與來源" },
-  { href: "/admin/channels", label: "發布頻道" },
-  { href: "/admin/scoreboard", label: "即時比分" },
-  { href: "/admin/analytics", label: "數據分析" },
+const navGroups = [
+  {
+    title: "總覽",
+    items: [
+      { href: "/admin", label: "儀表板", icon: "📊" },
+      { href: "/admin/pipeline", label: "管線狀態", icon: "🔄" },
+      { href: "/admin/analytics", label: "數據分析", icon: "📈" },
+    ],
+  },
+  {
+    title: "內容",
+    items: [
+      { href: "/admin/articles", label: "文章管理", icon: "📝" },
+      { href: "/admin/review", label: "審稿佇列", icon: "✅" },
+      { href: "/admin/raw", label: "素材庫", icon: "📰" },
+    ],
+  },
+  {
+    title: "設定",
+    items: [
+      { href: "/admin/personas", label: "寫手管理", icon: "✍️" },
+      { href: "/admin/sports", label: "球種分類", icon: "🏀" },
+      { href: "/admin/sources", label: "爬蟲來源", icon: "🕷️" },
+      { href: "/admin/channels", label: "發布頻道", icon: "📢" },
+      { href: "/admin/scoreboard", label: "比分設定", icon: "🏆" },
+    ],
+  },
 ];
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === "/admin") return pathname === "/admin";
+  return pathname.startsWith(href);
+}
 
 export default function AdminLayout({
   children,
@@ -24,93 +46,97 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white border-b sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            <div className="flex items-center gap-8">
-              <Link href="/admin" className="flex items-center">
-                <Image
-                  src="/logo.png"
-                  alt="超級運動資訊網 後台"
-                  width={224}
-                  height={40}
-                  className="h-7 w-auto"
-                  priority
-                />
-              </Link>
-              <nav className="hidden md:flex gap-1">
-                {navItems.map((item) => (
+    <div className="h-screen flex bg-gray-50">
+      {/* Mobile overlay */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          "fixed md:static inset-y-0 left-0 z-50 w-60 bg-white border-r flex flex-col transition-transform duration-200",
+          sidebarOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+        )}
+      >
+        {/* Brand */}
+        <div className="h-14 flex items-center px-4 border-b shrink-0">
+          <Link href="/admin" className="font-bold text-gray-900" onClick={() => setSidebarOpen(false)}>
+            Howger Sport 後台
+          </Link>
+        </div>
+
+        {/* Nav groups */}
+        <nav className="flex-1 overflow-y-auto py-3 px-3 space-y-5">
+          {navGroups.map((group) => (
+            <div key={group.title}>
+              <p className="px-2 mb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                {group.title}
+              </p>
+              <div className="space-y-0.5">
+                {group.items.map((item) => (
                   <Link
                     key={item.href}
                     href={item.href}
+                    onClick={() => setSidebarOpen(false)}
                     className={cn(
-                      "px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                      pathname === item.href
-                        ? "bg-gray-100 text-gray-900"
-                        : "text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+                      "flex items-center gap-2.5 px-2.5 py-2 rounded-md text-sm transition-colors",
+                      isActive(pathname, item.href)
+                        ? "bg-blue-50 text-blue-700 font-medium"
+                        : "text-gray-600 hover:bg-gray-100 hover:text-gray-900"
                     )}
                   >
+                    <span className="text-base">{item.icon}</span>
                     {item.label}
                   </Link>
                 ))}
-              </nav>
+              </div>
             </div>
-            <div className="flex items-center gap-3">
-              <button
-                onClick={() => signOut({ callbackUrl: "/login" })}
-                className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
-              >
-                登出
-              </button>
-              {/* Mobile hamburger */}
-              <button
-                className="md:hidden p-2 rounded-md text-gray-600 hover:bg-gray-100 transition-colors"
-                onClick={() => setMenuOpen(!menuOpen)}
-                aria-label="切換選單"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  {menuOpen ? (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                  )}
-                </svg>
-              </button>
-            </div>
-          </div>
+          ))}
+        </nav>
+
+        {/* Logout */}
+        <div className="border-t p-3 shrink-0">
+          <button
+            onClick={() => signOut({ callbackUrl: "/login" })}
+            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-md text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700 transition-colors"
+          >
+            <span className="text-base">🚪</span>
+            登出
+          </button>
         </div>
+      </aside>
 
-        {/* Mobile nav dropdown */}
-        {menuOpen && (
-          <nav className="md:hidden border-t bg-white px-4 pb-3 pt-2 space-y-1">
-            {navItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setMenuOpen(false)}
-                className={cn(
-                  "block px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                  pathname === item.href
-                    ? "bg-gray-100 text-gray-900"
-                    : "text-gray-600 hover:text-gray-900 hover:bg-gray-50"
-                )}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-        )}
-      </header>
+      {/* Main area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Top bar (mobile only) */}
+        <header className="h-14 flex items-center justify-between px-4 border-b bg-white md:hidden shrink-0">
+          <button
+            onClick={() => setSidebarOpen(true)}
+            className="p-2 -ml-2 rounded-md text-gray-600 hover:bg-gray-100"
+            aria-label="開啟選單"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <span className="font-bold text-sm text-gray-900">Howger Sport</span>
+          <div className="w-9" />
+        </header>
 
-      {/* Main */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {children}
-      </main>
+        {/* Content */}
+        <main className="flex-1 overflow-y-auto p-4 sm:p-6">
+          <div className="max-w-6xl mx-auto">
+            {children}
+          </div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,16 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { CHANNEL_TYPE_LABELS } from "@/lib/constants";
-import { AutomationPanel } from "@/components/admin/AutomationPanel";
-
-interface Channel {
-  id: number;
-  name: string;
-  type: string;
-  is_active: boolean;
-}
 
 interface Stats {
   raw_articles_total: number;
@@ -23,7 +13,7 @@ interface Stats {
   scheduled: number;
   total_views: number;
   personas: { id: string; name: string; is_active: boolean }[];
-  channels: Channel[];
+  channels: { id: number; name: string; type: string; is_active: boolean }[];
 }
 
 interface CrawlerStatus {
@@ -167,71 +157,6 @@ export default function AdminDashboard() {
           </CardContent>
         </Card>
       )}
-
-      {/* 自動化設定 */}
-      <AutomationPanel />
-
-      <div className="grid md:grid-cols-2 gap-6">
-        {/* 寫手列表 */}
-        <Card>
-          <CardHeader>
-            <CardTitle>寫手陣容</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 gap-3">
-              {stats.personas.map((persona) => (
-                <div
-                  key={persona.id}
-                  className="flex items-center gap-3 p-3 rounded-lg border"
-                >
-                  <div
-                    className={`w-3 h-3 rounded-full ${
-                      persona.is_active ? "bg-green-500" : "bg-gray-300"
-                    }`}
-                  />
-                  <div>
-                    <div className="font-medium text-sm">{persona.name}</div>
-                    <div className="text-xs text-gray-500">
-                      {persona.is_active ? "啟用中" : "已停用"}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* 發布頻道 */}
-        <Card>
-          <CardHeader>
-            <CardTitle>
-              發布頻道
-              <span className="ml-2 text-sm font-normal text-gray-500">
-                ({stats.channels.length} 個啟用中)
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {stats.channels.length === 0 ? (
-              <p className="text-sm text-gray-400">尚未設定發布頻道</p>
-            ) : (
-              <div className="grid grid-cols-1 gap-3">
-                {stats.channels.map((ch) => (
-                  <div
-                    key={ch.id}
-                    className="flex items-center justify-between p-3 rounded-lg border"
-                  >
-                    <div className="font-medium text-sm">{ch.name}</div>
-                    <Badge variant="outline">
-                      {CHANNEL_TYPE_LABELS[ch.type] || ch.type}
-                    </Badge>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
     </div>
   );
 }

--- a/src/app/admin/pipeline/page.tsx
+++ b/src/app/admin/pipeline/page.tsx
@@ -1,0 +1,13 @@
+export default function PipelinePage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">管線狀態</h1>
+      <div className="flex items-center justify-center py-24 text-gray-400 border-2 border-dashed rounded-lg">
+        <div className="text-center">
+          <p className="text-lg font-medium">Coming Soon</p>
+          <p className="text-sm mt-1">視覺化管線流程圖即將推出（Issue #163）</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/review/page.tsx
+++ b/src/app/admin/review/page.tsx
@@ -1,0 +1,13 @@
+export default function ReviewPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">審稿佇列</h1>
+      <div className="flex items-center justify-center py-24 text-gray-400 border-2 border-dashed rounded-lg">
+        <div className="text-center">
+          <p className="text-lg font-medium">Coming Soon</p>
+          <p className="text-sm mt-1">手動覆審工作台即將推出（Issue #164）</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/sources/page.tsx
+++ b/src/app/admin/sources/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { CrawlSourceList } from "@/components/admin/sports/CrawlSourceList";
+import type { CrawlSource, SportSettings, CrawlResult } from "@/components/admin/sports/types";
+
+export default function SourcesPage() {
+  const queryClient = useQueryClient();
+
+  // 新增來源表單
+  const [newName, setNewName] = useState("");
+  const [newUrl, setNewUrl] = useState("");
+
+  // 編輯來源
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+
+  // 刪除確認
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
+
+  // 手動觸發爬蟲
+  const [crawlingId, setCrawlingId] = useState<number | null>(null);
+  const [crawlResult, setCrawlResult] = useState<CrawlResult | null>(null);
+
+  const { data: settings = {} as SportSettings } = useQuery<SportSettings>({
+    queryKey: ["sport-settings"],
+    queryFn: async () => {
+      const res = await fetch("/api/settings/sports");
+      if (!res.ok) throw new Error("fetch failed");
+      const data = await res.json();
+      return data.error ? {} : data;
+    },
+  });
+
+  const { data: crawlSources = [], isLoading } = useQuery<CrawlSource[]>({
+    queryKey: ["crawl-sources"],
+    queryFn: async () => {
+      const res = await fetch("/api/settings/sources");
+      if (!res.ok) throw new Error("fetch failed");
+      const data = await res.json();
+      return Array.isArray(data) ? data : [];
+    },
+  });
+
+  const toggleCrawlImagesMutation = useMutation({
+    mutationFn: async ({ id, crawl_images }: { id: number; crawl_images: boolean }) => {
+      const res = await fetch("/api/settings/sources", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, crawl_images }),
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error("toggle failed");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
+    },
+  });
+
+  const addSourceMutation = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/settings/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newName.trim(), base_url: newUrl.trim() }),
+      });
+      const data = await res.json();
+      if (!data.id) throw new Error(data.error || "新增失敗");
+      return data;
+    },
+    onSuccess: () => {
+      setNewName("");
+      setNewUrl("");
+      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+
+  const deleteSourceMutation = useMutation({
+    mutationFn: async ({ id, name }: { id: number; name: string }) => {
+      const res = await fetch(`/api/settings/sources?id=${id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!data.success) throw new Error("delete failed");
+      return { id, name };
+    },
+    onSuccess: ({ name }) => {
+      const updatedSettings = { ...settings };
+      for (const key of Object.keys(updatedSettings)) {
+        const sources = updatedSettings[key].sources.filter((s) => s !== name);
+        if (sources.length !== updatedSettings[key].sources.length) {
+          updatedSettings[key] = { ...updatedSettings[key], sources };
+          fetch("/api/settings/sports", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ sport_key: key, sources }),
+          }).catch((err) => console.error("Failed to update sport sources after delete:", err));
+        }
+      }
+      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
+      queryClient.invalidateQueries({ queryKey: ["sport-settings"] });
+    },
+  });
+
+  const saveEditMutation = useMutation({
+    mutationFn: async ({ id, oldName }: { id: number; oldName: string }) => {
+      const res = await fetch("/api/settings/sources", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, name: editName.trim(), base_url: editUrl.trim() }),
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error("update failed");
+      return { oldName };
+    },
+    onSuccess: ({ oldName }) => {
+      if (oldName !== editName.trim()) {
+        for (const key of Object.keys(settings)) {
+          const idx = settings[key].sources.indexOf(oldName);
+          if (idx !== -1) {
+            const newSources = [...settings[key].sources];
+            newSources[idx] = editName.trim();
+            fetch("/api/settings/sports", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ sport_key: key, sources: newSources }),
+            }).catch((err) => console.error("Failed to update sport sources after rename:", err));
+          }
+        }
+        queryClient.invalidateQueries({ queryKey: ["sport-settings"] });
+      }
+      setEditingId(null);
+      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
+    },
+  });
+
+  function addSource() {
+    if (!newName.trim() || !newUrl.trim()) return;
+    addSourceMutation.mutate();
+  }
+
+  function deleteSource(id: number, name: string) {
+    setDeleteTarget({ id, name });
+  }
+
+  function confirmDeleteSource() {
+    if (!deleteTarget) return;
+    deleteSourceMutation.mutate(deleteTarget);
+    setDeleteTarget(null);
+  }
+
+  async function triggerCrawl(source: CrawlSource) {
+    setCrawlingId(source.id);
+    setCrawlResult(null);
+    try {
+      const res = await fetch("/api/settings/sources/crawl", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourceId: source.id }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setCrawlResult({ id: source.id, total: data.total, saved: data.saved, duplicate: data.duplicate || 0, filtered: data.filtered || 0 });
+      } else {
+        toast.error(`爬蟲失敗：${data.error || "未知錯誤"}`);
+      }
+    } catch (err) {
+      console.error("Crawl failed:", err);
+      toast.error("爬蟲執行失敗");
+    } finally {
+      setCrawlingId(null);
+    }
+  }
+
+  function saveEdit(id: number, oldName: string) {
+    if (!editName.trim() || !editUrl.trim()) return;
+    saveEditMutation.mutate({ id, oldName });
+  }
+
+  function handleStartEdit(source: CrawlSource) {
+    setEditingId(source.id);
+    setEditName(source.name);
+    setEditUrl(source.base_url);
+  }
+
+  if (isLoading) {
+    return <div className="text-center py-12 text-gray-500">載入中...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">爬蟲來源</h1>
+        <p className="text-gray-500 mt-1">管理爬蟲來源、手動觸發爬取</p>
+      </div>
+
+      <CrawlSourceList
+        crawlSources={crawlSources}
+        editingId={editingId}
+        editName={editName}
+        editUrl={editUrl}
+        crawlingId={crawlingId}
+        crawlResult={crawlResult}
+        newName={newName}
+        newUrl={newUrl}
+        adding={addSourceMutation.isPending}
+        onEditNameChange={setEditName}
+        onEditUrlChange={setEditUrl}
+        onNewNameChange={setNewName}
+        onNewUrlChange={setNewUrl}
+        onSaveEdit={saveEdit}
+        onCancelEdit={() => setEditingId(null)}
+        onStartEdit={handleStartEdit}
+        onDelete={deleteSource}
+        onToggleCrawlImages={(id, crawl_images) => toggleCrawlImagesMutation.mutate({ id, crawl_images })}
+        onTriggerCrawl={triggerCrawl}
+        onAddSource={addSource}
+      />
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認刪除</AlertDialogTitle>
+            <AlertDialogDescription>
+              確定刪除「{deleteTarget?.name}」？此操作無法復原。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDeleteSource}>刪除</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/admin/sports/page.tsx
+++ b/src/app/admin/sports/page.tsx
@@ -2,41 +2,13 @@
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { SPORTS, type SportKey } from "@/lib/sport-config";
-import { CrawlSourceList } from "@/components/admin/sports/CrawlSourceList";
 import { SportCard } from "@/components/admin/sports/SportCard";
-import type { CrawlSource, SportSettings, CrawlResult } from "@/components/admin/sports/types";
+import type { CrawlSource, SportSettings } from "@/components/admin/sports/types";
 
 export default function SportsSettingsPage() {
   const queryClient = useQueryClient();
   const [updating, setUpdating] = useState<string | null>(null);
-
-  // 新增來源表單
-  const [newName, setNewName] = useState("");
-  const [newUrl, setNewUrl] = useState("");
-
-  // 編輯來源
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [editName, setEditName] = useState("");
-  const [editUrl, setEditUrl] = useState("");
-
-  // 刪除確認
-  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
-
-  // 手動觸發爬蟲
-  const [crawlingId, setCrawlingId] = useState<number | null>(null);
-  const [crawlResult, setCrawlResult] = useState<CrawlResult | null>(null);
 
   const { data: settings = {} as SportSettings, isLoading: settingsLoading } = useQuery<SportSettings>({
     queryKey: ["sport-settings"],
@@ -98,107 +70,11 @@ export default function SportsSettingsPage() {
     },
   });
 
-  const toggleCrawlImagesMutation = useMutation({
-    mutationFn: async ({ id, crawl_images }: { id: number; crawl_images: boolean }) => {
-      const res = await fetch("/api/settings/sources", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, crawl_images }),
-      });
-      const data = await res.json();
-      if (!data.success) throw new Error("toggle failed");
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
-    },
-  });
-
-  const addSourceMutation = useMutation({
-    mutationFn: async () => {
-      const res = await fetch("/api/settings/sources", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newName.trim(), base_url: newUrl.trim() }),
-      });
-      const data = await res.json();
-      if (!data.id) throw new Error(data.error || "新增失敗");
-      return data;
-    },
-    onSuccess: () => {
-      setNewName("");
-      setNewUrl("");
-      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
-    },
-    onError: (err) => {
-      toast.error(err.message);
-    },
-  });
-
-  const deleteSourceMutation = useMutation({
-    mutationFn: async ({ id, name }: { id: number; name: string }) => {
-      const res = await fetch(`/api/settings/sources?id=${id}`, { method: "DELETE" });
-      const data = await res.json();
-      if (!data.success) throw new Error("delete failed");
-      return { id, name };
-    },
-    onSuccess: ({ name }) => {
-      // Also update sport settings that reference this source
-      const updatedSettings = { ...settings };
-      for (const key of Object.keys(updatedSettings)) {
-        const sources = updatedSettings[key].sources.filter((s) => s !== name);
-        if (sources.length !== updatedSettings[key].sources.length) {
-          updatedSettings[key] = { ...updatedSettings[key], sources };
-          fetch("/api/settings/sports", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ sport_key: key, sources }),
-          }).catch((err) => console.error("Failed to update sport sources after delete:", err));
-        }
-      }
-      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
-      queryClient.invalidateQueries({ queryKey: ["sport-settings"] });
-    },
-  });
-
-  const saveEditMutation = useMutation({
-    mutationFn: async ({ id, oldName }: { id: number; oldName: string }) => {
-      const res = await fetch("/api/settings/sources", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, name: editName.trim(), base_url: editUrl.trim() }),
-      });
-      const data = await res.json();
-      if (!data.success) throw new Error("update failed");
-      return { oldName };
-    },
-    onSuccess: ({ oldName }) => {
-      if (oldName !== editName.trim()) {
-        // Update sport settings referencing old name
-        for (const key of Object.keys(settings)) {
-          const idx = settings[key].sources.indexOf(oldName);
-          if (idx !== -1) {
-            const newSources = [...settings[key].sources];
-            newSources[idx] = editName.trim();
-            fetch("/api/settings/sports", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ sport_key: key, sources: newSources }),
-            }).catch((err) => console.error("Failed to update sport sources after rename:", err));
-          }
-        }
-        queryClient.invalidateQueries({ queryKey: ["sport-settings"] });
-      }
-      setEditingId(null);
-      queryClient.invalidateQueries({ queryKey: ["crawl-sources"] });
-    },
-  });
-
-
-  async function toggleSport(sportKey: SportKey, enabled: boolean) {
+  function toggleSport(sportKey: SportKey, enabled: boolean) {
     toggleSportMutation.mutate({ sportKey, enabled });
   }
 
-  async function toggleSource(sportKey: SportKey, sourceName: string, checked: boolean) {
+  function toggleSource(sportKey: SportKey, sourceName: string, checked: boolean) {
     const current = settings[sportKey]?.sources || [];
     const newSources = checked
       ? [...current, sourceName]
@@ -207,98 +83,16 @@ export default function SportsSettingsPage() {
     toggleSourceMutation.mutate({ sportKey, sourceName, newSources });
   }
 
-  async function toggleCrawlImages(id: number, crawl_images: boolean) {
-    toggleCrawlImagesMutation.mutate({ id, crawl_images });
-  }
-
-  function addSource() {
-    if (!newName.trim() || !newUrl.trim()) return;
-    addSourceMutation.mutate();
-  }
-
-  function deleteSource(id: number, name: string) {
-    setDeleteTarget({ id, name });
-  }
-
-  function confirmDeleteSource() {
-    if (!deleteTarget) return;
-    deleteSourceMutation.mutate(deleteTarget);
-    setDeleteTarget(null);
-  }
-
-  async function triggerCrawl(source: CrawlSource) {
-    setCrawlingId(source.id);
-    setCrawlResult(null);
-    try {
-      const res = await fetch("/api/settings/sources/crawl", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sourceId: source.id }),
-      });
-      const data = await res.json();
-      if (data.success) {
-        setCrawlResult({ id: source.id, total: data.total, saved: data.saved, duplicate: data.duplicate || 0, filtered: data.filtered || 0 });
-      } else {
-        toast.error(`爬蟲失敗：${data.error || "未知錯誤"}`);
-      }
-    } catch (err) {
-      console.error("Crawl failed:", err);
-      toast.error("爬蟲執行失敗");
-    } finally {
-      setCrawlingId(null);
-    }
-  }
-
-  function saveEdit(id: number, oldName: string) {
-    if (!editName.trim() || !editUrl.trim()) return;
-    saveEditMutation.mutate({ id, oldName });
-  }
-
-  function handleStartEdit(source: CrawlSource) {
-    setEditingId(source.id);
-    setEditName(source.name);
-    setEditUrl(source.base_url);
-  }
-
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <p className="text-gray-500">載入中...</p>
-      </div>
-    );
+    return <div className="text-center py-12 text-gray-500">載入中...</div>;
   }
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">球種與來源</h1>
-        <p className="text-gray-500 mt-1">
-          管理爬蟲來源、球種設定與標題風格提詞
-        </p>
+        <h1 className="text-2xl font-bold">球種分類</h1>
+        <p className="text-gray-500 mt-1">管理運動項目的啟用狀態與爬蟲來源對應</p>
       </div>
-
-      <CrawlSourceList
-        crawlSources={crawlSources}
-        editingId={editingId}
-        editName={editName}
-        editUrl={editUrl}
-        crawlingId={crawlingId}
-        crawlResult={crawlResult}
-        newName={newName}
-        newUrl={newUrl}
-        adding={addSourceMutation.isPending}
-        onEditNameChange={setEditName}
-        onEditUrlChange={setEditUrl}
-        onNewNameChange={setNewName}
-        onNewUrlChange={setNewUrl}
-        onSaveEdit={saveEdit}
-        onCancelEdit={() => setEditingId(null)}
-        onStartEdit={handleStartEdit}
-        onDelete={deleteSource}
-        onToggleCrawlImages={toggleCrawlImages}
-        onTriggerCrawl={triggerCrawl}
-        onAddSource={addSource}
-      />
 
       <div className="grid gap-4 sm:grid-cols-2">
         {(Object.entries(SPORTS) as [SportKey, (typeof SPORTS)[SportKey]][]).map(
@@ -325,22 +119,6 @@ export default function SportsSettingsPage() {
           }
         )}
       </div>
-
-      {/* 刪除確認 Dialog */}
-      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>確認刪除</AlertDialogTitle>
-            <AlertDialogDescription>
-              確定刪除「{deleteTarget?.name}」？此操作無法復原。
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>取消</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmDeleteSource}>刪除</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 後台導航從頂部 8 項扁平列改為左側側邊欄，分 3 大區塊（總覽/內容/設定）
- 儀表板精簡：移除寫手陣容、發布頻道、自動化面板
- 球種與來源拆分為兩頁
- 新增 pipeline、review placeholder 頁面

## Changes
- `AdminLayoutClient.tsx`: 完全重寫為側邊欄布局
- `page.tsx` (dashboard): 移除 AutomationPanel + 寫手/頻道區塊
- `sports/page.tsx`: 移除 CrawlSourceList，只保留球種分類
- 新增 `sources/page.tsx`: 爬蟲來源管理（從 sports 搬出）
- 新增 `pipeline/page.tsx`: Coming Soon placeholder
- 新增 `review/page.tsx`: Coming Soon placeholder

## Test
- 409 tests passed
- 安全掃描通過