### PR TITLE
fix(pipeline): 修復跨文章圖片重複 + 管線斷裂 + rate limit retry

### DIFF
--- a/docs/delivery/issue-197.md
+++ b/docs/delivery/issue-197.md
@@ -1,0 +1,71 @@
+# Issue #197: fix: 文章圖片重複 + 管線斷裂
+
+**級別**: M
+**類型**: Bug Fix
+**相關 Issue**: #196（skill 規則更新，已完成）
+
+## 需求摘要
+
+1. **Bug 1 — 跨文章圖片重複**：`collectImages()` 每篇獨立收集，同批次不同文章引用重疊素材時產出相同圖片組
+2. **Bug 2 — 管線靜默斷裂**：plan 存檔 `TypeError: fetch failed` 但 exit 0 → listener 判定成功但查無新 plan → 不觸發 produce/review/publish
+3. **附帶修復**：`shared-claude` 遇 rate limit 無 retry
+
+## 修復方案
+
+### 1. local-rewriter 重構
+- 拆出 `scripts/local-rewriter.logic.ts`，export `collectImages()` 和 `produceFromPlans()` 的核心邏輯
+- `collectImages()` 改為接受 `usedImages: Set<string>` 參數，同批次跨文章去重
+- 入口檔 `local-rewriter.ts` 只負責 DB IO + 呼叫 logic
+
+### 2. rewrite-listener 重構
+- 拆出 `scripts/rewrite-listener.logic.ts`，export `shouldTriggerProduce()` 和 `shouldTriggerReview()` 判斷邏輯
+- `shouldTriggerProduce()` 改為檢查實際存入筆數，不只看 exit code
+
+### 3. plan-generator 存檔 retry
+- Supabase insert 加 retry（最多 2 次，間隔 2 秒）
+- 失敗時 exit 1（而非 exit 0），讓 listener 能正確判斷
+
+### 4. shared-claude rate limit retry
+- 偵測 `You've hit your limit` 回應
+- 等待指定時間後重試（最多 3 次）
+
+### 5. 補 unit test
+- `src/__tests__/scripts/local-rewriter.logic.test.ts` — 測 collectImages 跨文章去重、produceFromPlans 批次邏輯
+- `src/__tests__/scripts/rewrite-listener.logic.test.ts` — 測 shouldTriggerProduce/Review 的各種邊界條件
+- `src/__tests__/scripts/shared-claude.test.ts` — 測 rate limit 偵測
+
+## 受影響檔案
+
+- `scripts/local-rewriter.ts` + 新增 `scripts/local-rewriter.logic.ts`
+- `scripts/rewrite-listener.ts` + 新增 `scripts/rewrite-listener.logic.ts`
+- `scripts/plan-generator.ts`
+- `scripts/shared-claude.ts`
+- `src/__tests__/scripts/` 下新增測試檔
+
+## BE 交付紀錄
+
+### 修改檔案清單
+- `scripts/local-rewriter.ts` — 移除內建 collectImages，改用 logic 模組；produceFromPlans 加入 batchUsedImages 追蹤
+- `scripts/local-rewriter.logic.ts` — **新增**：collectImages（含 usedImages 參數）、addToUsedImages
+- `scripts/rewrite-listener.ts` — 移除內建 parseTaskMode，改用 logic 模組；接力判斷改用 shouldTriggerProduce/Review
+- `scripts/rewrite-listener.logic.ts` — **新增**：shouldTriggerProduce、shouldTriggerReview、parseTaskMode
+- `scripts/plan-generator.ts` — 存檔加 retry（3 次 / 間隔 2 秒）+ 全部失敗 exit 1
+- `scripts/shared-claude.ts` — 新增 isRateLimitError + callClaude 加 rate limit retry（最多 3 次，遞增等待）
+
+### 新增測試
+- `src/__tests__/scripts/local-rewriter.logic.test.ts` — 12 tests
+- `src/__tests__/scripts/rewrite-listener.logic.test.ts` — 17 tests
+- `src/__tests__/scripts/shared-claude.test.ts` — 8 tests
+
+### 測試結果
+- 新增 37 tests 全部通過
+- 全站 1059 tests / 84 files 全部通過
+
+### 給 QA 的注意事項
+- 無新增 API route，smoke-test 不需更新
+- 修改 scripts/ 後必須重啟 rewrite-listener
+- 核心驗證：同批次產出的文章圖片不應完全相同
+
+## 部署注意
+
+- 修改 `scripts/` 後**必須重啟 rewrite-listener**

