### PR TITLE
refactor(admin): 素材庫改名 + 側邊欄 Badge

### DIFF
--- a/src/app/admin/AdminLayoutClient.tsx
+++ b/src/app/admin/AdminLayoutClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
+import { useQuery } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 
 const navGroups = [
@@ -47,6 +48,22 @@ export default function AdminLayout({
 }) {
   const pathname = usePathname();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const { data: pipelineData } = useQuery<{ pipeline: { review_pending: number; raw_unprocessed: number } }>({
+    queryKey: ["sidebar-badges"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/pipeline-status");
+      if (!res.ok) return { pipeline: { review_pending: 0, raw_unprocessed: 0 } };
+      return res.json();
+    },
+    refetchInterval: 60000,
+    staleTime: 30000,
+  });
+
+  const badgeMap: Record<string, number> = {
+    "/admin/review": pipelineData?.pipeline?.review_pending ?? 0,
+    "/admin/raw": pipelineData?.pipeline?.raw_unprocessed ?? 0,
+  };
 
   return (
     <div className="h-screen flex bg-gray-50">
@@ -93,7 +110,12 @@ export default function AdminLayout({
                     )}
                   >
                     <span className="text-base">{item.icon}</span>
-                    {item.label}
+                    <span className="flex-1">{item.label}</span>
+                    {badgeMap[item.href] > 0 && (
+                      <span className="ml-auto bg-blue-100 text-blue-700 text-xs font-medium px-1.5 py-0.5 rounded-full tabular-nums">
+                        {badgeMap[item.href]}
+                      </span>
+                    )}
                   </Link>
                 ))}
               </div>

--- a/src/app/admin/raw/page.tsx
+++ b/src/app/admin/raw/page.tsx
@@ -67,7 +67,7 @@ export default function RawArticlesPage() {
   return (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="text-2xl font-bold">原始新聞</h1>
+        <h1 className="text-2xl font-bold">素材庫</h1>
         <div className="flex flex-wrap items-center gap-2 sm:gap-4">
           <span className="text-sm text-gray-500">共 {total} 篇</span>
           <Select


### PR DESCRIPTION
## Summary
- 原始新聞改名素材庫
- 側邊欄為審稿佇列/素材庫顯示待處理數量 Badge

## Test
- 409 tests passed