### PR TITLE
feat(admin): 新增管線狀態頁 — 視覺化 pipeline + 自動化設定

### DIFF
--- a/src/app/admin/pipeline/page.tsx
+++ b/src/app/admin/pipeline/page.tsx
@@ -1,13 +1,91 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AutomationPanel } from "@/components/admin/AutomationPanel";
+
+interface PipelineData {
+  pipeline: {
+    raw_unprocessed: number;
+    plans_pending: number;
+    tasks_active: number;
+    review_pending: number;
+    published_total: number;
+  };
+}
+
+const stages = [
+  { key: "raw_unprocessed", label: "爬蟲素材", icon: "🕷️", desc: "未處理的原始文章" },
+  { key: "plans_pending", label: "待規劃", icon: "📋", desc: "等待 AI 分析規劃" },
+  { key: "tasks_active", label: "產文中", icon: "✍️", desc: "正在執行的產文任務" },
+  { key: "review_pending", label: "待審稿", icon: "🔍", desc: "等待審核的草稿" },
+  { key: "published_total", label: "已發布", icon: "✅", desc: "已上線的文章" },
+] as const;
+
+function getStageColor(key: string, value: number): string {
+  if (key === "published_total") return "text-emerald-600 bg-emerald-50 border-emerald-200";
+  if (value === 0) return "text-gray-400 bg-gray-50 border-gray-200";
+  if (key === "raw_unprocessed" && value > 50) return "text-yellow-600 bg-yellow-50 border-yellow-200";
+  if (key === "tasks_active" && value > 0) return "text-blue-600 bg-blue-50 border-blue-200";
+  if (key === "review_pending" && value > 5) return "text-orange-600 bg-orange-50 border-orange-200";
+  return "text-gray-700 bg-white border-gray-200";
+}
+
 export default function PipelinePage() {
+  const { data, isLoading } = useQuery<PipelineData>({
+    queryKey: ["pipeline-status"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/pipeline-status");
+      if (!res.ok) throw new Error("fetch failed");
+      return res.json();
+    },
+    refetchInterval: 30000,
+  });
+
+  if (isLoading) {
+    return <div className="text-center py-12 text-gray-500">載入中...</div>;
+  }
+
+  const pipeline = data?.pipeline;
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">管線狀態</h1>
-      <div className="flex items-center justify-center py-24 text-gray-400 border-2 border-dashed rounded-lg">
-        <div className="text-center">
-          <p className="text-lg font-medium">Coming Soon</p>
-          <p className="text-sm mt-1">視覺化管線流程圖即將推出（Issue #163）</p>
-        </div>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">管線狀態</h1>
+        <p className="text-gray-500 mt-1">內容產出管線各環節的即時狀態</p>
       </div>
+
+      {/* Pipeline flow visualization */}
+      <Card>
+        <CardHeader>
+          <CardTitle>產出管線</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-0">
+            {stages.map((stage, i) => {
+              const value = pipeline?.[stage.key] ?? 0;
+              const colorClass = getStageColor(stage.key, value);
+
+              return (
+                <div key={stage.key} className="flex items-center flex-1 min-w-0">
+                  <div className={`flex-1 rounded-lg border p-4 text-center ${colorClass}`}>
+                    <div className="text-2xl mb-1">{stage.icon}</div>
+                    <div className="text-2xl font-bold tabular-nums">{value}</div>
+                    <div className="text-xs font-medium mt-1">{stage.label}</div>
+                    <div className="text-xs opacity-60 mt-0.5">{stage.desc}</div>
+                  </div>
+                  {i < stages.length - 1 && (
+                    <div className="hidden sm:flex items-center px-1 text-gray-300 text-lg shrink-0">→</div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Automation settings (moved from dashboard) */}
+      <AutomationPanel />
     </div>
   );
 }

--- a/src/app/api/admin/pipeline-status/route.ts
+++ b/src/app/api/admin/pipeline-status/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase";
+import { auth } from "@/auth";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const supabase = createServiceClient();
+
+    const [rawResult, plansResult, tasksResult, reviewResult, publishedResult, automationResult] = await Promise.all([
+      supabase.from("raw_articles").select("*", { count: "exact", head: true }).eq("is_processed", false),
+      supabase.from("rewrite_plans").select("*", { count: "exact", head: true }).eq("status", "pending"),
+      supabase.from("rewrite_tasks").select("*", { count: "exact", head: true }).in("status", ["pending", "running"]),
+      supabase.from("generated_articles").select("*", { count: "exact", head: true }).eq("review_status", "pending"),
+      supabase.from("generated_articles").select("*", { count: "exact", head: true }).eq("status", "published"),
+      supabase.from("automation_settings").select("*").eq("id", 1).single(),
+    ]);
+
+    return NextResponse.json({
+      pipeline: {
+        raw_unprocessed: rawResult.count ?? 0,
+        plans_pending: plansResult.count ?? 0,
+        tasks_active: tasksResult.count ?? 0,
+        review_pending: reviewResult.count ?? 0,
+        published_total: publishedResult.count ?? 0,
+      },
+      automation: automationResult.data ?? null,
+    });
+  } catch (err) {
+    return NextResponse.json({ error: `Internal error: ${err}` }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 /admin/pipeline 管線狀態頁，替換 placeholder
- 5 階段流程圖：爬蟲素材 → 待規劃 → 產文中 → 待審稿 → 已發布
- AutomationPanel 從儀表板搬到管線狀態頁
- 新增 GET /api/admin/pipeline-status API

## Changes
- 新增 `src/app/api/admin/pipeline-status/route.ts`
- 重寫 `src/app/admin/pipeline/page.tsx`

## Test
- 409 tests passed
- 安全掃描通過