--- a/scripts/local-rewriter.logic.ts
+++ b/scripts/local-rewriter.logic.ts
@@ -1,0 +1,44 @@
+/**
+ * local-rewriter 業務邏輯模組
+ *
+ * 從入口檔拆出的純函式，可獨立 import 測試。
+ * 入口檔 (local-rewriter.ts) 只負責 DB IO + 呼叫這些函式。
+ */
+
+import { isValidImageUrl } from "../src/lib/constants";
+
+/**
+ * 從多篇原始文章中收集不重複的圖片 URL（最多取 maxImages 張）
+ *
+ * @param articles - 原始文章陣列（需有 images 欄位）
+ * @param usedImages - 同批次其他文章已使用的圖片 Set（跨文章去重）
+ * @param maxImages - 每篇文章最多收集的圖片數量（預設 5）
+ * @returns 收集到的圖片 URL 陣列
+ */
+export function collectImages(
+  articles: Array<{ images?: string[] }>,
+  usedImages: Set<string> = new Set(),
+  maxImages = 5,
+): string[] {
+  const seen = new Set<string>(usedImages);
+  const images: string[] = [];
+  for (const a of articles) {
+    for (const url of a.images || []) {
+      if (url && isValidImageUrl(url) && !seen.has(url) && images.length < maxImages) {
+        seen.add(url);
+        images.push(url);
+      }
+    }
+  }
+  return images;
+}
+
+/**
+ * 將本次收集到的圖片加入全域已使用集合
+ * 用於 produceFromPlans 的 for loop 中追蹤同批次已用圖片
+ */
+export function addToUsedImages(usedImages: Set<string>, newImages: string[]): void {
+  for (const url of newImages) {
+    usedImages.add(url);
+  }
+}

--- a/scripts/local-rewriter.ts
+++ b/scripts/local-rewriter.ts
@@ -21,7 +21,7 @@ config({ path: resolve(__dirname, "..", ".env.local") });
 import { createClient } from "@supabase/supabase-js";
 import { matchesSpecialties, Specialties, RawArticleBase } from "./shared-matching";
 import { callClaude } from "./shared-claude";
-import { isValidImageUrl } from "../src/lib/constants";
+import { collectImages, addToUsedImages } from "./local-rewriter.logic";
 
 const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -143,20 +143,7 @@ function extractNames(text: string): string[] {
   return [...new Set(filtered.map((n) => n.toLowerCase()))];
 }
 
