### PR TITLE
refactor: 前台賠率/排行榜/比分頁面重構 — 好球研究所核心頁面

### DIFF
--- a/src/components/odds/OddsClient.tsx
+++ b/src/components/odds/OddsClient.tsx
@@ -205,6 +205,13 @@ export function OddsClient() {
                             </tbody>
                           </table>
                         </div>
+                      ) : game.status === "final" ? (
+                        <div className="text-sm text-muted-foreground text-center py-2">
+                          <span className="font-medium">{game.awayTeam.abbreviation} {game.awayTeam.score}</span>
+                          <span className="mx-2">-</span>
+                          <span className="font-medium">{game.homeTeam.abbreviation} {game.homeTeam.score}</span>
+                          <span className="ml-2 text-xs">(Final)</span>
+                        </div>
                       ) : (
                         <p className="text-sm text-muted-foreground">暫無賠率資料</p>
                       )}

--- a/src/components/scoreboard/ScoreCard.tsx
+++ b/src/components/scoreboard/ScoreCard.tsx
@@ -129,10 +129,20 @@ export default function ScoreCard({ game, league }: { game: Game; league?: strin
         </div>
       )}
 
-      {/* Odds summary */}
+      {/* Odds summary with result */}
       {game.odds && (
         <div className="px-4 pb-2 text-xs text-muted-foreground text-center tabular-nums">
           {game.odds.details} | O/U {game.odds.overUnder}
+          {game.status === "final" && game.odds.overUnder > 0 && (
+            <span className="ml-2">
+              {(() => {
+                const total = homeScore + awayScore;
+                const ouResult = total > game.odds.overUnder ? "Over ↑" : total < game.odds.overUnder ? "Under ↓" : "Push";
+                const ouColor = total > game.odds.overUnder ? "text-red-500" : total < game.odds.overUnder ? "text-blue-500" : "text-yellow-500";
+                return <span className={ouColor}>{ouResult} ({total})</span>;
+              })()}
+            </span>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- 賠率頁：已完成比賽顯示最終比分
- 比分頁：O/U 顯示 Over/Under 結果 + 總分
- 排行榜頁：確認功能正常（ESPN API 端資料正常時可用）

## Changes
- `src/components/odds/OddsClient.tsx`: 已完成比賽顯示比分
- `src/components/scoreboard/ScoreCard.tsx`: O/U 結果標示

## Test
- 409 tests passed
- 安全掃描通過