### PR TITLE
refactor(pipeline): 提取管線共用常數消除硬編碼散落

### DIFF
--- a/scripts/plan-generator.ts
+++ b/scripts/plan-generator.ts
@@ -19,14 +19,12 @@ import { createClient } from "@supabase/supabase-js";
 import { z } from "zod";
 import { matchesSpecialties, Specialties, RawArticleBase, leagueKeywords } from "./shared-matching";
 import { callClaude } from "./shared-claude";
+import { MATERIAL_WINDOW_HOURS, MAX_MATERIALS_PER_WRITER } from "./shared-constants";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL || "",
   process.env.SUPABASE_SERVICE_ROLE_KEY || ""
 );
-
-/** 每位寫手每次最多處理的素材數量 */
-const MAX_MATERIALS = 20;
 
 interface WriterPersona { id: string; name: string; style_prompt: string; writer_type: string; specialties: Specialties; max_articles: number; }
 interface RawArticle extends RawArticleBase { crawled_at: string; images?: string[]; }
@@ -131,9 +129,9 @@ export async function generatePlans() {
 
   if (!personas?.length) { console.log("沒有啟用的寫手"); return; }
 
-  // 取得最近 12 小時的文章
+  // 取得時效窗口內的文章
   const since = new Date();
-  since.setHours(since.getHours() - 12);
+  since.setHours(since.getHours() - MATERIAL_WINDOW_HOURS);
 
   const { data: rawArticles } = await supabase
     .from("raw_articles").select("*")
@@ -207,10 +205,10 @@ const allPlans: { writer_persona_id: string; title: string; raw_article_ids: str
     }
 
     // 素材上限（DB 已按 crawled_at desc 排序，直接截取最新的）
-    const freshArticles = allFresh.slice(0, MAX_MATERIALS);
+    const freshArticles = allFresh.slice(0, MAX_MATERIALS_PER_WRITER);
 
-    if (allFresh.length > MAX_MATERIALS) {
-      console.log(`[${persona.name}] 匹配 ${matched.length} 篇，新素材 ${allFresh.length} 篇，截取最新 ${MAX_MATERIALS} 篇`);
+    if (allFresh.length > MAX_MATERIALS_PER_WRITER) {
+      console.log(`[${persona.name}] 匹配 ${matched.length} 篇，新素材 ${allFresh.length} 篇，截取最新 ${MAX_MATERIALS_PER_WRITER} 篇`);
     } else {
       console.log(`[${persona.name}] 匹配 ${matched.length} 篇，新素材 ${freshArticles.length} 篇`);
     }

--- a/scripts/rewrite-listener.ts
+++ b/scripts/rewrite-listener.ts
@@ -14,6 +14,7 @@ config({ path: resolve(__dirname, "..", ".env.local") });
 
 import { createClient } from "@supabase/supabase-js";
 import { spawnSync } from "child_process";
+import { MATERIAL_WINDOW_HOURS } from "./shared-constants";
 
 const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -231,9 +232,9 @@ async function checkAutoPipeline() {
       .update({ last_check_at: now.toISOString() })
       .eq("id", 1);
 
-    // 計算未處理素材數（只計 12h 內，與 plan-generator 窗口一致）
+    // 計算未處理素材數（與 plan-generator 使用相同時效窗口）
     const materialSince = new Date();
-    materialSince.setHours(materialSince.getHours() - 12);
+    materialSince.setHours(materialSince.getHours() - MATERIAL_WINDOW_HOURS);
     const { count } = await supabase
       .from("raw_articles")
       .select("*", { count: "exact", head: true })

--- a/scripts/shared-constants.ts
+++ b/scripts/shared-constants.ts
@@ -1,0 +1,10 @@
+/**
+ * 管線共用常數 — plan-generator / rewrite-listener / local-rewriter 共用
+ * 修改此檔案後必須重啟 rewrite-listener
+ */
+
+/** 素材時效窗口（小時）：只處理此時間內爬到的素材 */
+export const MATERIAL_WINDOW_HOURS = 12;
+
+/** 每位寫手每次最多處理的素材數量 */
+export const MAX_MATERIALS_PER_WRITER = 20;

--- a/src/__tests__/scripts/plan-generator.test.ts
+++ b/src/__tests__/scripts/plan-generator.test.ts
@@ -362,6 +362,31 @@ describe("isSimilarTitle — 標題相似度", () => {
   });
 });
 
+// --- 素材截取邏輯（Issue #187 新增） ---
+
+describe("素材上限截取邏輯", () => {
+  const MAX_MATERIALS = 20;
+
+  it("超過上限時截取前 N 篇", () => {
+    const articles = Array.from({ length: 50 }, (_, i) => ({ id: `art-${i}` }));
+    const result = articles.slice(0, MAX_MATERIALS);
+    expect(result).toHaveLength(20);
+    expect(result[0].id).toBe("art-0");
+    expect(result[19].id).toBe("art-19");
+  });
+
+  it("未達上限時全部保留", () => {
+    const articles = Array.from({ length: 10 }, (_, i) => ({ id: `art-${i}` }));
+    const result = articles.slice(0, MAX_MATERIALS);
+    expect(result).toHaveLength(10);
+  });
+
+  it("空陣列不報錯", () => {
+    const result = ([] as { id: string }[]).slice(0, MAX_MATERIALS);
+    expect(result).toHaveLength(0);
+  });
+});
+
 describe("is_processed 標記邏輯", () => {
   it("收集所有 allPlans 中的 raw_article_ids 並去重", () => {
     const allPlans = [


### PR DESCRIPTION
## Summary
- 管線時效窗口和素材上限從各檔案硬編碼改為 import 共用常數
- 補測試 + reviewer 規則強化

## Changes
- 新增 `scripts/shared-constants.ts`：MATERIAL_WINDOW_HOURS=12、MAX_MATERIALS_PER_WRITER=20
- `scripts/plan-generator.ts`：改 import 共用常數
- `scripts/rewrite-listener.ts`：改 import 共用常數
- `src/__tests__/scripts/plan-generator.test.ts`：補 3 個素材截取測試
- `~/.claude/agents/reviewer-architecture.md`：加第 16 項「外部子程序錯誤隔離」

## Test
- 412 tests passed ✓

Refs #187