-// 從多篇原始文章中收集不重複的圖片 URL（最多取 5 張）
-function collectImages(articles: RawArticle[]): string[] {
-  const seen = new Set<string>();
-  const images: string[] = [];
-  for (const a of articles) {
-    for (const url of a.images || []) {
-      if (url && isValidImageUrl(url) && !seen.has(url) && images.length < 5) {
-        seen.add(url);
-        images.push(url);
-      }
-    }
-  }
-  return images;
-}
+// collectImages 已移至 local-rewriter.logic.ts（含跨文章去重支援）
 
 interface CitedSource {
   type: string;
@@ -354,6 +341,7 @@ async function produceFromPlans(planIds: string[]) {
   let success = 0;
   let failed = 0;
   const producedPlanIds: string[] = [];
+  const batchUsedImages = new Set<string>(); // 同批次跨文章圖片去重
 
   for (const plan of plans as PlanItem[]) {
     const persona = personaMap[plan.writer_persona_id];
@@ -386,9 +374,9 @@ async function produceFromPlans(planIds: string[]) {
       const output = callClaude(prompt);
       const result = parseResult(output);
 
-      const collectedImages = collectImages(articles);
+      const collectedImages = collectImages(articles, batchUsedImages);
       if (collectedImages.length === 0) {
-        console.log(`    跳過: 素材無任何圖片，不存入 DB`);
+        console.log(`    跳過: 素材無任何圖片（或已被同批次文章使用），不存入 DB`);
         failed++;
         continue;
       }
@@ -424,6 +412,9 @@ async function produceFromPlans(planIds: string[]) {
         failed++;
         continue;
       }
+
+      // 只有成功存入才標記圖片為已用（避免 insert 失敗時污染去重 Set）
+      addToUsedImages(batchUsedImages, collectedImages);
 
       // 標記原始素材為已處理
       const usedIds = articles.map((a) => a.id);
@@ -522,6 +513,7 @@ async function main() {
 
   let success = 0;
   let failed = 0;
+  const batchUsedImages = new Set<string>(); // 手動模式也需要跨文章圖片去重
 
   // === 官方戰報寫手：按聯盟出每日綜合戰報 ===
   for (const official of officials) {
@@ -569,12 +561,13 @@ async function main() {
           const output = callClaude(prompt);
           const result = parseResult(output);
 
-          const officialImages = collectImages(group);
+          const officialImages = collectImages(group, batchUsedImages);
           if (officialImages.length === 0) {
-            console.log(`    跳過: 素材無任何圖片，不存入 DB`);
+            console.log(`    跳過: 素材無任何圖片（或已被同批次文章使用），不存入 DB`);
             failed++;
             continue;
           }
+          addToUsedImages(batchUsedImages, officialImages);
 
           const aiTagsOfficial = Array.isArray(result.tags) ? result.tags : [];
           const finalTagsOfficial = aiTagsOfficial.length > 0 ? aiTagsOfficial : extractTagsFromContent(result.title, result.content);
@@ -650,12 +643,13 @@ async function main() {
         const output = callClaude(prompt);
         const result = parseResult(output);
 
-        const columnistImages = collectImages(group);
+        const columnistImages = collectImages(group, batchUsedImages);
         if (columnistImages.length === 0) {
-          console.log(`    跳過: 素材無任何圖片，不存入 DB`);
+          console.log(`    跳過: 素材無任何圖片（或已被同批次文章使用），不存入 DB`);
           failed++;
           continue;
         }
+        addToUsedImages(batchUsedImages, columnistImages);
 
         const aiTagsCol = Array.isArray(result.tags) ? result.tags : [];
         const finalTagsCol = aiTagsCol.length > 0 ? aiTagsCol : extractTagsFromContent(result.title, result.content);

--- a/scripts/plan-generator.ts
+++ b/scripts/plan-generator.ts
@@ -339,10 +339,23 @@ ${articleList}
   }
 
   if (allPlans.length > 0) {
-    const { error } = await supabase.from("rewrite_plans").insert(allPlans);
-    if (error) {
-      console.error("儲存規劃失敗:", error.message);
-      return;
+    // 存檔含 retry（最多 3 次，間隔 2 秒）
+    let saved = false;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const { error } = await supabase.from("rewrite_plans").insert(allPlans);
+      if (!error) {
+        saved = true;
+        break;
+      }
+      console.error(`儲存規劃失敗 (attempt ${attempt}/3): ${error.message}`);
+      if (attempt < 3) {
+        console.log("等待 2 秒後重試...");
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    }
+    if (!saved) {
+      console.error("儲存規劃全部失敗，exit 1");
+      process.exit(1);
     }
     console.log(`\n=== 已產生 ${allPlans.length} 個規劃項目 ===`);
 

--- a/scripts/rewrite-listener.logic.ts
+++ b/scripts/rewrite-listener.logic.ts
@@ -1,0 +1,55 @@
+/**
+ * rewrite-listener 接力/編排邏輯模組
+ *
+ * 從入口檔拆出的純函式，可獨立 import 測試。
+ * 負責判斷 plan/produce/review 完成後是否觸發下一步。
+ */
+
+/**
+ * 判斷 plan 完成後是否應觸發 produce
+ *
+ * @param mode - 當前任務模式
+ * @param taskSucceeded - 子程序是否成功（exit code 0）
+ * @param newPlanCount - 實際新增的 plan 筆數
+ * @returns 是否應觸發 produce
+ */
+export function shouldTriggerProduce(
+  mode: string,
+  taskSucceeded: boolean,
+  newPlanCount: number,
+): boolean {
+  return mode === "plan" && taskSucceeded && newPlanCount > 0;
+}
+
+/**
+ * 判斷 produce 完成後是否應觸發 review
+ *
+ * @param mode - 當前任務模式
+ * @param generatedCount - 實際產出的文章數量
+ * @returns 是否應觸發 review
+ */
+export function shouldTriggerReview(
+  mode: string,
+  generatedCount: number,
+): boolean {
+  return mode === "produce" && generatedCount > 0;
+}
+
+/**
+ * 解析任務的模式：plan / produce / review
+ */
+export function parseTaskMode(
+  metadata: Record<string, unknown> | null,
+): { mode: string; planIds?: string[]; articleIds?: string[] } {
+  if (!metadata) return { mode: "plan" };
+  if (metadata.mode === "produce" && Array.isArray(metadata.plan_ids)) {
+    return { mode: "produce", planIds: metadata.plan_ids as string[] };
+  }
+  if (metadata.mode === "review") {
+    const articleIds = Array.isArray(metadata.article_ids)
+      ? (metadata.article_ids as string[])
+      : undefined;
+    return { mode: "review", articleIds };
+  }
+  return { mode: "plan" };
+}

--- a/scripts/rewrite-listener.ts
+++ b/scripts/rewrite-listener.ts
@@ -15,6 +15,7 @@ config({ path: resolve(__dirname, "..", ".env.local") });
 import { createClient } from "@supabase/supabase-js";
 import { spawnSync } from "child_process";
 import { MATERIAL_WINDOW_HOURS } from "./shared-constants";
+import { shouldTriggerProduce, shouldTriggerReview, parseTaskMode } from "./rewrite-listener.logic";
 
 const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -33,18 +34,7 @@ const EDITOR_IN_CHIEF_SCRIPT = resolve(__dirname, "editor-in-chief.ts");
 
 let isRunning = false;
 
-// 解析任務的模式：plan（產生規劃）、produce（根據規劃產出文章）、review（總編輯審稿）
-function parseTaskMode(metadata: Record<string, unknown> | null): { mode: string; planIds?: string[]; articleIds?: string[] } {
-  if (!metadata) return { mode: "plan" };
-  if (metadata.mode === "produce" && Array.isArray(metadata.plan_ids)) {
-    return { mode: "produce", planIds: metadata.plan_ids as string[] };
-  }
-  if (metadata.mode === "review") {
-    const articleIds = Array.isArray(metadata.article_ids) ? metadata.article_ids as string[] : undefined;
-    return { mode: "review", articleIds };
-  }
-  return { mode: "plan" };
-}
+// parseTaskMode 已移至 rewrite-listener.logic.ts
 
 async function executeTask(taskId: string) {
   if (isRunning) {
@@ -172,7 +162,7 @@ async function executeTask(taskId: string) {
     isRunning = false;
   }
 
-  // plan 完成後自動接力 produce
+  // plan 完成後自動接力 produce（使用 logic 模組判斷）
   // 必須在 finally（isRunning = false）之後才 insert，
   // 否則 Realtime callback 收到新任務時 isRunning 仍為 true 而被跳過
   if (mode === "plan" && taskSucceeded) {
@@ -183,8 +173,10 @@ async function executeTask(taskId: string) {
       .order("created_at", { ascending: false })
       .limit(100);
 
-    if (newPlans && newPlans.length > 0) {
-      const newPlanIds = newPlans.map((p) => p.id);
+    const newPlanCount = newPlans?.length || 0;
+
+    if (shouldTriggerProduce(mode, taskSucceeded, newPlanCount)) {
+      const newPlanIds = newPlans!.map((p) => p.id);
       console.log(`[${ts()}] plan 完成，產出 ${newPlanIds.length} 篇規劃，自動觸發 produce...`);
       const { error: produceTaskError } = await supabase
         .from("rewrite_tasks")
@@ -196,13 +188,13 @@ async function executeTask(taskId: string) {
         console.error(`[${ts()}] 建立 produce 任務失敗: ${produceTaskError.message}`);
       }
     } else {
-      console.log(`[${ts()}] plan 完成但無新規劃`);
+      console.log(`[${ts()}] plan 完成但無新規劃（實際存入 ${newPlanCount} 筆）`);
     }
   }
 
-  // produce 完成後自動觸發審稿
-  if (mode === "produce" && generated > 0) {
-    console.log(`[${ts()}] 產出完成，自動觸發總編輯審稿...`);
+  // produce 完成後自動觸發審稿（使用 logic 模組判斷）
+  if (shouldTriggerReview(mode, generated)) {
+    console.log(`[${ts()}] 產出完成（${generated} 篇），自動觸發總編輯審稿...`);
     const { error: reviewTaskError } = await supabase
       .from("rewrite_tasks")
       .insert({

--- a/scripts/shared-claude.ts
+++ b/scripts/shared-claude.ts
@@ -8,55 +8,84 @@ import { writeFileSync, readFileSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-export function callClaude(prompt: string, timeout = 180000): string {
-  const tmpPrompt = join(tmpdir(), `claude-prompt-${Date.now()}.txt`);
-  const tmpOutput = join(tmpdir(), `claude-output-${Date.now()}.txt`);
-  writeFileSync(tmpPrompt, prompt, "utf-8");
+/** Rate limit 偵測 pattern */
+const RATE_LIMIT_PATTERNS = [
+  "You've hit your limit",
+  "rate limit",
+  "too many requests",
+  "429",
+];
 
-  const env = { ...process.env };
-  delete env.CLAUDECODE;
-  delete env.ANTHROPIC_API_KEY;
+/** 檢查輸出是否為 rate limit 錯誤 */
+export function isRateLimitError(output: string): boolean {
+  const lower = output.toLowerCase();
+  return RATE_LIMIT_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
+}
 
-  const tmpStderr = join(tmpdir(), `claude-stderr-${Date.now()}.txt`);
-  const result = spawnSync(
-    "bash",
-    [
-      "-c",
-      `cat "${tmpPrompt}" | claude -p --model sonnet > "${tmpOutput}" 2>"${tmpStderr}"`,
-    ],
-    {
-      encoding: "utf-8",
-      timeout,
-      maxBuffer: 2 * 1024 * 1024,
-      env,
+export function callClaude(prompt: string, timeout = 180000, maxRetries = 3): string {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const tmpPrompt = join(tmpdir(), `claude-prompt-${Date.now()}.txt`);
+    const tmpOutput = join(tmpdir(), `claude-output-${Date.now()}.txt`);
+    writeFileSync(tmpPrompt, prompt, "utf-8");
+
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+    delete env.ANTHROPIC_API_KEY;
+
+    const tmpStderr = join(tmpdir(), `claude-stderr-${Date.now()}.txt`);
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `cat "${tmpPrompt}" | claude -p --model sonnet > "${tmpOutput}" 2>"${tmpStderr}"`,
+      ],
+      {
+        encoding: "utf-8",
+        timeout,
+        maxBuffer: 2 * 1024 * 1024,
+        env,
+      }
+    );
+
+    // 檢查 subprocess 是否因 timeout 或 signal 被殺死
+    if (result.signal) {
+      console.error(`[callClaude] 子程序被 ${result.signal} 終止（可能超時 ${timeout}ms）`);
+      try { unlinkSync(tmpPrompt); } catch {}
+      try { unlinkSync(tmpOutput); } catch {}
+      try { unlinkSync(tmpStderr); } catch {}
+      throw new Error(`Claude CLI 子程序被 ${result.signal} 終止`);
     }
-  );
 
-  // 檢查 subprocess 是否因 timeout 或 signal 被殺死
-  if (result.signal) {
-    console.error(`[callClaude] 子程序被 ${result.signal} 終止（可能超時 ${timeout}ms）`);
+    // Log stderr separately if present
+    try {
+      const stderrContent = readFileSync(tmpStderr, "utf-8").trim();
+      if (stderrContent) {
+        console.error("[callClaude stderr]", stderrContent.substring(0, 500));
+      }
+    } catch {}
+    try { unlinkSync(tmpStderr); } catch {}
+
+    let output = "";
+    try {
+      output = readFileSync(tmpOutput, "utf-8");
+    } catch {}
+
     try { unlinkSync(tmpPrompt); } catch {}
     try { unlinkSync(tmpOutput); } catch {}
-    try { unlinkSync(tmpStderr); } catch {}
-    throw new Error(`Claude CLI 子程序被 ${result.signal} 終止`);
+
+    // Rate limit 偵測 + retry
+    if (isRateLimitError(output)) {
+      const waitSec = attempt * 60; // 1 分鐘、2 分鐘、3 分鐘
+      console.warn(`[callClaude] Rate limit detected (attempt ${attempt}/${maxRetries})，等待 ${waitSec} 秒後重試...`);
+      if (attempt < maxRetries) {
+        spawnSync("sleep", [String(waitSec)]);
+        continue;
+      }
+      console.error(`[callClaude] Rate limit 重試 ${maxRetries} 次仍失敗`);
+    }
+
+    return output;
   }
 
-  // Log stderr separately if present
-  try {
-    const stderrContent = readFileSync(tmpStderr, "utf-8").trim();
-    if (stderrContent) {
-      console.error("[callClaude stderr]", stderrContent.substring(0, 500));
-    }
-  } catch {}
-  try { unlinkSync(tmpStderr); } catch {}
-
-  let output = "";
-  try {
-    output = readFileSync(tmpOutput, "utf-8");
-  } catch {}
-
-  try { unlinkSync(tmpPrompt); } catch {}
-  try { unlinkSync(tmpOutput); } catch {}
-
-  return output;
+  return ""; // 不應到達，但 TypeScript 需要
 }

--- a/src/__tests__/scripts/local-rewriter.logic.test.ts
+++ b/src/__tests__/scripts/local-rewriter.logic.test.ts
@@ -1,0 +1,135 @@
+/**
+ * local-rewriter.logic 業務邏輯測試
+ *
+ * 測試 collectImages 的跨文章去重和 addToUsedImages 的追蹤邏輯
+ */
+import { describe, it, expect } from "vitest";
+import { collectImages, addToUsedImages } from "../../../scripts/local-rewriter.logic";
+
+describe("collectImages — 圖片收集與去重", () => {
+  it("從單篇文章收集圖片", () => {
+    const articles = [
+      { images: ["https://example.com/a.jpg", "https://example.com/b.jpg"] },
+    ];
+    const result = collectImages(articles);
+    expect(result).toEqual(["https://example.com/a.jpg", "https://example.com/b.jpg"]);
+  });
+
+  it("單篇文章內去重", () => {
+    const articles = [
+      { images: ["https://example.com/a.jpg", "https://example.com/a.jpg", "https://example.com/b.jpg"] },
+    ];
+    const result = collectImages(articles);
+    expect(result).toEqual(["https://example.com/a.jpg", "https://example.com/b.jpg"]);
+  });
+
+  it("跨文章去重（同批次不同文章引用重疊素材）", () => {
+    const articles = [
+      { images: ["https://example.com/shared.jpg", "https://example.com/a.jpg"] },
+      { images: ["https://example.com/shared.jpg", "https://example.com/b.jpg"] },
+    ];
+    const result = collectImages(articles);
+    expect(result).toEqual([
+      "https://example.com/shared.jpg",
+      "https://example.com/a.jpg",
+      "https://example.com/b.jpg",
+    ]);
+  });
+
+  it("使用 usedImages 參數排除前面文章已用的圖片", () => {
+    const usedImages = new Set(["https://example.com/already-used.jpg"]);
+    const articles = [
+      { images: ["https://example.com/already-used.jpg", "https://example.com/new.jpg"] },
+    ];
+    const result = collectImages(articles, usedImages);
+    expect(result).toEqual(["https://example.com/new.jpg"]);
+  });
+
+  it("同批次多篇文章模擬 — 第二篇不會拿到第一篇已用的圖片", () => {
+    const batchUsed = new Set<string>();
+
+    // 第一篇文章
+    const articles1 = [
+      { images: ["https://example.com/shared.jpg", "https://example.com/a.jpg"] },
+    ];
+    const images1 = collectImages(articles1, batchUsed);
+    addToUsedImages(batchUsed, images1);
+
+    expect(images1).toEqual(["https://example.com/shared.jpg", "https://example.com/a.jpg"]);
+
+    // 第二篇文章（引用重疊素材）
+    const articles2 = [
+      { images: ["https://example.com/shared.jpg", "https://example.com/b.jpg"] },
+    ];
+    const images2 = collectImages(articles2, batchUsed);
+    addToUsedImages(batchUsed, images2);
+
+    // shared.jpg 被第一篇用過，不應再出現
+    expect(images2).toEqual(["https://example.com/b.jpg"]);
+  });
+
+  it("最多收集 maxImages 張", () => {
+    const articles = [
+      { images: Array.from({ length: 10 }, (_, i) => `https://example.com/${i}.jpg`) },
+    ];
+    const result = collectImages(articles, new Set(), 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it("過濾無效圖片 URL（非 http 開頭、含 logo/svg 等排除 pattern）", () => {
+    const articles = [
+      {
+        images: [
+          "https://example.com/valid.jpg",
+          "data:image/png;base64,xxx", // 非 http
+          "https://example.com/logo-icon.svg", // 含 logo 排除 pattern
+          "", // 空字串
+        ],
+      },
+    ];
+    const result = collectImages(articles);
+    expect(result).toContain("https://example.com/valid.jpg");
+    expect(result).not.toContain("data:image/png;base64,xxx");
+    expect(result).not.toContain("");
+  });
+
+  it("文章沒有 images 欄位時安全跳過", () => {
+    const articles = [
+      { images: undefined },
+      {},
+      { images: [] },
+    ] as Array<{ images?: string[] }>;
+    const result = collectImages(articles);
+    expect(result).toEqual([]);
+  });
+
+  it("所有圖片都被 usedImages 占用時回傳空陣列", () => {
+    const usedImages = new Set(["https://example.com/a.jpg", "https://example.com/b.jpg"]);
+    const articles = [
+      { images: ["https://example.com/a.jpg", "https://example.com/b.jpg"] },
+    ];
+    const result = collectImages(articles, usedImages);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("addToUsedImages — 追蹤已使用圖片", () => {
+  it("將新圖片加入 Set", () => {
+    const used = new Set<string>();
+    addToUsedImages(used, ["https://example.com/a.jpg", "https://example.com/b.jpg"]);
+    expect(used.size).toBe(2);
+    expect(used.has("https://example.com/a.jpg")).toBe(true);
+  });
+
+  it("不會重複加入", () => {
+    const used = new Set(["https://example.com/a.jpg"]);
+    addToUsedImages(used, ["https://example.com/a.jpg", "https://example.com/b.jpg"]);
+    expect(used.size).toBe(2);
+  });
+
+  it("空陣列不影響 Set", () => {
+    const used = new Set(["https://example.com/a.jpg"]);
+    addToUsedImages(used, []);
+    expect(used.size).toBe(1);
+  });
+});

--- a/src/__tests__/scripts/rewrite-listener.logic.test.ts
+++ b/src/__tests__/scripts/rewrite-listener.logic.test.ts
@@ -1,0 +1,108 @@
+/**
+ * rewrite-listener.logic 接力/編排邏輯測試
+ *
+ * 測試 shouldTriggerProduce、shouldTriggerReview、parseTaskMode 的各種邊界條件
+ */
+import { describe, it, expect } from "vitest";
+import {
+  shouldTriggerProduce,
+  shouldTriggerReview,
+  parseTaskMode,
+} from "../../../scripts/rewrite-listener.logic";
+
+describe("shouldTriggerProduce — plan 完成後是否觸發 produce", () => {
+  it("plan 成功且有新 plan → 觸發", () => {
+    expect(shouldTriggerProduce("plan", true, 5)).toBe(true);
+  });
+
+  it("plan 成功但 0 筆新 plan → 不觸發", () => {
+    expect(shouldTriggerProduce("plan", true, 0)).toBe(false);
+  });
+
+  it("plan 失敗 → 不觸發（即使有 plan）", () => {
+    expect(shouldTriggerProduce("plan", false, 5)).toBe(false);
+  });
+
+  it("不是 plan 模式 → 不觸發", () => {
+    expect(shouldTriggerProduce("produce", true, 5)).toBe(false);
+    expect(shouldTriggerProduce("review", true, 5)).toBe(false);
+  });
+
+  it("plan 成功 + exit 0 但實際存入 0 筆（Bug #197 場景）→ 不觸發", () => {
+    // 這是 Bug #197 的核心場景：
+    // plan-generator exit 0（TypeError: fetch failed 不影響 exit code）
+    // 但 Supabase 存檔失敗，實際 newPlanCount = 0
+    expect(shouldTriggerProduce("plan", true, 0)).toBe(false);
+  });
+});
+
+describe("shouldTriggerReview — produce 完成後是否觸發 review", () => {
+  it("produce 產出 > 0 篇 → 觸發", () => {
+    expect(shouldTriggerReview("produce", 3)).toBe(true);
+  });
+
+  it("produce 產出 0 篇 → 不觸發", () => {
+    expect(shouldTriggerReview("produce", 0)).toBe(false);
+  });
+
+  it("不是 produce 模式 → 不觸發", () => {
+    expect(shouldTriggerReview("plan", 5)).toBe(false);
+    expect(shouldTriggerReview("review", 5)).toBe(false);
+  });
+
+  it("produce 產出 1 篇 → 觸發（邊界值）", () => {
+    expect(shouldTriggerReview("produce", 1)).toBe(true);
+  });
+});
+
+describe("parseTaskMode — 解析任務模式", () => {
+  it("null metadata → plan 模式", () => {
+    expect(parseTaskMode(null)).toEqual({ mode: "plan" });
+  });
+
+  it("空物件 → plan 模式", () => {
+    expect(parseTaskMode({})).toEqual({ mode: "plan" });
+  });
+
+  it("produce 模式 + plan_ids", () => {
+    const metadata = { mode: "produce", plan_ids: ["p1", "p2"] };
+    expect(parseTaskMode(metadata)).toEqual({
+      mode: "produce",
+      planIds: ["p1", "p2"],
+    });
+  });
+
+  it("produce 模式但無 plan_ids → plan 模式（fallback）", () => {
+    const metadata = { mode: "produce" };
+    expect(parseTaskMode(metadata)).toEqual({ mode: "plan" });
+  });
+
+  it("review 模式（無 article_ids）", () => {
+    const metadata = { mode: "review" };
+    expect(parseTaskMode(metadata)).toEqual({
+      mode: "review",
+      articleIds: undefined,
+    });
+  });
+
+  it("review 模式 + article_ids", () => {
+    const metadata = { mode: "review", article_ids: ["a1", "a2"] };
+    expect(parseTaskMode(metadata)).toEqual({
+      mode: "review",
+      articleIds: ["a1", "a2"],
+    });
+  });
+
+  it("未知模式 → plan（預設）", () => {
+    const metadata = { mode: "unknown" };
+    expect(parseTaskMode(metadata)).toEqual({ mode: "plan" });
+  });
+
+  it("auto_publish 欄位不影響模式解析", () => {
+    const metadata = { mode: "produce", plan_ids: ["p1"], auto_publish: true };
+    expect(parseTaskMode(metadata)).toEqual({
+      mode: "produce",
+      planIds: ["p1"],
+    });
+  });
+});

--- a/src/__tests__/scripts/shared-claude.test.ts
+++ b/src/__tests__/scripts/shared-claude.test.ts
@@ -1,0 +1,41 @@
+/**
+ * shared-claude rate limit 偵測測試
+ */
+import { describe, it, expect } from "vitest";
+import { isRateLimitError } from "../../../scripts/shared-claude";
+
+describe("isRateLimitError — rate limit 偵測", () => {
+  it("偵測 'You've hit your limit' 訊息", () => {
+    expect(isRateLimitError("You've hit your limit · resets 1am (Asia/Taipei)")).toBe(true);
+  });
+
+  it("偵測 'rate limit' 訊息（大小寫不敏感）", () => {
+    expect(isRateLimitError("Rate Limit exceeded")).toBe(true);
+    expect(isRateLimitError("RATE LIMIT")).toBe(true);
+  });
+
+  it("偵測 'too many requests' 訊息", () => {
+    expect(isRateLimitError("Error: Too Many Requests")).toBe(true);
+  });
+
+  it("偵測 '429' 錯誤碼", () => {
+    expect(isRateLimitError("HTTP 429: Too many requests")).toBe(true);
+  });
+
+  it("正常 JSON 輸出不觸發", () => {
+    expect(isRateLimitError('{"title": "NBA 今日焦點", "content": "..."}')).toBe(false);
+  });
+
+  it("空字串不觸發", () => {
+    expect(isRateLimitError("")).toBe(false);
+  });
+
+  it("一般錯誤訊息不觸發", () => {
+    expect(isRateLimitError("Connection refused")).toBe(false);
+    expect(isRateLimitError("Internal Server Error")).toBe(false);
+  });
+
+  it("Claude 正常 markdown 回應不觸發", () => {
+    expect(isRateLimitError("```json\n{\"title\": \"test\"}\n```")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 修復同批次產出的文章圖片完全相同的問題（跨文章去重）
- 修復 plan 存檔失敗時管線靜默斷裂的問題（retry + exit 1）
- 新增 Claude CLI rate limit 偵測 + 自動重試

## Changes

- `scripts/local-rewriter.logic.ts` — 新增：collectImages（含 usedImages 參數）、addToUsedImages
- `scripts/local-rewriter.ts` — 改用 logic 模組，produceFromPlans + main 路徑均加入 batchUsedImages 追蹤
- `scripts/rewrite-listener.logic.ts` — 新增：shouldTriggerProduce、shouldTriggerReview、parseTaskMode
- `scripts/rewrite-listener.ts` — 改用 logic 模組的接力判斷
- `scripts/plan-generator.ts` — 存檔加 retry（3 次 / 間隔 2s）+ 全部失敗 exit 1
- `scripts/shared-claude.ts` — 新增 isRateLimitError + callClaude retry（遞增等待）
- 新增 3 個測試檔共 37 個 unit test

## Test

- Unit test: 1059/1059 通過 ✅
- Review: 5 agent 完成，2 個問題已修正 ✅
- QA: qa.sh 通過（E2E 失敗為既有問題，非本次變更引起）✅